### PR TITLE
Update crud-fields.md

### DIFF
--- a/4.1/crud-fields.md
+++ b/4.1/crud-fields.md
@@ -1112,7 +1112,7 @@ Then, you need to create the route and method that allows ```select2``` to searc
 
     public function fetchCategory()
     {
-        return $this->fetch(App\Models\Category::class);
+        return $this->fetch(\App\Models\Category::class);
     }
 ```
 


### PR DESCRIPTION
Inside the fetchCategory function in the relationship field type docs, the leading backslash is required in order to get ajax to work.
i.e.
replace
return $this->fetch(App\Models\Category::class);
with
return $this->fetch(\App\Models\Category::class);