### PR TITLE
Update for $this->crud->getRequest()

### DIFF
--- a/4.1/crud-cheat-sheet.md
+++ b/4.1/crud-cheat-sheet.md
@@ -149,7 +149,7 @@ $this->crud->groupBy();
 $this->crud->limit();
 
 $this->crud->orderBy();
-// please note it's generally a good idea to use crud->orderBy() inside "if (!$this->request->has('order')) {}"; that way, your custom order is applied ONLY IF the user hasn't forced another order (by clicking a column heading)
+// please note it's generally a good idea to use crud->orderBy() inside "if (!$this->crud->getRequest()->has('order')) {}"; that way, your custom order is applied ONLY IF the user hasn't forced another order (by clicking a column heading)
 ```
 
 <a name="show-api"></a>

--- a/4.1/crud-fields.md
+++ b/4.1/crud-fields.md
@@ -981,7 +981,7 @@ public function setPasswordAttribute($value) {
     
     public function store()
     {
-        $this->crud->request = $this->crud->validateRequest();
+        $this->crud->setRequest($this->crud->validateRequest());
     
         // Encrypt password if specified.
         if ($request->input('password')) {

--- a/4.1/crud-filters.md
+++ b/4.1/crud-filters.md
@@ -54,7 +54,7 @@ function() { // if the filter is active (the GET parameter "draft" exits)
 > Notes about the filter logic closure
 > - the code will only be run on the controller's ```index()``` or ```search()``` methods;
 > - you can get the filter value by specifying a parameter to the function (ex: ```$value```);
-> - you have access to other request variables using ```$this->crud->request```;
+> - you have access to other request variables using ```$this->crud->getRequest()```;
 > - you also have read/write access to public properties using ```$this->crud```;
 > - when building complicated "OR" logic, make sure the first "where" in your closure is a "where" and only the subsequent are "orWhere"; Laravel 5.3+ no longer convers the first "orWhere" into a "where";
 

--- a/4.1/crud-operation-create.md
+++ b/4.1/crud-operation-create.md
@@ -93,7 +93,7 @@ class ProductCrudController extends CrudController
 	// This is done by stripping the request of all inputs that do NOT match Backpack fields for this
 	// particular operation. This is an added security layer, to protect your database from malicious
 	// users who could theoretically add inputs using DeveloperTools or JavaScript. If you're not properly
-	// using $guarded or $fillable on your model, malicious inputs could get you into trouble.
+	// using $guarded or $fillable on your model, malicious inputs could get you into trcruouble.
 	
 	// However, if you know you have proper $guarded or $fillable on your model, andyou want to manipulate 
 	// the request directly to add or remove request parameters, you can also do that.
@@ -102,8 +102,8 @@ class ProductCrudController extends CrudController
     	// $this->crud->setOperationSetting('saveAllInputsExcept', ['_token', '_method', 'http_referrer', 'current_tab', 'save_action']);
 	// The above will make Backpack store all inputs EXCEPT for the ones it uses for various features.
 	// So you can manipulate the request and add any request variable you'd like.
-	// $this->crud->request->request->add(['author_id'=> backpack_user()->id]);
-	// $this->crud->request->request->remove('password_confirmation');
+	// $this->crud->getRequest()->request->add(['author_id'=> backpack_user()->id]);
+	// $this->crud->getRequest()->request->remove('password_confirmation');
 
     	$response = $this->traitStore();
     	// do something after save

--- a/4.1/crud-operation-list-entries.md
+++ b/4.1/crud-operation-list-entries.md
@@ -163,7 +163,7 @@ $this->crud->groupBy();
 $this->crud->limit();
 
 $this->crud->orderBy();
-// please note it's generally a good idea to use crud->orderBy() inside "if (!$this->request->has('order')) {}"; that way, your custom order is applied ONLY IF the user hasn't forced another order (by clicking a column heading)
+// please note it's generally a good idea to use crud->orderBy() inside "if (!$this->crud->getRequest()->has('order')) {}"; that way, your custom order is applied ONLY IF the user hasn't forced another order (by clicking a column heading)
 ```
 
 <a name="responsive-table"></a>

--- a/4.1/crud-operations.md
+++ b/4.1/crud-operations.md
@@ -882,6 +882,7 @@ protected function setupBulkCloneRoutes($segment, $routeName, $controller)
 ```
 
 4. Setup the default features we need for the operation to work:
+
 ```php
 protected function setupBulkCloneDefaults()
 {

--- a/4.1/crud-operations.md
+++ b/4.1/crud-operations.md
@@ -70,26 +70,27 @@ An action can do something with AJAX and return true/false, it can return a view
 
 You can check which action is currently being performed using the [standard Laravel Route API](https://laravel.com/api/5.7/Illuminate/Routing/Route.html):
 
-- ```\Route::getCurrentRoute()->getAction()``` or ```$this->request->route()->getAction()```:
+- ```\Route::getCurrentRoute()->getAction()``` or ```$this->crud->getRequest()->route()->getAction()```:
 ```
-array:7 [▼
+array:8 [▼
   "middleware" => array:2 [▼
     0 => "web"
     1 => "admin"
   ]
   "as" => "crud.monster.index"
   "uses" => "App\Http\Controllers\Admin\MonsterCrudController@index"
+  "operation" => "list"
   "controller" => "App\Http\Controllers\Admin\MonsterCrudController@index"
   "namespace" => "App\Http\Controllers\Admin"
   "prefix" => "admin"
   "where" => []
 ]
 ```
-- ```\Route::getCurrentRoute()->getActionName()``` or ```$this->request->route()->getActionName()```:
+- ```\Route::getCurrentRoute()->getActionName()``` or ```$this->crud->getRequest()->route()->getActionName()```:
 ```
 App\Http\Controllers\Admin\MonsterCrudController@index
 ```
-- ```\Route::getCurrentRoute()->getActionMethod()``` or ```$this->request->route()->getActionMethod()```:
+- ```\Route::getCurrentRoute()->getActionMethod()``` or ```$this->crud->getRequest()->route()->getActionMethod()```:
 ```
 index
 ```
@@ -854,7 +855,7 @@ Say we want to create a ```BulkClone``` operation, with a button which clones mu
     {
         $this->crud->hasAccessOrFail('create');
 
-        $entries = $this->request->input('entries');
+        $entries = $this->crud->getRequest()->input('entries');
         $clonedEntries = [];
 
         foreach ($entries as $key => $id) {


### PR DESCRIPTION
The way to access the request from a controller [has changed in version 4.1](https://backpackforlaravel.com/docs/4.1/upgrade-guide#step-11) but the change has not been reflected to all docs. This PR updates docs to use the new getter.

`$this->request` and `$this->crud->request` to `this->crud->getRequest()`