### PR TITLE
Added missing / causing broken links

### DIFF
--- a/3.4/getting-started-advanced-features.md
+++ b/3.4/getting-started-advanced-features.md
@@ -33,7 +33,7 @@ Here are some other cool things Backpack makes easy for you. We recommend going 
 
 
 Additionally, here are a few more ways you can customize your CRUDs:
-- [Custom Views for each CRUD](docs/{{version}}/crud-how-to#customize-views-for-each-crud-panel)
-- [Custom CSS or JS](docs/{{version}}/crud-how-to#customize-css-and-js-for-default-crud-operations) for each CRUD Operation
+- [Custom Views for each CRUD](/docs/{{version}}/crud-how-to#customize-views-for-each-crud-panel)
+- [Custom CSS or JS](/docs/{{version}}/crud-how-to#customize-css-and-js-for-default-crud-operations) for each CRUD Operation
 
 **That’s it for today!** Told you we’re done with long lessons :-) Hopefully some of the above have peaked your interest and you’ve clicked to see what Backpack can do. In the [next lesson](/docs/{{version}}/getting-started-license-and-support) we’ll go through a few other Backpack packages, that cover some recurring use cases.


### PR DESCRIPTION
The links under "Additionally, here are a few more ways you can customize your CRUDs:" were missing their forward slashes at the start, causing the links to land at 404s.