### PR TITLE
Update crud-operation-fetch.md

### DIFF
--- a/4.1/crud-operation-fetch.md
+++ b/4.1/crud-operation-fetch.md
@@ -25,7 +25,7 @@ In order to enable this operation in your CrudController, you need to:
 
     protected function fetchTag()
     {
-        return $this->fetch(App\Models\Tag::class);
+        return $this->fetch(\App\Models\Tag::class);
     }
 ```
 


### PR DESCRIPTION
Inside the fetchCategory function, the leading backslash is required in order to get ajax to work.
i.e.
replace
return $this->fetch(App\Models\Category::class);
with
return $this->fetch(\App\Models\Category::class);