### PR TITLE
Typo: addField instead of AddFields in crud-tutorial.md

### DIFF
--- a/3.4/crud-tutorial.md
+++ b/3.4/crud-tutorial.md
@@ -234,7 +234,7 @@ Since our ```Tag``` model is so simple, we _can_ leave it like this - it will wo
 +        $this->crud->addColumn(['name' => 'name', 'type' => 'text', 'label' => 'Name']);
 +
 +        // Fields
-+        $this->crud->addFields(['name' => 'name', 'type' => 'text', 'label' => 'Name']);
++        $this->crud->addField(['name' => 'name', 'type' => 'text', 'label' => 'Name']);
     }
 }
 ```


### PR DESCRIPTION
When the tutorial is telling how to add the model's 'name' field to the controller, it is using addFields instead of addField   ('s' needs removed)