### PR TITLE
Clarify about upload field validation rules.

### DIFF
--- a/4.0/crud-fields.md
+++ b/4.0/crud-fields.md
@@ -1431,6 +1431,8 @@ public function setImageAttribute($value)
 
 The field sends the file, through a Request, to the Controller. The Controller then tries to create/update the Model. That's when the mutator on your model will run. That also means we can do any [file validation](https://laravel.com/docs/5.3/validation#rule-file) (```file```, ```image```, ```mimetypes```, ```mimes```) in the Request, before the file is stored on the disk.
 
+>NOTE: If this field is mandatory (required in validation) please use the [sometimes laravel validation rule](https://laravel.com/docs/5.8/validation#conditionally-adding-rules) together with **required** in your validation. (sometimes|required|file etc... )
+
 [The ```uploadFileToDisk()``` method](https://github.com/Laravel-Backpack/CRUD/blob/master/src/CrudTrait.php#L108-L129) will take care of everything for most use cases:
 
 ```php


### PR DESCRIPTION
The way backpack is designed, when an upload field is present and required if you submit a form without uploading the file an empty field is going to validate and fail ofcourse in the required rule. 

If you submit the form and everything is correct the process will be smooth, until you edit that entity.

When editing an entry if the upload field value is present (user already sent one file with success) we will just re-create the fancy file preview and not the upload field. If user submits the form without changing anything and we are not using **sometimes|required**, the validation will fail, as we are not sending any upload field in request. Here comes the power of [sometimes laravel validation rule](https://laravel.com/docs/5.8/validation#conditionally-adding-rules) that will not trigger the required validation error because the upload field is not present in request.

If user clicks to remove the file in the preview we re-create the empty input, so if the user sets a new file it will be uploaded and pass the validation, if don't send new file the validation will fail.

I think this is just mandatory if your upload is required, so it should be mentioned and clear in the docs.