### PR TITLE
Fixed arguments of addButtonFromView

### DIFF
--- a/4.0/crud-buttons.md
+++ b/4.0/crud-buttons.md
@@ -197,5 +197,5 @@ public function import()
 
 - Now we can actually add this button to any of ```UserCrudController::setup()```:
 ```php
-$this->crud->addButtonFromView('top', 'import', 'view', 'crud::buttons.import', 'end');
+$this->crud->addButtonFromView('top', 'import', 'import', 'end');
 ```


### PR DESCRIPTION
Hi,

I have fixed the example code of `addButtonFromView` in crud-buttons.md

This was explaining about `\Backpack\CRUD\app\Library\CrudPanel\Traits\Buttons::addButton` not `\Backpack\CRUD\app\Library\CrudPanel\Traits\Buttons::addButtonFromView`.

Thanks,