### PR TITLE
Problem with namespace in fetch operation

### DIFF
--- a/4.1/crud-fields.md
+++ b/4.1/crud-fields.md
@@ -1112,7 +1112,7 @@ Then, you need to create the route and method that allows ```select2``` to searc
 
     public function fetchCategory()
     {
-        return $this->fetch(App\Models\Category::class);
+        return $this->fetch(\App\Models\Category::class);
     }
 ```
 

--- a/4.1/crud-operation-fetch.md
+++ b/4.1/crud-operation-fetch.md
@@ -25,7 +25,7 @@ In order to enable this operation in your CrudController, you need to:
 
     protected function fetchTag()
     {
-        return $this->fetch(App\Models\Tag::class);
+        return $this->fetch(\App\Models\Tag::class);
     }
 ```
 
@@ -45,7 +45,7 @@ class ProductCrudController extends CrudController
     protected function fetchTag()
     {
         return $this->fetch([
-            'model' => App\Models\Tag::class, // required
+            'model' => \App\Models\Tag::class, // required
             'searchable_attributes' => ['name', 'description'],
             'paginate' => 10, // items to show per page
             'query' => function($model) {


### PR DESCRIPTION
While trying the hasMany relationship, I realized that the select was not populated:

![fetch-operation](https://user-images.githubusercontent.com/66673634/92991908-14189700-f4e7-11ea-9877-7b57d1849953.png)

The logs shown an error 500: `"POST /admin/proyecto/fetch/tareas HTTP/1.1" 500 84`

Problem was App\Models was concatenated to namespace so it needs a heading backslash. :+1:  So other people don't have to spend some time figuring it out.

Also, when I read the documentation, maybe because English is not my first language, I misunderstood. After examples of not-ajax and ajax, where it says:

> Then, you need to create the route and method that allows select2 to search and fetch the results...

I misunderstood and though that only the ajax example needed the fetch operation. Maybe you could change it to:

> In both cases, you need to create the route and method that allows select2 to search and fetch the results...

Cheers!!
X.

