### PR TITLE
add extra param to the image column

### DIFF
--- a/4.0/crud-columns.md
+++ b/4.0/crud-columns.md
@@ -232,6 +232,8 @@ Show a thumbnail image.
    'label' => "Profile image", // Table column heading
    'type' => 'image',
     // 'prefix' => 'folder/subfolder/',
+    // image from a different disk (like s3 bucket)
+    // 'disk' => 'disk-name', 
     // optional width/height if 25px is not ok with you
     // 'height' => '30px',
     // 'width' => '30px',


### PR DESCRIPTION
I have been really struggling to find out a way to make an absolute path for images columns since I host my images in an s3 bucket, and it took me too long looking at the docs and in the internet trying to find a way to do that but I didn't. Finally, I decided to go to columns/image.blade.php and make my changes there, but it was surprising to me when I figured that there is already an option that you can add to the image field which is ```disk``` and it does exactly what I wanted but this wasn't mentioned in the docs, that's why I decided to add it there in case anyone was looking to do the same thing.