### PR TITLE
Adding $id parameter in "publish"

### DIFF
--- a/4.0/crud-operations.md
+++ b/4.0/crud-operations.md
@@ -273,7 +273,7 @@ To add an operation to an ```EntityCrudController```, you can:
 ```
 - create a method that performs the operation you want:
 ```php
-    public function publish()
+    public function publish($id)
     {
         // do something
         // return something
@@ -322,7 +322,7 @@ trait PublishOperation
         });
     }
 
-    public function publish()
+    public function publish($id)
     {
         // do something
         // return something


### PR DESCRIPTION
If I'm right (I've following the tuto), you need the $id parameter in the publish method to keep it related to the route where $id is present.
For someone who is mastering Laravel I think it's clear, but maybe you could, somewhere, add a note about putting parameters in route <=> public function ACTION($parameter)
Also, cherry on the cake, maybe a generator with optional parameter like
```
php artisan backpack:crud-operation --params=id Comment
php artisan backpack:crud-operation --params=key1,key2 Comment
```
2nd version to match composed primary key maybe

Thanks for the good work again.