### PR TITLE
removed unused parameter from 3.5

### DIFF
--- a/3.5/crud-fields.md
+++ b/3.5/crud-fields.md
@@ -1637,7 +1637,7 @@ And your blade file something like:
 </div>
 
 
-@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+@if ($crud->checkIfFieldIsFirstOfItsType($field))
   {{-- FIELD EXTRA CSS  --}}
   {{-- push things in the after_styles section --}}
 


### PR DESCRIPTION
## Overview

**File**: src / PanelTraits / Fields.php

before v3.4.39 had:  
`checkIfFieldIsFirstOfItsType( $field, $fields_array )`

v3.4.39 and later (inc. v3.5):  
`checkIfFieldIsFirstOfItsType( $field )`

**Result**: Removed second parameter from 3.5-docs example