### PR TITLE
Backpack's Sluggable saves as JSON

### DIFF
--- a/4.1/crud-operation-update.md
+++ b/4.1/crud-operation-update.md
@@ -167,7 +167,7 @@ class Product extends Model
 
 Change the languages available to translate to/from, in your crud config file (```config/backpack/crud.php```). By default there are quite a few enabled (English, French, German, Italian, Romanian).
 
-Additionally, if you have slugs, you'll need to use backpack's classes instead of the ones provided by cviebrock/eloquent-sluggable:
+Additionally, if you have slugs (but only if you need translatable slugs), you'll need to use backpack's classes instead of the ones provided by cviebrock/eloquent-sluggable:
 
 ```php
 <?php
@@ -216,6 +216,7 @@ class Category extends Model
     }
 }
 ```
+> If your slugs are not translatable, use the ```cviebrock/eloquent-sluggable``` traits. The Backpack's ```Sluggable``` trait saves your slug as a JSON object, regardless of the ```slug``` field being defined inside the ```$translatable``` property.
 
 <a name="separate-validation"></a>
 ## Separate Validation Rules for Create and Update


### PR DESCRIPTION
Make it clear that Backpack's Sluggable always saves the slug as JSON, ignoring the translatable property.