### PR TITLE
Select Field Requires 'attribute'

### DIFF
--- a/4.1/crud-fluent-syntax.md
+++ b/4.1/crud-fluent-syntax.md
@@ -154,7 +154,7 @@ CRUD::field('category_id')
         ->type('select')
         ->label('Category')
         ->entity('category')
-        // ->attribute('name') // optional;
+        ->attribute('name')
         // ->model('Backpack\NewsCRUD\app\Models\Category') // optional; guessed from entity;
         // ->wrapper(['class' => 'form-group col-md-6']) // possible, but easier with size below;
         ->size(6);


### PR DESCRIPTION
When using `select` field type it requires an attribute. Without it you receive an error: _Undefined index: attribute_