### PR TITLE
Fix wrong name of 'edit' button on the 'line' stack

### DIFF
--- a/3.5/crud-buttons.md
+++ b/3.5/crud-buttons.md
@@ -22,7 +22,7 @@ When adding a button to the stack, you can choose whether to insert it at the ``
 
 Backpack adds a few buttons by default: 
 - ```add``` to the ```top``` stack;
-- ```edit``` and ```delete``` to the ```line``` stack;
+- ```update``` and ```delete``` to the ```line``` stack;
 
 Default buttons are invisible if an operation has been disabled. For example, you can: 
 - hide the "delete" button using ```$this->crud->denyAccess('delete')```;


### PR DESCRIPTION
The button name is 'update', not 'edit'.

```
$this->crud->removeButton('edit', 'line');      // this doesn't remove the button
$this->crud->removeButton('update', 'line');    // this does
```