### PR TITLE
Update installation text for Laravel 8 users

### DIFF
--- a/4.1/installation.md
+++ b/4.1/installation.md
@@ -44,7 +44,7 @@ php artisan backpack:install
 3) Take note that:
 - By default all users are considered admins; If that's not what you want in your application (you have both users and admins), please change ```app/Http/Middleware/CheckIfAdmin.php```, particularly ```checkIfUserIsAdmin($user)```, to make sure you only allow admins to access the admin panel;
 - Change configuration values in ```config/backpack/base.php``` to make the admin panel your own. Backpack is white label, so you can change everything: menu color, project name, developer name etc.
-- If your User model has been moved (it is not ```App\User.php```), please change ```config/backpack/base.php``` to use the correct user model using the ```user_model_fqn``` config key;
+- If your User model has been moved (it is not ```App\User.php```), please change ```config/backpack/base.php``` to use the correct user model using the ```user_model_fqn``` config key. If you are using Laravel 8 and up, you need to change this. Because by default Laravel 8 and up save ```User``` model inside ```Models``` directory.
 
 That's it. If you already know how to use Backpack, next up you'll probably want to [create CRUD Panels](/docs/{{version}}/crud-tutorial#generate-files).
 


### PR DESCRIPTION
Since https://github.com/Laravel-Backpack/CRUD/pull/3241 was merged, I think the docs need to be updated too. 

Update installation text to tell backpack users to update `User` model in config if they are using Laravel 8 and up.