### PR TITLE
Removed obsolete upload attribute from image field

### DIFF
--- a/4.1/crud-fields.md
+++ b/4.1/crud-fields.md
@@ -748,7 +748,6 @@ $this->crud->addField([
     'label' => "Profile Image",
     'name' => "image",
     'type' => 'image',
-    'upload' => true,
     'crop' => true, // set to true to allow cropping, false to disable
     'aspect_ratio' => 1, // ommit or set to 0 to allow any aspect ratio
     // 'disk' => 's3_bucket', // in case you need to show images from a different disk


### PR DESCRIPTION
Apparently the 'image' field no longer uses the 'upload' attribute. At least the corresponding view 'image.blade.php' does not make use of it anymore.