### PR TITLE
Fixes syntax error in the crud tutorial page

### DIFF
--- a/4.0/crud-tutorial.md
+++ b/4.0/crud-tutorial.md
@@ -340,7 +340,7 @@ Route::group([
     'namespace'  => 'App\Http\Controllers\Admin',
 ], function () { // custom admin routes
     // CRUD resources and other admin routes
-    Route::crud('tag', 'Admin\TagCrudController');
+    Route::crud('tag', 'TagCrudController');
 }); // this should be the absolute last line of this file
 ```
 


### PR DESCRIPTION
Removes the Admin namespace, because right now the url would be Admin\Admin\TagCrudController which is not what you want!