### PR TITLE
Normalized quotation marks

### DIFF
--- a/3.4/crud-fields.md
+++ b/3.4/crud-fields.md
@@ -886,7 +886,7 @@ Display a select with the values you want:
     'name' => 'template',
     'label' => "Template",
     'type' => 'select_from_array',
-    'options' => [‘one’ => ‘One’, ‘two’ => ‘Two’],
+    'options' => ['one’ => 'One’, 'two’ => 'Two’],
     'allows_null' => false,
     'default' => 'one',
     // 'allows_multiple' => true, // OPTIONAL; needs you to cast this to array in your model;
@@ -907,7 +907,7 @@ Display a select2 with the values you want:
     'name' => 'template',
     'label' => "Template",
     'type' => 'select2_from_array',
-    'options' => [‘one’ => ‘One’, ‘two’ => ‘Two’],
+    'options' => ['one’ => 'One’, 'two’ => 'Two’],
     'allows_null' => false,
     'default' => 'one',
     // 'allows_multiple' => true, // OPTIONAL; needs you to cast this to array in your model;
@@ -1374,10 +1374,10 @@ An entry stored in the database will look like this:
 ```
 $video = {
     id: 234324,
-    title: ‘my video title’,
-    image: ‘https://provider.com/image.jpg',
-    url: ‘http://provider.com/video',
-    provider: ‘youtube’
+    title: 'my video title’,
+    image: 'https://provider.com/image.jpg',
+    url: 'http://provider.com/video',
+    provider: 'youtube’
 }
 ```
 

--- a/3.4/crud-fields.md
+++ b/3.4/crud-fields.md
@@ -104,7 +104,7 @@ In case you want to store insignificant information for an entry, that don't nee
     'name' => 'name', // JSON variable name
     'label' => "Tag Name", // human-readable label for the input
 
-    'fake' => true, // show the field, but don’t store it in the database column above
+    'fake' => true, // show the field, but don't store it in the database column above
     'store_in' => 'extras' // [optional] the database column name where you want the fake fields to ACTUALLY be stored as a JSON array 
 ],
 ```
@@ -138,7 +138,7 @@ Example:
 ],
 ```
 
-In this example, these 3 fields will show up in the create & update forms, the CRUD will process as usual, but in the database these values won’t be stored in the ```meta_title```, ```meta_description``` and ```meta_keywords``` columns. They will be stored in the ```metas``` column as a JSON array:
+In this example, these 3 fields will show up in the create & update forms, the CRUD will process as usual, but in the database these values won't be stored in the ```meta_title```, ```meta_description``` and ```meta_keywords``` columns. They will be stored in the ```metas``` column as a JSON array:
 
 ```php
 {"meta_title":"title","meta_description":"desc","meta_keywords":"keywords"}
@@ -720,7 +720,7 @@ Input preview:
 <a name="page-or-link"></a>
 ### page_or_link
 
-Select an existing page from PageManager or an internal or external link. It’s used in the MenuManager package, but can be used in any other model just as well. Its definition looks like this:
+Select an existing page from PageManager or an internal or external link. It's used in the MenuManager package, but can be used in any other model just as well. Its definition looks like this:
 ```php
 [   // PageOrLink
     'name' => 'type',
@@ -886,7 +886,7 @@ Display a select with the values you want:
     'name' => 'template',
     'label' => "Template",
     'type' => 'select_from_array',
-    'options' => ['one’ => 'One’, 'two’ => 'Two’],
+    'options' => ['one' => 'One', 'two' => 'Two'],
     'allows_null' => false,
     'default' => 'one',
     // 'allows_multiple' => true, // OPTIONAL; needs you to cast this to array in your model;
@@ -907,7 +907,7 @@ Display a select2 with the values you want:
     'name' => 'template',
     'label' => "Template",
     'type' => 'select2_from_array',
-    'options' => ['one’ => 'One’, 'two’ => 'Two’],
+    'options' => ['one' => 'One', 'two' => 'Two'],
     'allows_null' => false,
     'default' => 'one',
     // 'allows_multiple' => true, // OPTIONAL; needs you to cast this to array in your model;
@@ -1374,10 +1374,10 @@ An entry stored in the database will look like this:
 ```
 $video = {
     id: 234324,
-    title: 'my video title’,
+    title: 'my video title',
     image: 'https://provider.com/image.jpg',
     url: 'http://provider.com/video',
-    provider: 'youtube’
+    provider: 'youtube'
 }
 ```
 
@@ -1430,7 +1430,7 @@ Show a wysiwyg (CKEditor) to the user.
 <a name="overwriting-default-field-types"></a>
 ## Overwriting Default Field Types
 
-The actual field types are stored in the Backpack/CRUD package in ```/resources/views/fields```. If you need to change an existing field, you don’t need to modify the package, you just need to add a blade file in your application in ```/resources/views/vendor/backpack/crud/fields```, with the same name. The package checks there first, and only if there's no file there, will it load it from the package.
+The actual field types are stored in the Backpack/CRUD package in ```/resources/views/fields```. If you need to change an existing field, you don't need to modify the package, you just need to add a blade file in your application in ```/resources/views/vendor/backpack/crud/fields```, with the same name. The package checks there first, and only if there's no file there, will it load it from the package.
 
 To quickly publish a field blade file in your project, you can use ```php artisan backpack:crud:publish fields/field_name```. For example, to publish the number field type, you'd type ```php artisan backpack:crud:publish fields/number```
 

--- a/3.4/crud-how-to.md
+++ b/3.4/crud-how-to.md
@@ -36,7 +36,7 @@ If you don't find one there, you can create one, and Backpack will pick it up in
 Starting with Backpack\CRUD 3.2, you can use the ```with()``` method on ```CRUD::resource``` to better organize your routes. Something like this:
 
 ```php
-CRUD::resource(‘teams’, ‘Admin\TeamCrudController’)->with(function(){
+CRUD::resource('teams’, 'Admin\TeamCrudController’)->with(function(){
     // add extra routes to this resource
     Route::get('teams/ajax-name-options', 'Admin\TeamCrudController@nameOptions');
     Route::get('teams/ajax-category-options', 'Admin\TeamCrudController@categoryOptions');
@@ -133,9 +133,9 @@ In order to insert two column with the same name, use the ```key``` attribute on
 ## Use the Media Library (File Manager)
 
 If you've chosen to install [elFinder](http://elfinder.org/) when installing Backpack, you already have a media manager. And it’s integrated into:
-- TinyMCE (as “tinymce” fieldtype)
-- CKEditor (as “ckeditor” fieldtype)
-- CRUD “browse” fieldtype
+- TinyMCE (as "tinymce" fieldtype)
+- CKEditor (as "ckeditor" fieldtype)
+- CRUD "browse" fieldtype
 - standalone, at the *your-project/admin/elfinder* route;
 
 For the integration, barryvdh's [laravel-elfinder](https://github.com/barryvdh/laravel-elfinder) package is used.

--- a/3.4/crud-how-to.md
+++ b/3.4/crud-how-to.md
@@ -36,7 +36,7 @@ If you don't find one there, you can create one, and Backpack will pick it up in
 Starting with Backpack\CRUD 3.2, you can use the ```with()``` method on ```CRUD::resource``` to better organize your routes. Something like this:
 
 ```php
-CRUD::resource('teams’, 'Admin\TeamCrudController’)->with(function(){
+CRUD::resource('teams', 'Admin\TeamCrudController')->with(function(){
     // add extra routes to this resource
     Route::get('teams/ajax-name-options', 'Admin\TeamCrudController@nameOptions');
     Route::get('teams/ajax-category-options', 'Admin\TeamCrudController@categoryOptions');
@@ -132,7 +132,7 @@ In order to insert two column with the same name, use the ```key``` attribute on
 <a name="use-the-media-library"></a>
 ## Use the Media Library (File Manager)
 
-If you've chosen to install [elFinder](http://elfinder.org/) when installing Backpack, you already have a media manager. And it’s integrated into:
+If you've chosen to install [elFinder](http://elfinder.org/) when installing Backpack, you already have a media manager. And it's integrated into:
 - TinyMCE (as "tinymce" fieldtype)
 - CKEditor (as "ckeditor" fieldtype)
 - CRUD "browse" fieldtype

--- a/3.4/getting-started-advanced-features.md
+++ b/3.4/getting-started-advanced-features.md
@@ -27,7 +27,7 @@ Here are some other cool things Backpack makes easy for you. We recommend going 
 --
 
 - **ListEntries**
-    - you can add a “+” button next to each entry, to allow the admin to easily preview some quick information that was too big to fit inside a columns - we call it [details row](/docs/{{version}}/crud-operation-list-entries#details-row)
+    - you can add a "+" button next to each entry, to allow the admin to easily preview some quick information that was too big to fit inside a columns - we call it [details row](/docs/{{version}}/crud-operation-list-entries#details-row)
     - export all visible items in the table by adding [export buttons](/docs/{{version}}/crud-operation-list-entries#export-buttons)
     - [custom search logic](/docs/{{version}}/crud-columns#custom-search-logic) for the columns in the list view
 

--- a/3.4/getting-started-advanced-features.md
+++ b/3.4/getting-started-advanced-features.md
@@ -4,7 +4,7 @@
 
 **Duration:** 5 min
 
-Here are some other cool things Backpack makes easy for you. We recommend going through them one by one, just browsing. You might not need the feature _right now_, but when _you do_, you’ll know how to find it.
+Here are some other cool things Backpack makes easy for you. We recommend going through them one by one, just browsing. You might not need the feature _right now_, but when _you do_, you'll know how to find it.
 
 ---
 
@@ -36,4 +36,4 @@ Additionally, here are a few more ways you can customize your CRUDs:
 - [Custom Views for each CRUD](/docs/{{version}}/crud-how-to#customize-views-for-each-crud-panel)
 - [Custom CSS or JS](/docs/{{version}}/crud-how-to#customize-css-and-js-for-default-crud-operations) for each CRUD Operation
 
-**That’s it for today!** Told you we’re done with long lessons :-) Hopefully some of the above have peaked your interest and you’ve clicked to see what Backpack can do. In the [next lesson](/docs/{{version}}/getting-started-license-and-support) we’ll go through a few other Backpack packages, that cover some recurring use cases.
+**That's it for today!** Told you we're done with long lessons :-) Hopefully some of the above have peaked your interest and you've clicked to see what Backpack can do. In the [next lesson](/docs/{{version}}/getting-started-license-and-support) we'll go through a few other Backpack packages, that cover some recurring use cases.

--- a/3.4/getting-started-basics.md
+++ b/3.4/getting-started-basics.md
@@ -59,7 +59,7 @@ php artisan backpack:base:add-sidebar-content "<li><a href='{{ backpack_url('tag
 
 This will create a simple CRUD panel, which you should now be able to see in the Sidebar.
 
-For a simple entry like this, the generated CRUD panel will even work “as is”, no need for customizations. But don’t expect this for more complex entities. They will usually require have particularities and need customization. That’s where Backpack shines - modifying anything in the CRUD Panel is easy and intuitive, once you understand how it works.
+For a simple entry like this, the generated CRUD panel will even work "as is", no need for customizations. But don’t expect this for more complex entities. They will usually require have particularities and need customization. That’s where Backpack shines - modifying anything in the CRUD Panel is easy and intuitive, once you understand how it works.
 
 The code above would generate:
 - a **migration** file

--- a/3.4/getting-started-basics.md
+++ b/3.4/getting-started-basics.md
@@ -4,14 +4,14 @@
 
 **Duration:** 5 minutes
 
-> **Are you already comfortable with Laravel?** In order to understand this series and make use of Backpack, you’ll need to have a decent understanding of the Laravel framework. If you don’t, please go ahead and [watch this excellent intro series on Laracasts](https://laracasts.com/series/laravel-from-scratch-2017) and accomodate yourself with Laravel first.
+> **Are you already comfortable with Laravel?** In order to understand this series and make use of Backpack, you'll need to have a decent understanding of the Laravel framework. If you don't, please go ahead and [watch this excellent intro series on Laracasts](https://laracasts.com/series/laravel-from-scratch-2017) and accomodate yourself with Laravel first.
 
 
 <a name="what-is-backpack"></a>
 ## What is Backpack?
 A software that helps Laravel professionals build administration panels - secure areas where administrators login and create, read, update and delete application information. It is *not* a CMS, it is more a framework that lets you *build your own* CMS. You can install it in your existing project or in a totally new project. 
 
-It’s designed to be flexible enough to allow you to **build admin panels for everything from simple presentation websites to CRMs, ERPs, eCommerce, eLearning, etc**. We can vouch for that, because we have built all that stuff using Backpack already.
+It's designed to be flexible enough to allow you to **build admin panels for everything from simple presentation websites to CRMs, ERPs, eCommerce, eLearning, etc**. We can vouch for that, because we have built all that stuff using Backpack already.
 
 <a name="how-to-use-backpack"></a>
 ## How to use?
@@ -22,7 +22,7 @@ Backpack consists of two **core packages**:
 
 A **CRUD** is what we call a section of your admin panel that lets the admin _Create, Read, Update or Delete_ entries of a certain entity (or Model). So you can have a CRUD for Products, a CRUD for Articles, a CRUD for Categories, or whatever else you might want to create, read, update or delete.
 
-For the purpose of this series, we’ll show examples on the Tag entry. This is what it could look like:
+For the purpose of this series, we'll show examples on the Tag entry. This is what it could look like:
 
 ![Tag CRUD - List Entries Operation](https://backpackforlaravel.com/uploads/docs/getting_started/tag_crud_list_entries.png)
 
@@ -32,15 +32,15 @@ For the purpose of this series, we’ll show examples on the Tag entry. This is 
 <a name="backpack-base"></a>
 ### Backpack\Base
 
-**Backpack/Base** is the package that **will handle the authentication** and provide you with minimal admin area functionality. **Your admin will be able to login and change his password or email.** And that’s pretty much it. 
+**Backpack/Base** is the package that **will handle the authentication** and provide you with minimal admin area functionality. **Your admin will be able to login and change his password or email.** And that's pretty much it. 
 
-Thanks to Base, after you [install Backpack](/docs/{{version}}/installation) (don't do it now), you’ll be able to log into your admin panel at ```http://yourapp/admin```. You can change the URL prefix from ```admin``` to something else in your ```config/backpack/base.php``` file, along with a bunch of other configuration options. [Click here](https://github.com/Laravel-Backpack/Base/blob/master/src/config/backpack/base.php) to browse the configuration file and see what it can do for you.
+Thanks to Base, after you [install Backpack](/docs/{{version}}/installation) (don't do it now), you'll be able to log into your admin panel at ```http://yourapp/admin```. You can change the URL prefix from ```admin``` to something else in your ```config/backpack/base.php``` file, along with a bunch of other configuration options. [Click here](https://github.com/Laravel-Backpack/Base/blob/master/src/config/backpack/base.php) to browse the configuration file and see what it can do for you.
 
 Backpack\Base pulls in the free [AdminLTE](https://adminlte.io/themes/AdminLTE/index2.html) theme and enhances the design a little bit. So any front-end block that AdminLTE has, you'll also be able to use in your custom pages. It also includes a system for bubble notifications, which you can use across the admin panel. You can easily [trigger notification bubbles in PHP](/docs/{{version}}/base-about#triggering-notification-bubbles-in-php) or [trigger notification bubbles in JavaScript](/docs/{{version}}/base-about#triggering-notification-bubbles-in-javascript).
 
 <a name="backpack-crud"></a>
 ### Backpack\CRUD
-This is where it gets interesting. As soon as you [install Backpack](docs/3.4/installation) in your project, you can create **CRUDs** for your admins to easily manipulate DB information. Let’s browse through a simple example, of creating a CRUD administration panel for a Tag entity:
+This is where it gets interesting. As soon as you [install Backpack](docs/3.4/installation) in your project, you can create **CRUDs** for your admins to easily manipulate DB information. Let's browse through a simple example, of creating a CRUD administration panel for a Tag entity:
 
 ```zsh
 # STEP 1. create migration
@@ -59,7 +59,7 @@ php artisan backpack:base:add-sidebar-content "<li><a href='{{ backpack_url('tag
 
 This will create a simple CRUD panel, which you should now be able to see in the Sidebar.
 
-For a simple entry like this, the generated CRUD panel will even work "as is", no need for customizations. But don’t expect this for more complex entities. They will usually require have particularities and need customization. That’s where Backpack shines - modifying anything in the CRUD Panel is easy and intuitive, once you understand how it works.
+For a simple entry like this, the generated CRUD panel will even work "as is", no need for customizations. But don't expect this for more complex entities. They will usually require have particularities and need customization. That's where Backpack shines - modifying anything in the CRUD Panel is easy and intuitive, once you understand how it works.
 
 The code above would generate:
 - a **migration** file
@@ -68,7 +68,7 @@ The code above would generate:
 - a **controller** file, where you can customize how the CrudPanel looks and feels (```app\Http\Controllers\Admin\TagCrudController.php```)
 - a **route**, as a line inside ```routes/backpack/custom.php```
 
-We won’t be covering the **migration**, **model** and **request** files here, as they are in no way custom. The only thing you need to make sure is that the Model is properly configured (db table, relationships, ```$fillable``` or ```$guarded``` properties, etc) and that it uses our ```CrudTrait```. What we _will_ be covering is ```TagCrudController``` - which is where most of your logic will reside. Here’s a copy of a simple one you might use to achieve the above:
+We won't be covering the **migration**, **model** and **request** files here, as they are in no way custom. The only thing you need to make sure is that the Model is properly configured (db table, relationships, ```$fillable``` or ```$guarded``` properties, etc) and that it uses our ```CrudTrait```. What we _will_ be covering is ```TagCrudController``` - which is where most of your logic will reside. Here's a copy of a simple one you might use to achieve the above:
 
 ```php
 <?php namespace App\Http\Controllers\Admin;
@@ -114,7 +114,7 @@ class TagCrudController extends CrudController {
 
 You should notice:
 - It uses basic inheritance (```TagCrudController extends CrudController```); so if you want to modify a behaviour (save, update, reorder, etc), you can easily do that by overwriting the corresponding method in your ```TagCrudController```;
-- The request file is typehinted in the ```store()``` and ```update()``` methods; Since in case form validation fails, the information won’t even reach these methods;
+- The request file is typehinted in the ```store()``` and ```update()``` methods; Since in case form validation fails, the information won't even reach these methods;
 - All the CRUD setup is usually done in the ```setup()``` method;
 
-**That’s all for today! **If you want to learn more, go ahead and [read the next lesson](/docs/{{version}}/getting-started-crud-operations) of this series.
+**That's all for today! **If you want to learn more, go ahead and [read the next lesson](/docs/{{version}}/getting-started-crud-operations) of this series.

--- a/3.4/getting-started-crud-operations.md
+++ b/3.4/getting-started-crud-operations.md
@@ -53,9 +53,9 @@ class TagCrudController extends CrudController {
 ```
 
 By default, CRUDs have these operations already enabled:
-- **Create** - using a create form (aka “*add form*”)
-- **ListEntries** - using AJAX DataTables (aka “*list view*”, aka “*table view*”)
-- **Update** - using an update form (aka “*edit form*”)
+- **Create** - using a create form (aka "*add form*")
+- **ListEntries** - using AJAX DataTables (aka "*list view*", aka "*table view*")
+- **Update** - using an update form (aka "*edit form*")
 - **Delete** - using a *button* in the *list view* 
 
 These are the basic operations an admin can execute on an Eloquent model, thanks to Backpack. We do have additional operations (Preview, Reorder, Revisions), and you can easily _create a custom operation_, but let’s not get ahead of ourselves. Baby steps. **Let's go through the most important features of the operations you'll be using _all the time_: ListEntries, Create and Update**.
@@ -116,7 +116,7 @@ $this->crud->addField([
     'entity' => 'articles', // the relationship name in your Model
     'attribute' => 'title', // attribute on Article that is shown to admin
     'pivot' => true, // on create&update, do you need to add/delete pivot table entries?
-], ‘update’);
+], 'update’);
 ```
 
 **Notes:**

--- a/3.4/getting-started-crud-operations.md
+++ b/3.4/getting-started-crud-operations.md
@@ -4,7 +4,7 @@
 
 **Duration:** 10 minutes
 
-Let’s bring back the example in our first lesson. The Tags CRUD:
+Let's bring back the example in our first lesson. The Tags CRUD:
 
 ![Tag CRUD - List Entries Operation](https://backpackforlaravel.com/uploads/docs/getting_started/tag_crud_list_entries.png)
 
@@ -58,7 +58,7 @@ By default, CRUDs have these operations already enabled:
 - **Update** - using an update form (aka "*edit form*")
 - **Delete** - using a *button* in the *list view* 
 
-These are the basic operations an admin can execute on an Eloquent model, thanks to Backpack. We do have additional operations (Preview, Reorder, Revisions), and you can easily _create a custom operation_, but let’s not get ahead of ourselves. Baby steps. **Let's go through the most important features of the operations you'll be using _all the time_: ListEntries, Create and Update**.
+These are the basic operations an admin can execute on an Eloquent model, thanks to Backpack. We do have additional operations (Preview, Reorder, Revisions), and you can easily _create a custom operation_, but let's not get ahead of ourselves. Baby steps. **Let's go through the most important features of the operations you'll be using _all the time_: ListEntries, Create and Update**.
 
 <a name="create-and-update-operations"></a>
 ## Create & Update Operations
@@ -95,7 +95,7 @@ A typical *field definition array* will need at least three things:
 - ```label``` - the human-readable label for the input (will be generated from ```name``` if not given);
 
 
-You can use [one of the 44+ field types we’ve provided](/docs/{{version}}/crud-fields#default-field-types), or easily [create a custom field type](/docs/{{version}}/crud-fields#creating-a-custom-field-type) if you have some super-specific need that we haven’t covered yet, or even [overwrite how a field type works](#overwriting-default-field-types). Take a few minutes and [browse the 44+ field types](/docs/{{version}}/crud-fields#default-field-types), to understand how the definition array differs from one to another and how many use cases you have already covered.
+You can use [one of the 44+ field types we've provided](/docs/{{version}}/crud-fields#default-field-types), or easily [create a custom field type](/docs/{{version}}/crud-fields#creating-a-custom-field-type) if you have some super-specific need that we haven't covered yet, or even [overwrite how a field type works](#overwriting-default-field-types). Take a few minutes and [browse the 44+ field types](/docs/{{version}}/crud-fields#default-field-types), to understand how the definition array differs from one to another and how many use cases you have already covered.
 
 Let's take another example, slightly more complicated than the ```text``` fields we used above. Something you'll find encounter all the time is relationship fields. So let's say the ```Tag``` model has an **n-n relationship** with an Article model:
 
@@ -116,7 +116,7 @@ $this->crud->addField([
     'entity' => 'articles', // the relationship name in your Model
     'attribute' => 'title', // attribute on Article that is shown to admin
     'pivot' => true, // on create&update, do you need to add/delete pivot table entries?
-], 'update’);
+], 'update');
 ```
 
 **Notes:**
@@ -139,7 +139,7 @@ $this->crud->addField([
 **Note: **Because the last parameter is missing, the field will be added to both Create and Update forms.
 
 
-> When generating a CrudController, you’ll be using the ```$this->crud->setFromDb();``` method by default, which tries to figure out what fields you might need in your create/update forms and in your list view, but - as you'd expect - only works for the simple field types. You can:
+> When generating a CrudController, you'll be using the ```$this->crud->setFromDb();``` method by default, which tries to figure out what fields you might need in your create/update forms and in your list view, but - as you'd expect - only works for the simple field types. You can:
 > 
 > (1) choose to keep using ```setFromDb()``` and add/remove/change additional fields
 > 
@@ -184,7 +184,7 @@ ListEntries shows the admin a table with all entries. On the front-end, the info
 <a name="columns"></a>
 ### Columns
 
-Columns help you specify *which* attributes are shown in the table and *in which order*. **They’re defined in the ```setup()``` method, the same as fields, and their syntax is super-similar to fields too**:
+Columns help you specify *which* attributes are shown in the table and *in which order*. **They're defined in the ```setup()``` method, the same as fields, and their syntax is super-similar to fields too**:
 
 ```php
 $this->crud->addColumn($column_definition_array); // add a single column, at the end of the table
@@ -241,4 +241,4 @@ $this->crud->removeButton($name);
 $this->crud->removeButtonFromStack($name, $stack);
 ```
 
-**That’s it for today!** Thanks for sticking with us this long. This has been the most important and longest lesson. You can go ahead and [install Backpack](/docs/{{version}}/installation) now, as you’ve already gone through the most important features. Or [read the next lesson](/docs/{{version}}/getting-started-advanced-features), about advanced features.
+**That's it for today!** Thanks for sticking with us this long. This has been the most important and longest lesson. You can go ahead and [install Backpack](/docs/{{version}}/installation) now, as you've already gone through the most important features. Or [read the next lesson](/docs/{{version}}/getting-started-advanced-features), about advanced features.

--- a/3.4/getting-started-license-and-support.md
+++ b/3.4/getting-started-license-and-support.md
@@ -25,12 +25,12 @@ Backpack is **free for non-commercial use**, but needs a license code in order t
 But **developers** or companies **who make money using it** - for themselves, their employers or their clients, **should [purchase a commercial license here](https://backpackforlaravel.com/pricing)**. We do give away free license codes for personal use, non-commercial purposes, non-profits or Backpack contributors, just [let us know](https://backpackforlaravel.com/contact), happy to help.
 
 
->**You don't need a license code on LOCALHOST.** If you’re just trying Backpack on your own machine, you don’t need a license code. You only need a license code when you take your application to production.
+>**You don't need a license code on LOCALHOST.** If you're just trying Backpack on your own machine, you don't need a license code. You only need a license code when you take your application to production.
 
 <a name="support"></a>
 ## Support
 
-With thousands of developers using Backpack, a lot of them non-commercial, and such a small price, **we can’t offer official support for the packages**. We've been doing this since 2016, we actively maintain the packages, we try to squash any bugs ASAP and add new features all the time, but we unfortunately can't spend time on back-and-forth on implementation issues in your project. But. We do have good documentation and have been blessed with a **great community**, where people help each other out. If Backpack becomes your tool of preference, I highly recommend you join our gang. Help others get started, create cool stuff, or even influence the direction of Backpack: 
+With thousands of developers using Backpack, a lot of them non-commercial, and such a small price, **we can't offer official support for the packages**. We've been doing this since 2016, we actively maintain the packages, we try to squash any bugs ASAP and add new features all the time, but we unfortunately can't spend time on back-and-forth on implementation issues in your project. But. We do have good documentation and have been blessed with a **great community**, where people help each other out. If Backpack becomes your tool of preference, I highly recommend you join our gang. Help others get started, create cool stuff, or even influence the direction of Backpack: 
 
 - **[StackOverflow tag](https://stackoverflow.com/questions/tagged/backpack-for-laravel) for support requests** (If you need help creating something using Backpack, post your question on StackOverflow using the ```backpack-for-laravel``` tag. We've been blessed with a great community, that is happy to help. Who doesn't like getting StackOverflow points?)
 - **[Gitter Chatroom](https://gitter.im/BackpackForLaravel/Lobby) for quick questions** (If you have an urgent matter that won't take much time to answer, use our 24/7 Gitter chatroom. Be considerate, everyone's probably working on their own project right now.)

--- a/3.4/getting-started-license-and-support.md
+++ b/3.4/getting-started-license-and-support.md
@@ -16,7 +16,7 @@ Take a look at:
 <a name="license"></a>
 ## License
 
-Backpack is **free for non-commercial use**, but needs a license code in order to prevent “_unlicensed use_” notification bubbles and interruption of service. You can get a license code for your project:
+Backpack is **free for non-commercial use**, but needs a license code in order to prevent "_unlicensed use_" notification bubbles and interruption of service. You can get a license code for your project:
 - ```free```, if you're using it for non-commercial purposes;
 - ```free```, if you've contributed to Backpack on Github;
 - ```$49 EUR/project```, if you're making money using it for a project;

--- a/3.5/crud-fields.md
+++ b/3.5/crud-fields.md
@@ -7,7 +7,7 @@
 
 Field types define how the admin can manipulate an entry's values. They're used by the Create and Update operations.
 
-Think of the field type as the type of input: ```<input type=”text” />```. But for most entities, you won't just need text inputs - you'll need datepickers, upload buttons, 1-n relationship, n-n relationships, textareas, etc.
+Think of the field type as the type of input: ```<input type="text" />```. But for most entities, you won't just need text inputs - you'll need datepickers, upload buttons, 1-n relationship, n-n relationships, textareas, etc.
 
 We have a lot of default field types, detailed below. If you don't find what you're looking for, you can [create a custom field type](/docs/{{version}}/crud-fields#creating-a-custom-field-type). Or if you just want to tweak a default field type a little bit, you can [overwrite default field types](/docs/{{version}}/crud-fields#overwriting-default-field-types).
 
@@ -1058,7 +1058,7 @@ Display a select with the values you want:
     'name' => 'template',
     'label' => "Template",
     'type' => 'select_from_array',
-    'options' => [‘one’ => ‘One’, ‘two’ => ‘Two’],
+    'options' => ['one’ => 'One’, 'two’ => 'Two’],
     'allows_null' => false,
     'default' => 'one',
     // 'allows_multiple' => true, // OPTIONAL; needs you to cast this to array in your model;
@@ -1079,7 +1079,7 @@ Display a select2 with the values you want:
     'name' => 'template',
     'label' => "Template",
     'type' => 'select2_from_array',
-    'options' => [‘one’ => ‘One’, ‘two’ => ‘Two’],
+    'options' => ['one’ => 'One’, 'two’ => 'Two’],
     'allows_null' => false,
     'default' => 'one',
     // 'allows_multiple' => true, // OPTIONAL; needs you to cast this to array in your model;
@@ -1107,8 +1107,8 @@ Display a select2 that takes its values from an AJAX call.
             'data_source' => url("api/category"), // url to controller search function (with /{id} should return model)
             'placeholder' => "Select a category", // placeholder for the select
             'minimum_input_length' => 2, // minimum characters to type before querying results
-            // 'dependencies'         => [‘category’], // when a dependency changes, this select2 is reset to null
-            // ‘method'                    => ‘GET’, // optional - HTTP method to use for the AJAX call (GET, POST)
+            // 'dependencies'         => ['category’], // when a dependency changes, this select2 is reset to null
+            // 'method'                    => 'GET’, // optional - HTTP method to use for the AJAX call (GET, POST)
  ]
 ```
 
@@ -1548,10 +1548,10 @@ An entry stored in the database will look like this:
 ```
 $video = {
     id: 234324,
-    title: ‘my video title’,
-    image: ‘https://provider.com/image.jpg',
-    url: ‘http://provider.com/video',
-    provider: ‘youtube’
+    title: 'my video title’,
+    image: 'https://provider.com/image.jpg',
+    url: 'http://provider.com/video',
+    provider: 'youtube’
 }
 ```
 

--- a/3.5/crud-fields.md
+++ b/3.5/crud-fields.md
@@ -113,7 +113,7 @@ In case you want to store insignificant information for an entry, that don't nee
     'name' => 'name', // JSON variable name
     'label' => "Tag Name", // human-readable label for the input
 
-    'fake' => true, // show the field, but don’t store it in the database column above
+    'fake' => true, // show the field, but don't store it in the database column above
     'store_in' => 'extras' // [optional] the database column name where you want the fake fields to ACTUALLY be stored as a JSON array 
 ],
 ```
@@ -147,7 +147,7 @@ Example:
 ],
 ```
 
-In this example, these 3 fields will show up in the create & update forms, the CRUD will process as usual, but in the database these values won’t be stored in the ```meta_title```, ```meta_description``` and ```meta_keywords``` columns. They will be stored in the ```metas``` column as a JSON array:
+In this example, these 3 fields will show up in the create & update forms, the CRUD will process as usual, but in the database these values won't be stored in the ```meta_title```, ```meta_description``` and ```meta_keywords``` columns. They will be stored in the ```metas``` column as a JSON array:
 
 ```php
 {"meta_title":"title","meta_description":"desc","meta_keywords":"keywords"}
@@ -223,7 +223,7 @@ Using Google Places API is dependant on using an API Key. Please [get an API key
 
 ```php
     'google_places' => [
-        'key' => ’the-key-you-got-from-google-places'
+        'key' => 'the-key-you-got-from-google-places'
     ],
 ```
 
@@ -758,7 +758,7 @@ Input preview:
 <a name="page-or-link"></a>
 ### page_or_link
 
-Select an existing page from PageManager or an internal or external link. It’s used in the MenuManager package, but can be used in any other model just as well. Its definition looks like this:
+Select an existing page from PageManager or an internal or external link. It's used in the MenuManager package, but can be used in any other model just as well. Its definition looks like this:
 ```php
 [   // PageOrLink
     'name' => 'type',
@@ -1058,7 +1058,7 @@ Display a select with the values you want:
     'name' => 'template',
     'label' => "Template",
     'type' => 'select_from_array',
-    'options' => ['one’ => 'One’, 'two’ => 'Two’],
+    'options' => ['one' => 'One', 'two' => 'Two'],
     'allows_null' => false,
     'default' => 'one',
     // 'allows_multiple' => true, // OPTIONAL; needs you to cast this to array in your model;
@@ -1079,7 +1079,7 @@ Display a select2 with the values you want:
     'name' => 'template',
     'label' => "Template",
     'type' => 'select2_from_array',
-    'options' => ['one’ => 'One’, 'two’ => 'Two’],
+    'options' => ['one' => 'One', 'two' => 'Two'],
     'allows_null' => false,
     'default' => 'one',
     // 'allows_multiple' => true, // OPTIONAL; needs you to cast this to array in your model;
@@ -1107,8 +1107,8 @@ Display a select2 that takes its values from an AJAX call.
             'data_source' => url("api/category"), // url to controller search function (with /{id} should return model)
             'placeholder' => "Select a category", // placeholder for the select
             'minimum_input_length' => 2, // minimum characters to type before querying results
-            // 'dependencies'         => ['category’], // when a dependency changes, this select2 is reset to null
-            // 'method'                    => 'GET’, // optional - HTTP method to use for the AJAX call (GET, POST)
+            // 'dependencies'         => ['category'], // when a dependency changes, this select2 is reset to null
+            // 'method'                    => 'GET', // optional - HTTP method to use for the AJAX call (GET, POST)
  ]
 ```
 
@@ -1548,10 +1548,10 @@ An entry stored in the database will look like this:
 ```
 $video = {
     id: 234324,
-    title: 'my video title’,
+    title: 'my video title',
     image: 'https://provider.com/image.jpg',
     url: 'http://provider.com/video',
-    provider: 'youtube’
+    provider: 'youtube'
 }
 ```
 
@@ -1604,7 +1604,7 @@ Show a wysiwyg (CKEditor) to the user.
 <a name="overwriting-default-field-types"></a>
 ## Overwriting Default Field Types
 
-The actual field types are stored in the Backpack/CRUD package in ```/resources/views/fields```. If you need to change an existing field, you don’t need to modify the package, you just need to add a blade file in your application in ```/resources/views/vendor/backpack/crud/fields```, with the same name. The package checks there first, and only if there's no file there, will it load it from the package.
+The actual field types are stored in the Backpack/CRUD package in ```/resources/views/fields```. If you need to change an existing field, you don't need to modify the package, you just need to add a blade file in your application in ```/resources/views/vendor/backpack/crud/fields```, with the same name. The package checks there first, and only if there's no file there, will it load it from the package.
 
 To quickly publish a field blade file in your project, you can use ```php artisan backpack:crud:publish fields/field_name```. For example, to publish the number field type, you'd type ```php artisan backpack:crud:publish fields/number```
 

--- a/3.5/crud-how-to.md
+++ b/3.5/crud-how-to.md
@@ -37,7 +37,7 @@ If you don't find one there, you can create one, and Backpack will pick it up in
 Starting with Backpack\CRUD 3.2, you can use the ```with()``` method on ```CRUD::resource``` to better organize your routes. Something like this:
 
 ```php
-CRUD::resource('teams’, 'Admin\TeamCrudController’)->with(function(){
+CRUD::resource('teams', 'Admin\TeamCrudController')->with(function(){
     // add extra routes to this resource
     Route::get('teams/ajax-name-options', 'Admin\TeamCrudController@nameOptions');
     Route::get('teams/ajax-category-options', 'Admin\TeamCrudController@categoryOptions');
@@ -133,7 +133,7 @@ In order to insert two column with the same name, use the ```key``` attribute on
 <a name="use-the-media-library"></a>
 ## Use the Media Library (File Manager)
 
-If you've chosen to install [elFinder](http://elfinder.org/) when installing Backpack, you already have a media manager. And it’s integrated into:
+If you've chosen to install [elFinder](http://elfinder.org/) when installing Backpack, you already have a media manager. And it's integrated into:
 - TinyMCE (as "tinymce" fieldtype)
 - CKEditor (as "ckeditor" fieldtype)
 - CRUD "browse" fieldtype
@@ -221,8 +221,8 @@ Say you want to show two selects:
             'data_source'          => url('api/article'), // url to controller search function (with /{id} should return model)
             'placeholder'          => 'Select an article', // placeholder for the select
             'minimum_input_length' => 0, // minimum characters to type before querying results
-            'dependencies'         => ['category’], // when a dependency changes, this select2 is reset to null
-            // 'method'                    => 'GET’, // optional - HTTP method to use for the AJAX call (GET, POST)
+            'dependencies'         => ['category'], // when a dependency changes, this select2 is reset to null
+            // 'method'                    => 'GET', // optional - HTTP method to use for the AJAX call (GET, POST)
         ]);
 ```
 
@@ -232,7 +232,7 @@ Say you want to show two selects:
 
 ```php
 Route::get('api/article', 'App\Http\Controllers\Api\ArticleController@index');
-Route::get('api/article/{id}', 'App\Http\Controllers\Api\ArticleController@show’);
+Route::get('api/article/{id}', 'App\Http\Controllers\Api\ArticleController@show');
 ```
 
 **DIFFERENT HERE**: Nothing.

--- a/3.5/crud-how-to.md
+++ b/3.5/crud-how-to.md
@@ -37,7 +37,7 @@ If you don't find one there, you can create one, and Backpack will pick it up in
 Starting with Backpack\CRUD 3.2, you can use the ```with()``` method on ```CRUD::resource``` to better organize your routes. Something like this:
 
 ```php
-CRUD::resource(‘teams’, ‘Admin\TeamCrudController’)->with(function(){
+CRUD::resource('teams’, 'Admin\TeamCrudController’)->with(function(){
     // add extra routes to this resource
     Route::get('teams/ajax-name-options', 'Admin\TeamCrudController@nameOptions');
     Route::get('teams/ajax-category-options', 'Admin\TeamCrudController@categoryOptions');
@@ -134,9 +134,9 @@ In order to insert two column with the same name, use the ```key``` attribute on
 ## Use the Media Library (File Manager)
 
 If you've chosen to install [elFinder](http://elfinder.org/) when installing Backpack, you already have a media manager. And it’s integrated into:
-- TinyMCE (as “tinymce” fieldtype)
-- CKEditor (as “ckeditor” fieldtype)
-- CRUD “browse” fieldtype
+- TinyMCE (as "tinymce" fieldtype)
+- CKEditor (as "ckeditor" fieldtype)
+- CRUD "browse" fieldtype
 - standalone, at the *your-project/admin/elfinder* route;
 
 For the integration, barryvdh's [laravel-elfinder](https://github.com/barryvdh/laravel-elfinder) package is used.
@@ -205,9 +205,9 @@ Say you want to show two selects:
 ```php
 
         $this->crud->addField([    // SELECT2
-            'label'         => ‘Category',
+            'label'         => 'Category',
             'type'          => 'select',
-            'name'          => ‘category',
+            'name'          => 'category',
             'entity'        => 'category',
             'attribute'     => 'name',
         ]);
@@ -221,8 +221,8 @@ Say you want to show two selects:
             'data_source'          => url('api/article'), // url to controller search function (with /{id} should return model)
             'placeholder'          => 'Select an article', // placeholder for the select
             'minimum_input_length' => 0, // minimum characters to type before querying results
-            'dependencies'         => [‘category’], // when a dependency changes, this select2 is reset to null
-            // ‘method'                    => ‘GET’, // optional - HTTP method to use for the AJAX call (GET, POST)
+            'dependencies'         => ['category’], // when a dependency changes, this select2 is reset to null
+            // 'method'                    => 'GET’, // optional - HTTP method to use for the AJAX call (GET, POST)
         ]);
 ```
 

--- a/3.5/getting-started-advanced-features.md
+++ b/3.5/getting-started-advanced-features.md
@@ -27,7 +27,7 @@ Here are some other cool things Backpack makes easy for you. We recommend going 
 --
 
 - **ListEntries**
-    - you can add a “+” button next to each entry, to allow the admin to easily preview some quick information that was too big to fit inside a columns - we call it [details row](/docs/{{version}}/crud-operation-list-entries#details-row)
+    - you can add a "+" button next to each entry, to allow the admin to easily preview some quick information that was too big to fit inside a columns - we call it [details row](/docs/{{version}}/crud-operation-list-entries#details-row)
     - export all visible items in the table by adding [export buttons](/docs/{{version}}/crud-operation-list-entries#export-buttons)
     - [custom search logic](/docs/{{version}}/crud-columns#custom-search-logic) for the columns in the list view
 

--- a/3.5/getting-started-advanced-features.md
+++ b/3.5/getting-started-advanced-features.md
@@ -4,7 +4,7 @@
 
 **Duration:** 5 min
 
-Here are some other cool things Backpack makes easy for you. We recommend going through them one by one, just browsing. You might not need the feature _right now_, but when _you do_, you’ll know how to find it.
+Here are some other cool things Backpack makes easy for you. We recommend going through them one by one, just browsing. You might not need the feature _right now_, but when _you do_, you'll know how to find it.
 
 ---
 
@@ -36,4 +36,4 @@ Additionally, here are a few more ways you can customize your CRUDs:
 - [Custom Views for each CRUD](/docs/{{version}}/crud-how-to#customize-views-for-each-crud-panel)
 - [Custom CSS or JS](/docs/{{version}}/crud-how-to#customize-css-and-js-for-default-crud-operations) for each CRUD Operation
 
-**That’s it for today!** Told you we’re done with long lessons :-) Hopefully some of the above have peaked your interest and you’ve clicked to see what Backpack can do. In the [next lesson](/docs/{{version}}/getting-started-license-and-support) we’ll go through a few other Backpack packages, that cover some recurring use cases.
+**That's it for today!** Told you we're done with long lessons :-) Hopefully some of the above have peaked your interest and you've clicked to see what Backpack can do. In the [next lesson](/docs/{{version}}/getting-started-license-and-support) we'll go through a few other Backpack packages, that cover some recurring use cases.

--- a/3.5/getting-started-basics.md
+++ b/3.5/getting-started-basics.md
@@ -4,14 +4,14 @@
 
 **Duration:** 5 minutes
 
-> **Are you already comfortable with Laravel?** In order to understand this series and make use of Backpack, you’ll need to have a decent understanding of the Laravel framework. If you don’t, please go ahead and [watch this excellent intro series on Laracasts](https://laracasts.com/series/laravel-from-scratch-2017) and accomodate yourself with Laravel first.
+> **Are you already comfortable with Laravel?** In order to understand this series and make use of Backpack, you'll need to have a decent understanding of the Laravel framework. If you don't, please go ahead and [watch this excellent intro series on Laracasts](https://laracasts.com/series/laravel-from-scratch-2017) and accomodate yourself with Laravel first.
 
 
 <a name="what-is-backpack"></a>
 ## What is Backpack?
 A software that helps Laravel professionals build administration panels - secure areas where administrators login and create, read, update and delete application information. It is *not* a CMS, it is more a framework that lets you *build your own* CMS. You can install it in your existing project or in a totally new project. 
 
-It’s designed to be flexible enough to allow you to **build admin panels for everything from simple presentation websites to CRMs, ERPs, eCommerce, eLearning, etc**. We can vouch for that, because we have built all that stuff using Backpack already.
+It's designed to be flexible enough to allow you to **build admin panels for everything from simple presentation websites to CRMs, ERPs, eCommerce, eLearning, etc**. We can vouch for that, because we have built all that stuff using Backpack already.
 
 <a name="how-to-use-backpack"></a>
 ## How to use?
@@ -22,7 +22,7 @@ Backpack consists of two **core packages**:
 
 A **CRUD** is what we call a section of your admin panel that lets the admin _Create, Read, Update or Delete_ entries of a certain entity (or Model). So you can have a CRUD for Products, a CRUD for Articles, a CRUD for Categories, or whatever else you might want to create, read, update or delete.
 
-For the purpose of this series, we’ll show examples on the ```Tag``` entity. This is what a Tag CRUD could look like:
+For the purpose of this series, we'll show examples on the ```Tag``` entity. This is what a Tag CRUD could look like:
 
 ![Tag CRUD - List Entries Operation](https://backpackforlaravel.com/uploads/docs-3-5/getting_started/tag_crud_list_entries.png)
 
@@ -38,17 +38,17 @@ Mind that you will _almost never_ use all of Backpack's features in one CRUD. Bu
 <a name="backpack-base"></a>
 ### Backpack\Base
 
-**Backpack/Base** is the package that **will handle the authentication** and provide you with minimal admin area functionality. **Your admin will be able to login and change his password or email.** And that’s pretty much it. 
+**Backpack/Base** is the package that **will handle the authentication** and provide you with minimal admin area functionality. **Your admin will be able to login and change his password or email.** And that's pretty much it. 
 
 ![Backpack 3.5 Authentication Screens](https://backpackforlaravel.com/uploads/docs-3-5/getting_started/auth_screens.png)
 
-Thanks to Base, after you [install Backpack](/docs/{{version}}/installation) (don't do it now), you’ll be able to log into your admin panel at ```http://yourapp/admin```. You can change the URL prefix from ```admin``` to something else in your ```config/backpack/base.php``` file, along with a bunch of other configuration options. [Click here](https://github.com/Laravel-Backpack/Base/blob/master/src/config/backpack/base.php) to browse the configuration file and see what it can do for you.
+Thanks to Base, after you [install Backpack](/docs/{{version}}/installation) (don't do it now), you'll be able to log into your admin panel at ```http://yourapp/admin```. You can change the URL prefix from ```admin``` to something else in your ```config/backpack/base.php``` file, along with a bunch of other configuration options. [Click here](https://github.com/Laravel-Backpack/Base/blob/master/src/config/backpack/base.php) to browse the configuration file and see what it can do for you.
 
 Backpack\Base pulls in the free [AdminLTE](https://adminlte.io/themes/AdminLTE/index2.html) theme and enhances the design a little bit. So any front-end block that AdminLTE has, you'll also be able to use in your custom pages. It also includes a system for bubble notifications, which you can use across the admin panel. You can easily [trigger notification bubbles in PHP](/docs/{{version}}/base-about#triggering-notification-bubbles-in-php) or [trigger notification bubbles in JavaScript](/docs/{{version}}/base-about#triggering-notification-bubbles-in-javascript).
 
 <a name="backpack-crud"></a>
 ### Backpack\CRUD
-This is where it gets interesting. As soon as you [install Backpack](/docs/{{version}}/installation) in your project, you can create **CRUDs** for your admins to easily manipulate DB information. Let’s browse through a simple example, of creating a CRUD administration panel for a Tag entity:
+This is where it gets interesting. As soon as you [install Backpack](/docs/{{version}}/installation) in your project, you can create **CRUDs** for your admins to easily manipulate DB information. Let's browse through a simple example, of creating a CRUD administration panel for a Tag entity:
 
 ```zsh
 # STEP 1. create migration
@@ -67,7 +67,7 @@ php artisan backpack:base:add-sidebar-content "<li><a href='{{ backpack_url('tag
 
 This will create a simple CRUD panel, which you should now be able to see in the Sidebar.
 
-For a simple entry like this, the generated CRUD panel will even work "as is", no need for customizations. But don’t expect this for more complex entities. They will usually require have particularities and need customization. That’s where Backpack shines - modifying anything in the CRUD Panel is easy and intuitive, once you understand how it works.
+For a simple entry like this, the generated CRUD panel will even work "as is", no need for customizations. But don't expect this for more complex entities. They will usually require have particularities and need customization. That's where Backpack shines - modifying anything in the CRUD Panel is easy and intuitive, once you understand how it works.
 
 The code above would generate:
 - a **migration** file
@@ -76,7 +76,7 @@ The code above would generate:
 - a **controller** file, where you can customize how the CrudPanel looks and feels (```app\Http\Controllers\Admin\TagCrudController.php```)
 - a **route**, as a line inside ```routes/backpack/custom.php```
 
-We won’t be covering the **migration**, **model** and **request** files here, as they are in no way custom. The only thing you need to make sure is that the Model is properly configured (db table, relationships, ```$fillable``` or ```$guarded``` properties, etc) and that it uses our ```CrudTrait```. What we _will_ be covering is ```TagCrudController``` - which is where most of your logic will reside. Here’s a copy of a simple one you might use to achieve the above:
+We won't be covering the **migration**, **model** and **request** files here, as they are in no way custom. The only thing you need to make sure is that the Model is properly configured (db table, relationships, ```$fillable``` or ```$guarded``` properties, etc) and that it uses our ```CrudTrait```. What we _will_ be covering is ```TagCrudController``` - which is where most of your logic will reside. Here's a copy of a simple one you might use to achieve the above:
 
 ```php
 <?php namespace App\Http\Controllers\Admin;
@@ -122,7 +122,7 @@ class TagCrudController extends CrudController {
 
 You should notice:
 - It uses basic inheritance (```TagCrudController extends CrudController```); so if you want to modify a behaviour (save, update, reorder, etc), you can easily do that by overwriting the corresponding method in your ```TagCrudController```;
-- The request file is typehinted in the ```store()``` and ```update()``` methods; Since in case form validation fails, the information won’t even reach these methods;
+- The request file is typehinted in the ```store()``` and ```update()``` methods; Since in case form validation fails, the information won't even reach these methods;
 - All the CRUD setup is usually done in the ```setup()``` method;
 
-**That’s all for today! **If you want to learn more, go ahead and [read the next lesson](/docs/{{version}}/getting-started-crud-operations) of this series.
+**That's all for today! **If you want to learn more, go ahead and [read the next lesson](/docs/{{version}}/getting-started-crud-operations) of this series.

--- a/3.5/getting-started-basics.md
+++ b/3.5/getting-started-basics.md
@@ -67,7 +67,7 @@ php artisan backpack:base:add-sidebar-content "<li><a href='{{ backpack_url('tag
 
 This will create a simple CRUD panel, which you should now be able to see in the Sidebar.
 
-For a simple entry like this, the generated CRUD panel will even work “as is”, no need for customizations. But don’t expect this for more complex entities. They will usually require have particularities and need customization. That’s where Backpack shines - modifying anything in the CRUD Panel is easy and intuitive, once you understand how it works.
+For a simple entry like this, the generated CRUD panel will even work "as is", no need for customizations. But don’t expect this for more complex entities. They will usually require have particularities and need customization. That’s where Backpack shines - modifying anything in the CRUD Panel is easy and intuitive, once you understand how it works.
 
 The code above would generate:
 - a **migration** file

--- a/3.5/getting-started-crud-operations.md
+++ b/3.5/getting-started-crud-operations.md
@@ -4,7 +4,7 @@
 
 **Duration:** 10 minutes
 
-Let’s bring back the example in our first lesson. The Tags CRUD:
+Let's bring back the example in our first lesson. The Tags CRUD:
 
 ![Tag CRUD - List Entries Operation](https://backpackforlaravel.com/uploads/docs-3-5/getting_started/tag_crud_list_entries.png)
 
@@ -58,7 +58,7 @@ By default, CRUDs have these operations already enabled:
 - **Update** - using an update form (aka "*edit form*")
 - **Delete** - using a *button* in the *list view* 
 
-These are the basic operations an admin can execute on an Eloquent model, thanks to Backpack. We do have additional operations (Preview, Reorder, Revisions), and you can easily _create a custom operation_, but let’s not get ahead of ourselves. Baby steps. **Let's go through the most important features of the operations you'll be using _all the time_: ListEntries, Create and Update**.
+These are the basic operations an admin can execute on an Eloquent model, thanks to Backpack. We do have additional operations (Preview, Reorder, Revisions), and you can easily _create a custom operation_, but let's not get ahead of ourselves. Baby steps. **Let's go through the most important features of the operations you'll be using _all the time_: ListEntries, Create and Update**.
 
 <a name="create-and-update-operations"></a>
 ## Create & Update Operations
@@ -95,7 +95,7 @@ A typical *field definition array* will need at least three things:
 - ```label``` - the human-readable label for the input (will be generated from ```name``` if not given);
 
 
-You can use [one of the 44+ field types we’ve provided](/docs/{{version}}/crud-fields#default-field-types), or easily [create a custom field type](/docs/{{version}}/crud-fields#creating-a-custom-field-type) if you have some super-specific need that we haven’t covered yet, or even [overwrite how a field type works](#overwriting-default-field-types). Take a few minutes and [browse the 44+ field types](/docs/{{version}}/crud-fields#default-field-types), to understand how the definition array differs from one to another and how many use cases you have already covered.
+You can use [one of the 44+ field types we've provided](/docs/{{version}}/crud-fields#default-field-types), or easily [create a custom field type](/docs/{{version}}/crud-fields#creating-a-custom-field-type) if you have some super-specific need that we haven't covered yet, or even [overwrite how a field type works](#overwriting-default-field-types). Take a few minutes and [browse the 44+ field types](/docs/{{version}}/crud-fields#default-field-types), to understand how the definition array differs from one to another and how many use cases you have already covered.
 
 Let's take another example, slightly more complicated than the ```text``` fields we used above. Something you'll encounter all the time is relationship fields. So let's say the ```Tag``` model has an **n-n relationship** with an Article model:
 
@@ -115,7 +115,7 @@ $this->crud->addField([
     'entity' => 'articles', // the relationship name in your Model
     'attribute' => 'title', // attribute on Article that is shown to admin
     'pivot' => true, // on create&update, do you need to add/delete pivot table entries?
-], 'update’);
+], 'update');
 ```
 
 **Notes:**
@@ -138,7 +138,7 @@ $this->crud->addField([
 **Note: **Because the last parameter is missing, the field will be added to both Create and Update forms.
 
 
-> When generating a CrudController, you’ll be using the ```$this->crud->setFromDb();``` method by default, which tries to figure out what fields you might need in your create/update forms and in your list view, but - as you'd expect - only works for the simple field types. You can:
+> When generating a CrudController, you'll be using the ```$this->crud->setFromDb();``` method by default, which tries to figure out what fields you might need in your create/update forms and in your list view, but - as you'd expect - only works for the simple field types. You can:
 > 
 > (1) choose to keep using ```setFromDb()``` and add/remove/change additional fields
 > 
@@ -183,7 +183,7 @@ ListEntries shows the admin a table with all entries. On the front-end, the info
 <a name="columns"></a>
 ### Columns
 
-Columns help you specify *which* attributes are shown in the table and *in which order*. **They’re defined in the ```setup()``` method, the same as fields, and their syntax is super-similar to fields too**:
+Columns help you specify *which* attributes are shown in the table and *in which order*. **They're defined in the ```setup()``` method, the same as fields, and their syntax is super-similar to fields too**:
 
 ```php
 $this->crud->addColumn($column_definition_array); // add a single column, at the end of the table
@@ -240,4 +240,4 @@ $this->crud->removeButton($name);
 $this->crud->removeButtonFromStack($name, $stack);
 ```
 
-**That’s it for today!** Thanks for sticking with us this long. This has been the most important and longest lesson. You can go ahead and [install Backpack](/docs/{{version}}/installation) now, as you’ve already gone through the most important features. Or [read the next lesson](/docs/{{version}}/getting-started-advanced-features), about advanced features.
+**That's it for today!** Thanks for sticking with us this long. This has been the most important and longest lesson. You can go ahead and [install Backpack](/docs/{{version}}/installation) now, as you've already gone through the most important features. Or [read the next lesson](/docs/{{version}}/getting-started-advanced-features), about advanced features.

--- a/3.5/getting-started-crud-operations.md
+++ b/3.5/getting-started-crud-operations.md
@@ -53,9 +53,9 @@ class TagCrudController extends CrudController {
 ```
 
 By default, CRUDs have these operations already enabled:
-- **Create** - using a create form (aka “*add form*”)
-- **ListEntries** - using AJAX DataTables (aka “*list view*”, aka “*table view*”)
-- **Update** - using an update form (aka “*edit form*”)
+- **Create** - using a create form (aka "*add form*")
+- **ListEntries** - using AJAX DataTables (aka "*list view*", aka "*table view*")
+- **Update** - using an update form (aka "*edit form*")
 - **Delete** - using a *button* in the *list view* 
 
 These are the basic operations an admin can execute on an Eloquent model, thanks to Backpack. We do have additional operations (Preview, Reorder, Revisions), and you can easily _create a custom operation_, but let’s not get ahead of ourselves. Baby steps. **Let's go through the most important features of the operations you'll be using _all the time_: ListEntries, Create and Update**.
@@ -115,7 +115,7 @@ $this->crud->addField([
     'entity' => 'articles', // the relationship name in your Model
     'attribute' => 'title', // attribute on Article that is shown to admin
     'pivot' => true, // on create&update, do you need to add/delete pivot table entries?
-], ‘update’);
+], 'update’);
 ```
 
 **Notes:**

--- a/3.5/getting-started-license-and-support.md
+++ b/3.5/getting-started-license-and-support.md
@@ -16,7 +16,7 @@ Take a look at:
 <a name="license"></a>
 ## License
 
-Backpack is **free for non-commercial use**, but needs a license code in order to prevent “_unlicensed use_” notification bubbles and interruption of service. You can get a license code for your project:
+Backpack is **free for non-commercial use**, but needs a license code in order to prevent "_unlicensed use_" notification bubbles and interruption of service. You can get a license code for your project:
 - ```free```, if you're using it for non-commercial purposes; [apply here](https://backpackforlaravel.com/pricing);
 - ```free```, if you've contributed to Backpack on Github; [apply here](https://backpackforlaravel.com/pricing);
 - ```$49 EUR/project```, if you're making money using it for a project; [buy here](https://backpackforlaravel.com/pricing);

--- a/3.5/getting-started-license-and-support.md
+++ b/3.5/getting-started-license-and-support.md
@@ -25,12 +25,12 @@ Backpack is **free for non-commercial use**, but needs a license code in order t
 **Freelancers** or companies **who make money using Backpack** - for themselves, their employers or their clients, **should [purchase a commercial license here](https://backpackforlaravel.com/pricing)**.
 
 
->**You don't need a license code on LOCALHOST.** If you’re just trying Backpack on your own machine, you don’t need a license code. You only need a license code when you take your application to production.
+>**You don't need a license code on LOCALHOST.** If you're just trying Backpack on your own machine, you don't need a license code. You only need a license code when you take your application to production.
 
 <a name="support"></a>
 ## Support
 
-With thousands of developers using Backpack, a lot of them non-commercial, and such a small price, **we can’t offer official support for the packages**. We've been doing this since 2016, we actively maintain the packages, we try to squash any bugs ASAP and add new features all the time, but we unfortunately can't spend time on back-and-forth on implementation issues in your project. But. We do have good documentation and have been blessed with a **great community**, where people help each other out. If Backpack becomes your tool of preference, I highly recommend you join our gang. Help others get started, create cool stuff, or even influence the direction of Backpack: 
+With thousands of developers using Backpack, a lot of them non-commercial, and such a small price, **we can't offer official support for the packages**. We've been doing this since 2016, we actively maintain the packages, we try to squash any bugs ASAP and add new features all the time, but we unfortunately can't spend time on back-and-forth on implementation issues in your project. But. We do have good documentation and have been blessed with a **great community**, where people help each other out. If Backpack becomes your tool of preference, I highly recommend you join our gang. Help others get started, create cool stuff, or even influence the direction of Backpack: 
 
 - **[StackOverflow tag](https://stackoverflow.com/questions/tagged/backpack-for-laravel) for support requests** (If you need help creating something using Backpack, post your question on StackOverflow using the ```backpack-for-laravel``` tag. We've been blessed with a great community, that is happy to help. Who doesn't like getting StackOverflow points?)
 - **[Gitter Chatroom](https://gitter.im/BackpackForLaravel/Lobby) for quick questions** (If you have an urgent matter that won't take much time to answer, use our 24/7 Gitter chatroom. Be considerate, everyone's probably working on their own project right now.)

--- a/3.5/release-notes.md
+++ b/3.5/release-notes.md
@@ -18,8 +18,8 @@ Here are the main differences between [Backpack 3.4](https://backpackforlaravel.
 - added ```php artisan backpack:base:publish-middleware``` command; [details here](https://github.com/Laravel-Backpack/Base/pull/334);
 - upon installation, ```BackpackUser``` model and ```CheckIfAdmin``` middleware are published by default - so they can EASILY be customized; [details here](https://github.com/Laravel-Backpack/Base/pull/334);
 - two separate files: ```inc/topbar_left_content.blade.php``` and ```inc/topbar_right_content.blade.php``` where the user can specify additional content for the top menu; [details here](https://github.com/Laravel-Backpack/Base/pull/302); [documentation here](docs/{{version}}/base-how-to#use-separate-login-register-forms-for-users-and-admins);
-- error views now use a layout file, so it’s easier to customize how all error pages look; defaut error view design is now consistent with default AdminLTE design;
-- split ```layout``` into multiple views (```head```, ```scripts```), so it’s easier to customize just one part of it;
+- error views now use a layout file, so it's easier to customize how all error pages look; defaut error view design is now consistent with default AdminLTE design;
+- split ```layout``` into multiple views (```head```, ```scripts```), so it's easier to customize just one part of it;
 - ```backpack_url()``` can now take parameters, just like ```url()```;
 - password reset page is a clear two-step process, and pre-populates the email field; big UX improvement for something that is often used by inexperienced users (they're the ones losing their password);
 
@@ -29,7 +29,7 @@ Here are the main differences between [Backpack 3.4](https://backpackforlaravel.
 - default CSS file now uses ```body.skin-purple``` as a selector, to fix the paint glitch, where buttons and other things were shown blue, then changed to purple, when using the purple skin;
 - now using jquery and font-awesome from adminlte package instead of CDN;
 - language folders like ```da_DK```, ```fr_CA``` and ```pt_br``` have been duplicated into their standardized form (```da-DK```, ```fr-CA``` and ```pt-BR```); introduced notice that the old folders will be deprecated in the next release;
-- the footer is now transparent; it is not a primary piece of content, it shouldn’t stand out;
+- the footer is now transparent; it is not a primary piece of content, it shouldn't stand out;
 
 ### Removed
 - removed Laravel 5.5 support;

--- a/3.5/upgrade-guide.md
+++ b/3.5/upgrade-guide.md
@@ -107,7 +107,7 @@ Search any custom files you use in your admin panels for ```Auth::```. You _migh
 <a name="step-5"></a>
 #### Step 5
 
-If you haven’t created any custom **error views**, re-publish the ```resources/views/errors``` folder. Please note that this will delete your existing folder. 
+If you haven't created any custom **error views**, re-publish the ```resources/views/errors``` folder. Please note that this will delete your existing folder. 
 
 ```bash
 php artisan vendor:publish --provider="Backpack\Base\BaseServiceProvider" --tag=errors --force
@@ -146,7 +146,7 @@ And change the overlays path in your ```config/backpack/base.php``` file (```ove
 <a name="step-7"></a>
 #### Step 7
 
-**ALL Backpack/Base views have suffered some changes**. If you’ve published/customized/overwritten any of the Backpack/Base views, please [take a look at the changes](https://github.com/Laravel-Backpack/Base/pull/324/files) and implement them in your file. To rephrase this:
+**ALL Backpack/Base views have suffered some changes**. If you've published/customized/overwritten any of the Backpack/Base views, please [take a look at the changes](https://github.com/Laravel-Backpack/Base/pull/324/files) and implement them in your file. To rephrase this:
 - if you have files in you ```resources/views/vendor/backpack/base/``` it means you're actually using _that_ file, instead of the new one provided by upgrading to Base 1.0.0;
 - you need to either (A) delete that file and forfeit any changes you've made (Backpack will pick up the new one) OR (B) apply the changes yourself
 

--- a/3.6/crud-fields.md
+++ b/3.6/crud-fields.md
@@ -7,7 +7,7 @@
 
 Field types define how the admin can manipulate an entry's values. They're used by the Create and Update operations.
 
-Think of the field type as the type of input: ```<input type=”text” />```. But for most entities, you won't just need text inputs - you'll need datepickers, upload buttons, 1-n relationship, n-n relationships, textareas, etc.
+Think of the field type as the type of input: ```<input type="text" />```. But for most entities, you won't just need text inputs - you'll need datepickers, upload buttons, 1-n relationship, n-n relationships, textareas, etc.
 
 We have a lot of default field types, detailed below. If you don't find what you're looking for, you can [create a custom field type](/docs/{{version}}/crud-fields#creating-a-custom-field-type). Or if you just want to tweak a default field type a little bit, you can [overwrite default field types](/docs/{{version}}/crud-fields#overwriting-default-field-types).
 
@@ -1066,7 +1066,7 @@ Display a select with the values you want:
     'name' => 'template',
     'label' => "Template",
     'type' => 'select_from_array',
-    'options' => [‘one’ => ‘One’, ‘two’ => ‘Two’],
+    'options' => ['one’ => 'One’, 'two’ => 'Two’],
     'allows_null' => false,
     'default' => 'one',
     // 'allows_multiple' => true, // OPTIONAL; needs you to cast this to array in your model;
@@ -1087,7 +1087,7 @@ Display a select2 with the values you want:
     'name' => 'template',
     'label' => "Template",
     'type' => 'select2_from_array',
-    'options' => [‘one’ => ‘One’, ‘two’ => ‘Two’],
+    'options' => ['one’ => 'One’, 'two’ => 'Two’],
     'allows_null' => false,
     'default' => 'one',
     // 'allows_multiple' => true, // OPTIONAL; needs you to cast this to array in your model;
@@ -1115,8 +1115,8 @@ Display a select2 that takes its values from an AJAX call.
             'data_source' => url("api/category"), // url to controller search function (with /{id} should return model)
             'placeholder' => "Select a category", // placeholder for the select
             'minimum_input_length' => 2, // minimum characters to type before querying results
-            // 'dependencies'         => [‘category’], // when a dependency changes, this select2 is reset to null
-            // ‘method'                    => ‘GET’, // optional - HTTP method to use for the AJAX call (GET, POST)
+            // 'dependencies'         => ['category’], // when a dependency changes, this select2 is reset to null
+            // 'method'                    => 'GET’, // optional - HTTP method to use for the AJAX call (GET, POST)
 	    // 'include_all_form_fields'  => false, // optional - only send the current field through AJAX (for a smaller payload if you're not using multiple chained select2s)
  ]
 ```
@@ -1562,10 +1562,10 @@ An entry stored in the database will look like this:
 ```
 $video = {
     id: 234324,
-    title: ‘my video title’,
-    image: ‘https://provider.com/image.jpg',
-    url: ‘http://provider.com/video',
-    provider: ‘youtube’
+    title: 'my video title’,
+    image: 'https://provider.com/image.jpg',
+    url: 'http://provider.com/video',
+    provider: 'youtube’
 }
 ```
 

--- a/3.6/crud-fields.md
+++ b/3.6/crud-fields.md
@@ -113,7 +113,7 @@ In case you want to store insignificant information for an entry, that don't nee
     'name' => 'name', // JSON variable name
     'label' => "Tag Name", // human-readable label for the input
 
-    'fake' => true, // show the field, but don’t store it in the database column above
+    'fake' => true, // show the field, but don't store it in the database column above
     'store_in' => 'extras' // [optional] the database column name where you want the fake fields to ACTUALLY be stored as a JSON array 
 ],
 ```
@@ -147,7 +147,7 @@ Example:
 ],
 ```
 
-In this example, these 3 fields will show up in the create & update forms, the CRUD will process as usual, but in the database these values won’t be stored in the ```meta_title```, ```meta_description``` and ```meta_keywords``` columns. They will be stored in the ```metas``` column as a JSON array:
+In this example, these 3 fields will show up in the create & update forms, the CRUD will process as usual, but in the database these values won't be stored in the ```meta_title```, ```meta_description``` and ```meta_keywords``` columns. They will be stored in the ```metas``` column as a JSON array:
 
 ```php
 {"meta_title":"title","meta_description":"desc","meta_keywords":"keywords"}
@@ -223,7 +223,7 @@ Using Google Places API is dependant on using an API Key. Please [get an API key
 
 ```php
     'google_places' => [
-        'key' => ’the-key-you-got-from-google-places'
+        'key' => 'the-key-you-got-from-google-places'
     ],
 ```
 
@@ -765,7 +765,7 @@ Input preview:
 <a name="page-or-link"></a>
 ### page_or_link
 
-Select an existing page from PageManager or an internal or external link. It’s used in the MenuManager package, but can be used in any other model just as well. Its definition looks like this:
+Select an existing page from PageManager or an internal or external link. It's used in the MenuManager package, but can be used in any other model just as well. Its definition looks like this:
 ```php
 [   // PageOrLink
     'name' => 'type',
@@ -1066,7 +1066,7 @@ Display a select with the values you want:
     'name' => 'template',
     'label' => "Template",
     'type' => 'select_from_array',
-    'options' => ['one’ => 'One’, 'two’ => 'Two’],
+    'options' => ['one' => 'One', 'two' => 'Two'],
     'allows_null' => false,
     'default' => 'one',
     // 'allows_multiple' => true, // OPTIONAL; needs you to cast this to array in your model;
@@ -1087,7 +1087,7 @@ Display a select2 with the values you want:
     'name' => 'template',
     'label' => "Template",
     'type' => 'select2_from_array',
-    'options' => ['one’ => 'One’, 'two’ => 'Two’],
+    'options' => ['one' => 'One', 'two' => 'Two'],
     'allows_null' => false,
     'default' => 'one',
     // 'allows_multiple' => true, // OPTIONAL; needs you to cast this to array in your model;
@@ -1115,8 +1115,8 @@ Display a select2 that takes its values from an AJAX call.
             'data_source' => url("api/category"), // url to controller search function (with /{id} should return model)
             'placeholder' => "Select a category", // placeholder for the select
             'minimum_input_length' => 2, // minimum characters to type before querying results
-            // 'dependencies'         => ['category’], // when a dependency changes, this select2 is reset to null
-            // 'method'                    => 'GET’, // optional - HTTP method to use for the AJAX call (GET, POST)
+            // 'dependencies'         => ['category'], // when a dependency changes, this select2 is reset to null
+            // 'method'                    => 'GET', // optional - HTTP method to use for the AJAX call (GET, POST)
 	    // 'include_all_form_fields'  => false, // optional - only send the current field through AJAX (for a smaller payload if you're not using multiple chained select2s)
  ]
 ```
@@ -1562,10 +1562,10 @@ An entry stored in the database will look like this:
 ```
 $video = {
     id: 234324,
-    title: 'my video title’,
+    title: 'my video title',
     image: 'https://provider.com/image.jpg',
     url: 'http://provider.com/video',
-    provider: 'youtube’
+    provider: 'youtube'
 }
 ```
 
@@ -1618,7 +1618,7 @@ Show a wysiwyg (CKEditor) to the user.
 <a name="overwriting-default-field-types"></a>
 ## Overwriting Default Field Types
 
-The actual field types are stored in the Backpack/CRUD package in ```/resources/views/fields```. If you need to change an existing field, you don’t need to modify the package, you just need to add a blade file in your application in ```/resources/views/vendor/backpack/crud/fields```, with the same name. The package checks there first, and only if there's no file there, will it load it from the package.
+The actual field types are stored in the Backpack/CRUD package in ```/resources/views/fields```. If you need to change an existing field, you don't need to modify the package, you just need to add a blade file in your application in ```/resources/views/vendor/backpack/crud/fields```, with the same name. The package checks there first, and only if there's no file there, will it load it from the package.
 
 To quickly publish a field blade file in your project, you can use ```php artisan backpack:crud:publish fields/field_name```. For example, to publish the number field type, you'd type ```php artisan backpack:crud:publish fields/number```
 

--- a/3.6/crud-how-to.md
+++ b/3.6/crud-how-to.md
@@ -37,7 +37,7 @@ If you don't find one there, you can create one, and Backpack will pick it up in
 Starting with Backpack\CRUD 3.2, you can use the ```with()``` method on ```CRUD::resource``` to better organize your routes. Something like this:
 
 ```php
-CRUD::resource('teams’, 'Admin\TeamCrudController’)->with(function(){
+CRUD::resource('teams', 'Admin\TeamCrudController')->with(function(){
     // add extra routes to this resource
     Route::get('teams/ajax-name-options', 'Admin\TeamCrudController@nameOptions');
     Route::get('teams/ajax-category-options', 'Admin\TeamCrudController@categoryOptions');
@@ -133,7 +133,7 @@ In order to insert two column with the same name, use the ```key``` attribute on
 <a name="use-the-media-library"></a>
 ## Use the Media Library (File Manager)
 
-If you've chosen to install [elFinder](http://elfinder.org/) when installing Backpack, you already have a media manager. And it’s integrated into:
+If you've chosen to install [elFinder](http://elfinder.org/) when installing Backpack, you already have a media manager. And it's integrated into:
 - TinyMCE (as "tinymce" fieldtype)
 - CKEditor (as "ckeditor" fieldtype)
 - CRUD "browse" fieldtype
@@ -221,8 +221,8 @@ Say you want to show two selects:
             'data_source'          => url('api/article'), // url to controller search function (with /{id} should return model)
             'placeholder'          => 'Select an article', // placeholder for the select
             'minimum_input_length' => 0, // minimum characters to type before querying results
-            'dependencies'         => ['category’], // when a dependency changes, this select2 is reset to null
-            // 'method'                    => 'GET’, // optional - HTTP method to use for the AJAX call (GET, POST)
+            'dependencies'         => ['category'], // when a dependency changes, this select2 is reset to null
+            // 'method'                    => 'GET', // optional - HTTP method to use for the AJAX call (GET, POST)
         ]);
 ```
 
@@ -232,7 +232,7 @@ Say you want to show two selects:
 
 ```php
 Route::get('api/article', 'App\Http\Controllers\Api\ArticleController@index');
-Route::get('api/article/{id}', 'App\Http\Controllers\Api\ArticleController@show’);
+Route::get('api/article/{id}', 'App\Http\Controllers\Api\ArticleController@show');
 ```
 
 **DIFFERENT HERE**: Nothing.

--- a/3.6/crud-how-to.md
+++ b/3.6/crud-how-to.md
@@ -37,7 +37,7 @@ If you don't find one there, you can create one, and Backpack will pick it up in
 Starting with Backpack\CRUD 3.2, you can use the ```with()``` method on ```CRUD::resource``` to better organize your routes. Something like this:
 
 ```php
-CRUD::resource(‘teams’, ‘Admin\TeamCrudController’)->with(function(){
+CRUD::resource('teams’, 'Admin\TeamCrudController’)->with(function(){
     // add extra routes to this resource
     Route::get('teams/ajax-name-options', 'Admin\TeamCrudController@nameOptions');
     Route::get('teams/ajax-category-options', 'Admin\TeamCrudController@categoryOptions');
@@ -134,9 +134,9 @@ In order to insert two column with the same name, use the ```key``` attribute on
 ## Use the Media Library (File Manager)
 
 If you've chosen to install [elFinder](http://elfinder.org/) when installing Backpack, you already have a media manager. And it’s integrated into:
-- TinyMCE (as “tinymce” fieldtype)
-- CKEditor (as “ckeditor” fieldtype)
-- CRUD “browse” fieldtype
+- TinyMCE (as "tinymce" fieldtype)
+- CKEditor (as "ckeditor" fieldtype)
+- CRUD "browse" fieldtype
 - standalone, at the *your-project/admin/elfinder* route;
 
 For the integration, barryvdh's [laravel-elfinder](https://github.com/barryvdh/laravel-elfinder) package is used.
@@ -205,9 +205,9 @@ Say you want to show two selects:
 ```php
 
         $this->crud->addField([    // SELECT2
-            'label'         => ‘Category',
+            'label'         => 'Category',
             'type'          => 'select',
-            'name'          => ‘category',
+            'name'          => 'category',
             'entity'        => 'category',
             'attribute'     => 'name',
         ]);
@@ -221,8 +221,8 @@ Say you want to show two selects:
             'data_source'          => url('api/article'), // url to controller search function (with /{id} should return model)
             'placeholder'          => 'Select an article', // placeholder for the select
             'minimum_input_length' => 0, // minimum characters to type before querying results
-            'dependencies'         => [‘category’], // when a dependency changes, this select2 is reset to null
-            // ‘method'                    => ‘GET’, // optional - HTTP method to use for the AJAX call (GET, POST)
+            'dependencies'         => ['category’], // when a dependency changes, this select2 is reset to null
+            // 'method'                    => 'GET’, // optional - HTTP method to use for the AJAX call (GET, POST)
         ]);
 ```
 

--- a/3.6/getting-started-advanced-features.md
+++ b/3.6/getting-started-advanced-features.md
@@ -27,7 +27,7 @@ Here are some other cool things Backpack makes easy for you. We recommend going 
 --
 
 - **ListEntries**
-    - you can add a “+” button next to each entry, to allow the admin to easily preview some quick information that was too big to fit inside a columns - we call it [details row](/docs/{{version}}/crud-operation-list-entries#details-row)
+    - you can add a "+" button next to each entry, to allow the admin to easily preview some quick information that was too big to fit inside a columns - we call it [details row](/docs/{{version}}/crud-operation-list-entries#details-row)
     - export all visible items in the table by adding [export buttons](/docs/{{version}}/crud-operation-list-entries#export-buttons)
     - [custom search logic](/docs/{{version}}/crud-columns#custom-search-logic) for the columns in the list view
 

--- a/3.6/getting-started-advanced-features.md
+++ b/3.6/getting-started-advanced-features.md
@@ -4,7 +4,7 @@
 
 **Duration:** 5 min
 
-Here are some other cool things Backpack makes easy for you. We recommend going through them one by one, just browsing. You might not need the feature _right now_, but when _you do_, you’ll know how to find it.
+Here are some other cool things Backpack makes easy for you. We recommend going through them one by one, just browsing. You might not need the feature _right now_, but when _you do_, you'll know how to find it.
 
 ---
 
@@ -36,4 +36,4 @@ Additionally, here are a few more ways you can customize your CRUDs:
 - [Custom Views for each CRUD](/docs/{{version}}/crud-how-to#customize-views-for-each-crud-panel)
 - [Custom CSS or JS](/docs/{{version}}/crud-how-to#customize-css-and-js-for-default-crud-operations) for each CRUD Operation
 
-**That’s it for today!** Told you we’re done with long lessons :-) Hopefully some of the above have peaked your interest and you’ve clicked to see what Backpack can do. In the [next lesson](/docs/{{version}}/getting-started-license-and-support) we’ll go through a few other Backpack packages, that cover some recurring use cases.
+**That's it for today!** Told you we're done with long lessons :-) Hopefully some of the above have peaked your interest and you've clicked to see what Backpack can do. In the [next lesson](/docs/{{version}}/getting-started-license-and-support) we'll go through a few other Backpack packages, that cover some recurring use cases.

--- a/3.6/getting-started-basics.md
+++ b/3.6/getting-started-basics.md
@@ -67,7 +67,7 @@ php artisan backpack:base:add-sidebar-content "<li><a href='{{ backpack_url('tag
 
 This will create a simple CRUD panel, which you should now be able to see in the Sidebar.
 
-For a simple entry like this, the generated CRUD panel will even work “as is”, no need for customizations. But don’t expect this for more complex entities. They will usually have particularities and need customization. That’s where Backpack shines - modifying anything in the CRUD Panel is easy and intuitive, once you understand how it works.
+For a simple entry like this, the generated CRUD panel will even work "as is", no need for customizations. But don’t expect this for more complex entities. They will usually have particularities and need customization. That’s where Backpack shines - modifying anything in the CRUD Panel is easy and intuitive, once you understand how it works.
 
 The code above would generate:
 - a **migration** file

--- a/3.6/getting-started-basics.md
+++ b/3.6/getting-started-basics.md
@@ -4,14 +4,14 @@
 
 **Duration:** 5 minutes
 
-> **Are you already comfortable with Laravel?** In order to understand this series and make use of Backpack, you’ll need to have a decent understanding of the Laravel framework. If you don’t, please go ahead and [watch this excellent intro series on Laracasts](https://laracasts.com/series/laravel-from-scratch-2017) and accomodate yourself with Laravel first.
+> **Are you already comfortable with Laravel?** In order to understand this series and make use of Backpack, you'll need to have a decent understanding of the Laravel framework. If you don't, please go ahead and [watch this excellent intro series on Laracasts](https://laracasts.com/series/laravel-from-scratch-2017) and accomodate yourself with Laravel first.
 
 
 <a name="what-is-backpack"></a>
 ## What is Backpack?
 A software that helps Laravel professionals build administration panels - secure areas where administrators login and create, read, update and delete application information. It is *not* a CMS, it is more a framework that lets you *build your own* CMS. You can install it in your existing project or in a totally new project. 
 
-It’s designed to be flexible enough to allow you to **build admin panels for everything from simple presentation websites to CRMs, ERPs, eCommerce, eLearning, etc**. We can vouch for that, because we have built all that stuff using Backpack already.
+It's designed to be flexible enough to allow you to **build admin panels for everything from simple presentation websites to CRMs, ERPs, eCommerce, eLearning, etc**. We can vouch for that, because we have built all that stuff using Backpack already.
 
 <a name="how-to-use-backpack"></a>
 ## How to use?
@@ -22,7 +22,7 @@ Backpack consists of two **core packages**:
 
 A **CRUD** is what we call a section of your admin panel that lets the admin _Create, Read, Update or Delete_ entries of a certain entity (or Model). So you can have a CRUD for Products, a CRUD for Articles, a CRUD for Categories, or whatever else you might want to create, read, update or delete.
 
-For the purpose of this series, we’ll show examples on the ```Tag``` entity. This is what a Tag CRUD could look like:
+For the purpose of this series, we'll show examples on the ```Tag``` entity. This is what a Tag CRUD could look like:
 
 ![Tag CRUD - List Entries Operation](https://backpackforlaravel.com/uploads/docs-3-5/getting_started/tag_crud_list_entries.png)
 
@@ -38,17 +38,17 @@ Mind that you will _almost never_ use all of Backpack's features in one CRUD. Bu
 <a name="backpack-base"></a>
 ### Backpack\Base
 
-**Backpack/Base** is the package that **will handle the authentication** and provide you with minimal admin area functionality. **Your admin will be able to login and change his password or email.** And that’s pretty much it. 
+**Backpack/Base** is the package that **will handle the authentication** and provide you with minimal admin area functionality. **Your admin will be able to login and change his password or email.** And that's pretty much it. 
 
 ![Backpack 3.5 Authentication Screens](https://backpackforlaravel.com/uploads/docs-3-5/getting_started/auth_screens.png)
 
-Thanks to Base, after you [install Backpack](/docs/{{version}}/installation) (don't do it now), you’ll be able to log into your admin panel at ```http://yourapp/admin```. You can change the URL prefix from ```admin``` to something else in your ```config/backpack/base.php``` file, along with a bunch of other configuration options. [Click here](https://github.com/Laravel-Backpack/Base/blob/master/src/config/backpack/base.php) to browse the configuration file and see what it can do for you.
+Thanks to Base, after you [install Backpack](/docs/{{version}}/installation) (don't do it now), you'll be able to log into your admin panel at ```http://yourapp/admin```. You can change the URL prefix from ```admin``` to something else in your ```config/backpack/base.php``` file, along with a bunch of other configuration options. [Click here](https://github.com/Laravel-Backpack/Base/blob/master/src/config/backpack/base.php) to browse the configuration file and see what it can do for you.
 
 Backpack\Base pulls in the free [AdminLTE](https://adminlte.io/themes/AdminLTE/index2.html) theme and enhances the design a little bit. So any front-end block that AdminLTE has, you'll also be able to use in your custom pages. It also includes a system for bubble notifications, which you can use across the admin panel. You can easily [trigger notification bubbles in PHP](/docs/{{version}}/base-about#triggering-notification-bubbles-in-php) or [trigger notification bubbles in JavaScript](/docs/{{version}}/base-about#triggering-notification-bubbles-in-javascript).
 
 <a name="backpack-crud"></a>
 ### Backpack\CRUD
-This is where it gets interesting. As soon as you [install Backpack](/docs/{{version}}/installation) in your project, you can create **CRUDs** for your admins to easily manipulate DB information. Let’s browse through a simple example, of creating a CRUD administration panel for a Tag entity:
+This is where it gets interesting. As soon as you [install Backpack](/docs/{{version}}/installation) in your project, you can create **CRUDs** for your admins to easily manipulate DB information. Let's browse through a simple example, of creating a CRUD administration panel for a Tag entity:
 
 ```zsh
 # STEP 1. create migration
@@ -67,7 +67,7 @@ php artisan backpack:base:add-sidebar-content "<li><a href='{{ backpack_url('tag
 
 This will create a simple CRUD panel, which you should now be able to see in the Sidebar.
 
-For a simple entry like this, the generated CRUD panel will even work "as is", no need for customizations. But don’t expect this for more complex entities. They will usually have particularities and need customization. That’s where Backpack shines - modifying anything in the CRUD Panel is easy and intuitive, once you understand how it works.
+For a simple entry like this, the generated CRUD panel will even work "as is", no need for customizations. But don't expect this for more complex entities. They will usually have particularities and need customization. That's where Backpack shines - modifying anything in the CRUD Panel is easy and intuitive, once you understand how it works.
 
 The code above would generate:
 - a **migration** file
@@ -76,7 +76,7 @@ The code above would generate:
 - a **controller** file, where you can customize how the CrudPanel looks and feels (```app\Http\Controllers\Admin\TagCrudController.php```)
 - a **route**, as a line inside ```routes/backpack/custom.php```
 
-We won’t be covering the **migration**, **model** and **request** files here, as they are in no way custom. The only thing you need to make sure is that the Model is properly configured (db table, relationships, ```$fillable``` or ```$guarded``` properties, etc) and that it uses our ```CrudTrait```. What we _will_ be covering is ```TagCrudController``` - which is where most of your logic will reside. Here’s a copy of a simple one you might use to achieve the above:
+We won't be covering the **migration**, **model** and **request** files here, as they are in no way custom. The only thing you need to make sure is that the Model is properly configured (db table, relationships, ```$fillable``` or ```$guarded``` properties, etc) and that it uses our ```CrudTrait```. What we _will_ be covering is ```TagCrudController``` - which is where most of your logic will reside. Here's a copy of a simple one you might use to achieve the above:
 
 ```php
 <?php namespace App\Http\Controllers\Admin;
@@ -122,7 +122,7 @@ class TagCrudController extends CrudController {
 
 You should notice:
 - It uses basic inheritance (```TagCrudController extends CrudController```); so if you want to modify a behaviour (save, update, reorder, etc), you can easily do that by overwriting the corresponding method in your ```TagCrudController```;
-- The request file is typehinted in the ```store()``` and ```update()``` methods; Since in case form validation fails, the information won’t even reach these methods;
+- The request file is typehinted in the ```store()``` and ```update()``` methods; Since in case form validation fails, the information won't even reach these methods;
 - All the CRUD setup is usually done in the ```setup()``` method;
 
-**That’s all for today! **If you want to learn more, go ahead and [read the next lesson](/docs/{{version}}/getting-started-crud-operations) of this series.
+**That's all for today! **If you want to learn more, go ahead and [read the next lesson](/docs/{{version}}/getting-started-crud-operations) of this series.

--- a/3.6/getting-started-crud-operations.md
+++ b/3.6/getting-started-crud-operations.md
@@ -4,7 +4,7 @@
 
 **Duration:** 10 minutes
 
-Let’s bring back the example in our first lesson. The Tags CRUD:
+Let's bring back the example in our first lesson. The Tags CRUD:
 
 ![Tag CRUD - List Entries Operation](https://backpackforlaravel.com/uploads/docs-3-5/getting_started/tag_crud_list_entries.png)
 
@@ -58,7 +58,7 @@ By default, CRUDs have these operations already enabled:
 - **Update** - using an update form (aka "*edit form*")
 - **Delete** - using a *button* in the *list view* 
 
-These are the basic operations an admin can execute on an Eloquent model, thanks to Backpack. We do have additional operations (Preview, Reorder, Revisions), and you can easily _create a custom operation_, but let’s not get ahead of ourselves. Baby steps. **Let's go through the most important features of the operations you'll be using _all the time_: ListEntries, Create and Update**.
+These are the basic operations an admin can execute on an Eloquent model, thanks to Backpack. We do have additional operations (Preview, Reorder, Revisions), and you can easily _create a custom operation_, but let's not get ahead of ourselves. Baby steps. **Let's go through the most important features of the operations you'll be using _all the time_: ListEntries, Create and Update**.
 
 <a name="create-and-update-operations"></a>
 ## Create & Update Operations
@@ -95,7 +95,7 @@ A typical *field definition array* will need at least three things:
 - ```label``` - the human-readable label for the input (will be generated from ```name``` if not given);
 
 
-You can use [one of the 44+ field types we’ve provided](/docs/{{version}}/crud-fields#default-field-types), or easily [create a custom field type](/docs/{{version}}/crud-fields#creating-a-custom-field-type) if you have some super-specific need that we haven’t covered yet, or even [overwrite how a field type works](#overwriting-default-field-types). Take a few minutes and [browse the 44+ field types](/docs/{{version}}/crud-fields#default-field-types), to understand how the definition array differs from one to another and how many use cases you have already covered.
+You can use [one of the 44+ field types we've provided](/docs/{{version}}/crud-fields#default-field-types), or easily [create a custom field type](/docs/{{version}}/crud-fields#creating-a-custom-field-type) if you have some super-specific need that we haven't covered yet, or even [overwrite how a field type works](#overwriting-default-field-types). Take a few minutes and [browse the 44+ field types](/docs/{{version}}/crud-fields#default-field-types), to understand how the definition array differs from one to another and how many use cases you have already covered.
 
 Let's take another example, slightly more complicated than the ```text``` fields we used above. Something you'll encounter all the time is relationship fields. So let's say the ```Tag``` model has an **n-n relationship** with an Article model:
 
@@ -115,7 +115,7 @@ $this->crud->addField([
     'entity' => 'articles', // the relationship name in your Model
     'attribute' => 'title', // attribute on Article that is shown to admin
     'pivot' => true, // on create&update, do you need to add/delete pivot table entries?
-], 'update’);
+], 'update');
 ```
 
 **Notes:**
@@ -138,7 +138,7 @@ $this->crud->addField([
 **Note: **Because the last parameter is missing, the field will be added to both Create and Update forms.
 
 
-> When generating a CrudController, you’ll be using the ```$this->crud->setFromDb();``` method by default, which tries to figure out what fields you might need in your create/update forms and in your list view, but - as you'd expect - only works for the simple field types. You can:
+> When generating a CrudController, you'll be using the ```$this->crud->setFromDb();``` method by default, which tries to figure out what fields you might need in your create/update forms and in your list view, but - as you'd expect - only works for the simple field types. You can:
 > 
 > (1) choose to keep using ```setFromDb()``` and add/remove/change additional fields
 > 
@@ -183,7 +183,7 @@ ListEntries shows the admin a table with all entries. On the front-end, the info
 <a name="columns"></a>
 ### Columns
 
-Columns help you specify *which* attributes are shown in the table and *in which order*. **They’re defined in the ```setup()``` method, the same as fields, and their syntax is super-similar to fields too**:
+Columns help you specify *which* attributes are shown in the table and *in which order*. **They're defined in the ```setup()``` method, the same as fields, and their syntax is super-similar to fields too**:
 
 ```php
 $this->crud->addColumn($column_definition_array); // add a single column, at the end of the table
@@ -240,4 +240,4 @@ $this->crud->removeButton($name);
 $this->crud->removeButtonFromStack($name, $stack);
 ```
 
-**That’s it for today!** Thanks for sticking with us this long. This has been the most important and longest lesson. You can go ahead and [install Backpack](/docs/{{version}}/installation) now, as you’ve already gone through the most important features. Or [read the next lesson](/docs/{{version}}/getting-started-advanced-features), about advanced features.
+**That's it for today!** Thanks for sticking with us this long. This has been the most important and longest lesson. You can go ahead and [install Backpack](/docs/{{version}}/installation) now, as you've already gone through the most important features. Or [read the next lesson](/docs/{{version}}/getting-started-advanced-features), about advanced features.

--- a/3.6/getting-started-crud-operations.md
+++ b/3.6/getting-started-crud-operations.md
@@ -53,9 +53,9 @@ class TagCrudController extends CrudController {
 ```
 
 By default, CRUDs have these operations already enabled:
-- **Create** - using a create form (aka “*add form*”)
-- **ListEntries** - using AJAX DataTables (aka “*list view*”, aka “*table view*”)
-- **Update** - using an update form (aka “*edit form*”)
+- **Create** - using a create form (aka "*add form*")
+- **ListEntries** - using AJAX DataTables (aka "*list view*", aka "*table view*")
+- **Update** - using an update form (aka "*edit form*")
 - **Delete** - using a *button* in the *list view* 
 
 These are the basic operations an admin can execute on an Eloquent model, thanks to Backpack. We do have additional operations (Preview, Reorder, Revisions), and you can easily _create a custom operation_, but let’s not get ahead of ourselves. Baby steps. **Let's go through the most important features of the operations you'll be using _all the time_: ListEntries, Create and Update**.
@@ -115,7 +115,7 @@ $this->crud->addField([
     'entity' => 'articles', // the relationship name in your Model
     'attribute' => 'title', // attribute on Article that is shown to admin
     'pivot' => true, // on create&update, do you need to add/delete pivot table entries?
-], ‘update’);
+], 'update’);
 ```
 
 **Notes:**

--- a/3.6/getting-started-license-and-support.md
+++ b/3.6/getting-started-license-and-support.md
@@ -16,7 +16,7 @@ Take a look at:
 <a name="license"></a>
 ## License
 
-Backpack is **free for non-commercial use**, but needs a license code in order to prevent “_unlicensed use_” notification bubbles and interruption of service. You can get a license code for your project:
+Backpack is **free for non-commercial use**, but needs a license code in order to prevent "_unlicensed use_" notification bubbles and interruption of service. You can get a license code for your project:
 - ```free```, if you're using it for non-commercial purposes; [apply here](https://backpackforlaravel.com/pricing);
 - ```free```, if you've contributed to Backpack on Github; [apply here](https://backpackforlaravel.com/pricing);
 - ```$49 EUR/project```, if you're making money using it for a project; [buy here](https://backpackforlaravel.com/pricing);

--- a/3.6/getting-started-license-and-support.md
+++ b/3.6/getting-started-license-and-support.md
@@ -25,12 +25,12 @@ Backpack is **free for non-commercial use**, but needs a license code in order t
 **Freelancers** or companies **who make money using Backpack** - for themselves, their employers or their clients, **should [purchase a commercial license here](https://backpackforlaravel.com/pricing)**.
 
 
->**You don't need a license code on LOCALHOST.** If you’re just trying Backpack on your own machine, you don’t need a license code. You only need a license code when you take your application to production.
+>**You don't need a license code on LOCALHOST.** If you're just trying Backpack on your own machine, you don't need a license code. You only need a license code when you take your application to production.
 
 <a name="support"></a>
 ## Support
 
-With thousands of developers using Backpack, a lot of them non-commercial, and such a small price, **we can’t offer official support for the packages**. We've been doing this since 2016, we actively maintain the packages, we try to squash any bugs ASAP and add new features all the time, but we unfortunately can't spend time on back-and-forth on implementation issues in your project. But. We do have good documentation and have been blessed with a **great community**, where people help each other out. If Backpack becomes your tool of preference, I highly recommend you join our gang. Help others get started, create cool stuff, or even influence the direction of Backpack: 
+With thousands of developers using Backpack, a lot of them non-commercial, and such a small price, **we can't offer official support for the packages**. We've been doing this since 2016, we actively maintain the packages, we try to squash any bugs ASAP and add new features all the time, but we unfortunately can't spend time on back-and-forth on implementation issues in your project. But. We do have good documentation and have been blessed with a **great community**, where people help each other out. If Backpack becomes your tool of preference, I highly recommend you join our gang. Help others get started, create cool stuff, or even influence the direction of Backpack: 
 
 - **[StackOverflow tag](https://stackoverflow.com/questions/tagged/backpack-for-laravel) for support requests** (If you need help creating something using Backpack, post your question on StackOverflow using the ```backpack-for-laravel``` tag. We've been blessed with a great community, that is happy to help. Who doesn't like getting StackOverflow points?)
 - **[Gitter Chatroom](https://gitter.im/BackpackForLaravel/Lobby) for quick questions** (If you have an urgent matter that won't take much time to answer, use our 24/7 Gitter chatroom. Be considerate, everyone's probably working on their own project right now.)

--- a/4.0/crud-fields.md
+++ b/4.0/crud-fields.md
@@ -7,7 +7,7 @@
 
 Field types define how the admin can manipulate an entry's values. They're used by the Create and Update operations.
 
-Think of the field type as the type of input: ```<input type=”text” />```. But for most entities, you won't just need text inputs - you'll need datepickers, upload buttons, 1-n relationship, n-n relationships, textareas, etc.
+Think of the field type as the type of input: ```<input type="text" />```. But for most entities, you won't just need text inputs - you'll need datepickers, upload buttons, 1-n relationship, n-n relationships, textareas, etc.
 
 We have a lot of default field types, detailed below. If you don't find what you're looking for, you can [create a custom field type](/docs/{{version}}/crud-fields#creating-a-custom-field-type). Or if you just want to tweak a default field type a little bit, you can [overwrite default field types](/docs/{{version}}/crud-fields#overwriting-default-field-types).
 

--- a/4.0/crud-how-to.md
+++ b/4.0/crud-how-to.md
@@ -144,9 +144,9 @@ In order to insert two column with the same name, use the ```key``` attribute on
 ## Use the Media Library (File Manager)
 
 If you've chosen to install [elFinder](http://elfinder.org/) when installing Backpack, you already have a media manager. And it’s integrated into:
-- TinyMCE (as “tinymce” fieldtype)
-- CKEditor (as “ckeditor” fieldtype)
-- CRUD “browse” fieldtype
+- TinyMCE (as "tinymce" fieldtype)
+- CKEditor (as "ckeditor" fieldtype)
+- CRUD "browse" fieldtype
 - standalone, at the *your-project/admin/elfinder* route;
 
 For the integration, barryvdh's [laravel-elfinder](https://github.com/barryvdh/laravel-elfinder) package is used.
@@ -216,9 +216,9 @@ Say you want to show two selects:
 
 ```php
 $this->crud->addField([    // SELECT2
-    'label'         => ‘Category',
+    'label'         => 'Category',
     'type'          => 'select',
-    'name'          => ‘category',
+    'name'          => 'category',
     'entity'        => 'category',
     'attribute'     => 'name',
 ]);
@@ -232,8 +232,8 @@ $this->crud->addField([ // select2_from_ajax: 1-n relationship
     'data_source'          => url('api/article'), // url to controller search function (with /{id} should return model)
     'placeholder'          => 'Select an article', // placeholder for the select
     'minimum_input_length' => 0, // minimum characters to type before querying results
-    'dependencies'         => [‘category’], // when a dependency changes, this select2 is reset to null
-    // ‘method'                    => ‘GET’, // optional - HTTP method to use for the AJAX call (GET, POST)
+    'dependencies'         => ['category’], // when a dependency changes, this select2 is reset to null
+    // 'method'                    => 'GET’, // optional - HTTP method to use for the AJAX call (GET, POST)
 ]);
 ```
 

--- a/4.0/crud-how-to.md
+++ b/4.0/crud-how-to.md
@@ -143,7 +143,7 @@ In order to insert two column with the same name, use the ```key``` attribute on
 <a name="use-the-media-library"></a>
 ## Use the Media Library (File Manager)
 
-If you've chosen to install [elFinder](http://elfinder.org/) when installing Backpack, you already have a media manager. And it’s integrated into:
+If you've chosen to install [elFinder](http://elfinder.org/) when installing Backpack, you already have a media manager. And it's integrated into:
 - TinyMCE (as "tinymce" fieldtype)
 - CKEditor (as "ckeditor" fieldtype)
 - CRUD "browse" fieldtype
@@ -232,8 +232,8 @@ $this->crud->addField([ // select2_from_ajax: 1-n relationship
     'data_source'          => url('api/article'), // url to controller search function (with /{id} should return model)
     'placeholder'          => 'Select an article', // placeholder for the select
     'minimum_input_length' => 0, // minimum characters to type before querying results
-    'dependencies'         => ['category’], // when a dependency changes, this select2 is reset to null
-    // 'method'                    => 'GET’, // optional - HTTP method to use for the AJAX call (GET, POST)
+    'dependencies'         => ['category'], // when a dependency changes, this select2 is reset to null
+    // 'method'                    => 'GET', // optional - HTTP method to use for the AJAX call (GET, POST)
 ]);
 ```
 
@@ -243,7 +243,7 @@ $this->crud->addField([ // select2_from_ajax: 1-n relationship
 
 ```php
 Route::get('api/article', 'App\Http\Controllers\Api\ArticleController@index');
-Route::get('api/article/{id}', 'App\Http\Controllers\Api\ArticleController@show’);
+Route::get('api/article/{id}', 'App\Http\Controllers\Api\ArticleController@show');
 ```
 
 **DIFFERENT HERE**: Nothing.

--- a/4.0/getting-started-advanced-features.md
+++ b/4.0/getting-started-advanced-features.md
@@ -30,7 +30,7 @@ Here are some other cool things Backpack makes easy for you. We recommend going 
 --
 
 - **ListEntries**
-    - you can add a “+” button next to each entry, to allow the admin to easily preview some quick information that was too big to fit inside a columns - we call it [details row](/docs/{{version}}/crud-operation-list-entries#details-row)
+    - you can add a "+" button next to each entry, to allow the admin to easily preview some quick information that was too big to fit inside a columns - we call it [details row](/docs/{{version}}/crud-operation-list-entries#details-row)
     - export all visible items in the table by adding [export buttons](/docs/{{version}}/crud-operation-list-entries#export-buttons)
     - [custom search logic](/docs/{{version}}/crud-columns#custom-search-logic) for the columns in the list view
 

--- a/4.0/getting-started-advanced-features.md
+++ b/4.0/getting-started-advanced-features.md
@@ -4,7 +4,7 @@
 
 **Duration:** 5 min
 
-Here are some other cool things Backpack makes easy for you. We recommend going through them one by one, just browsing. You might not need the feature _right now_, but when _you do_, you’ll know how to find it.
+Here are some other cool things Backpack makes easy for you. We recommend going through them one by one, just browsing. You might not need the feature _right now_, but when _you do_, you'll know how to find it.
 
 ---
 
@@ -40,4 +40,4 @@ Additionally, here are a few more ways you can customize your CRUDs:
 - [Custom Content Class for each CRUD](/docs/{{version}}/crud-how-to#resize-the-content-wrapper-for-an-operation)
 - [Custom CSS or JS](/docs/{{version}}/crud-how-to#customize-css-and-js-for-default-crud-operations) for each CRUD Operation
 
-**That’s it for today!** Told you we’re done with long lessons :-) Hopefully some of the above have peaked your interest and you’ve clicked to see what Backpack can do. In the [next lesson](/docs/{{version}}/getting-started-license-and-support) we’ll go through a few other Backpack packages, that cover some recurring use cases.
+**That's it for today!** Told you we're done with long lessons :-) Hopefully some of the above have peaked your interest and you've clicked to see what Backpack can do. In the [next lesson](/docs/{{version}}/getting-started-license-and-support) we'll go through a few other Backpack packages, that cover some recurring use cases.

--- a/4.0/getting-started-basics.md
+++ b/4.0/getting-started-basics.md
@@ -4,21 +4,21 @@
 
 **Duration:** 5 minutes
 
-> **Are you already comfortable with Laravel?** In order to understand this series and make use of Backpack, you’ll need to have a decent understanding of the Laravel framework. If you don’t, please go ahead and [watch this excellent intro series on Laracasts](https://laracasts.com/series/laravel-from-scratch-2018) and accomodate yourself with Laravel first.
+> **Are you already comfortable with Laravel?** In order to understand this series and make use of Backpack, you'll need to have a decent understanding of the Laravel framework. If you don't, please go ahead and [watch this excellent intro series on Laracasts](https://laracasts.com/series/laravel-from-scratch-2018) and accomodate yourself with Laravel first.
 
 
 <a name="what-is-backpack"></a>
 ## What is Backpack?
 A software that helps Laravel professionals build administration panels - secure areas where administrators login and create, read, update and delete application information. It is *not* a CMS, it is more a framework that lets you *build your own* CMS. You can install it in your existing project or in a totally new project. 
 
-It’s designed to be flexible enough to allow you to **build admin panels for everything from simple presentation websites to CRMs, ERPs, eCommerce, eLearning, etc**. We can vouch for that, because we have built all that stuff using Backpack already.
+It's designed to be flexible enough to allow you to **build admin panels for everything from simple presentation websites to CRMs, ERPs, eCommerce, eLearning, etc**. We can vouch for that, because we have built all that stuff using Backpack already.
 
 <a name="how-to-use-backpack"></a>
 ## What's a CRUD?
 
 A **CRUD** is what we call a section of your admin panel that lets the admin _Create, Read, Update or Delete_ entries of a certain entity (or Model). So you can have a CRUD for Products, a CRUD for Articles, a CRUD for Categories, or whatever else you might want to create, read, update or delete.
 
-For the purpose of this series, we’ll show examples on the ```Tag``` entity. This is what a Tag CRUD could look like:
+For the purpose of this series, we'll show examples on the ```Tag``` entity. This is what a Tag CRUD could look like:
 
 ![Tag CRUD - List Entries Operation](https://backpackforlaravel.com/uploads/docs-4-0/getting_started/tag_crud_list_entries.png)
 
@@ -46,13 +46,13 @@ Backpack comes with a basic authentication system, that's separate from Laravel'
 
 ![Backpack 3.5 Authentication Screens](https://backpackforlaravel.com/uploads/docs-4-0/getting_started/auth_screens.png)
 
-After you [install Backpack](/docs/{{version}}/installation) (don't do it now), you’ll be able to log into your admin panel at ```http://yourapp/admin```. You can change the URL prefix from ```admin``` to something else in your ```config/backpack/base.php``` file, along with a bunch of other configuration options. [Click here](https://github.com/Laravel-Backpack/CRUD/blob/master/src/config/backpack/base.php) to browse the configuration file and see what it can do for you.
+After you [install Backpack](/docs/{{version}}/installation) (don't do it now), you'll be able to log into your admin panel at ```http://yourapp/admin```. You can change the URL prefix from ```admin``` to something else in your ```config/backpack/base.php``` file, along with a bunch of other configuration options. [Click here](https://github.com/Laravel-Backpack/CRUD/blob/master/src/config/backpack/base.php) to browse the configuration file and see what it can do for you.
 
 
 <a name="backpack-crud"></a>
 ### CRUDs
 
-This is where it gets interesting. As soon as you [install Backpack](/docs/{{version}}/installation) in your project, you can create **CRUDs** for your admins to easily manipulate DB information. Let’s browse through a simple example, of creating a CRUD administration panel for a Tag entity:
+This is where it gets interesting. As soon as you [install Backpack](/docs/{{version}}/installation) in your project, you can create **CRUDs** for your admins to easily manipulate DB information. Let's browse through a simple example, of creating a CRUD administration panel for a Tag entity:
 
 ```zsh
 # STEP 1. create migration
@@ -65,7 +65,7 @@ php artisan backpack:crud tag #use singular, not plural
 
 This will create a simple CRUD panel, which you should now be able to see in the Sidebar.
 
-For a simple entry like this, the generated CRUD panel will even work "as is", no need for customizations. But don’t expect this for more complex entities. They will usually have particularities and need customization. That’s where Backpack shines - modifying anything in the CRUD Panel is easy and intuitive, once you understand how it works.
+For a simple entry like this, the generated CRUD panel will even work "as is", no need for customizations. But don't expect this for more complex entities. They will usually have particularities and need customization. That's where Backpack shines - modifying anything in the CRUD Panel is easy and intuitive, once you understand how it works.
 
 The code above would generate:
 - a **migration** file
@@ -80,7 +80,7 @@ It will also add:
 
 You might have noticed that **no views** are generated. That's because in most cases you _don't need_ custom views with Backpack. All your custom code is in the controller, model or request, so the default views are loaded, from the pacakge. If you do, however, need to customize a view, it is [ridiculously easy](/docs/{{version}}/crud-how-to#customize-views-for-each-crud-panel).
 
-Also, we won’t be covering the **migration**, **model** and **request** files here, as they are in no way custom. The only thing you need to make sure is that the Model is properly configured (db table, relationships, ```$fillable``` or ```$guarded``` properties, etc) and that it uses our ```CrudTrait```. What we _will_ be covering is ```TagCrudController``` - which is where most of your logic will reside. Here’s a copy of a simple one you might use to achieve the above:
+Also, we won't be covering the **migration**, **model** and **request** files here, as they are in no way custom. The only thing you need to make sure is that the Model is properly configured (db table, relationships, ```$fillable``` or ```$guarded``` properties, etc) and that it uses our ```CrudTrait```. What we _will_ be covering is ```TagCrudController``` - which is where most of your logic will reside. Here's a copy of a simple one you might use to achieve the above:
 
 ```php
 <?php namespace App\Http\Controllers\Admin;
@@ -137,4 +137,4 @@ You should notice:
 - The ```setup()``` method defines the basics of the CRUD panel;
 - Each operation is set up inside a ```setupXxxOperation()``` method;
 
-**That’s all for today! **If you want to learn more, go ahead and [read the next lesson](/docs/{{version}}/getting-started-crud-operations) of this series.
+**That's all for today! **If you want to learn more, go ahead and [read the next lesson](/docs/{{version}}/getting-started-crud-operations) of this series.

--- a/4.0/getting-started-basics.md
+++ b/4.0/getting-started-basics.md
@@ -65,7 +65,7 @@ php artisan backpack:crud tag #use singular, not plural
 
 This will create a simple CRUD panel, which you should now be able to see in the Sidebar.
 
-For a simple entry like this, the generated CRUD panel will even work “as is”, no need for customizations. But don’t expect this for more complex entities. They will usually have particularities and need customization. That’s where Backpack shines - modifying anything in the CRUD Panel is easy and intuitive, once you understand how it works.
+For a simple entry like this, the generated CRUD panel will even work "as is", no need for customizations. But don’t expect this for more complex entities. They will usually have particularities and need customization. That’s where Backpack shines - modifying anything in the CRUD Panel is easy and intuitive, once you understand how it works.
 
 The code above would generate:
 - a **migration** file

--- a/4.0/getting-started-crud-operations.md
+++ b/4.0/getting-started-crud-operations.md
@@ -4,7 +4,7 @@
 
 **Duration:** 10 minutes
 
-Let’s bring back the example in our first lesson. The Tags CRUD:
+Let's bring back the example in our first lesson. The Tags CRUD:
 
 ![Tag CRUD - List Entries Operation](https://backpackforlaravel.com/uploads/docs-4-0/getting_started/tag_crud_list_entries.png)
 
@@ -66,7 +66,7 @@ In the example above, we've enabled the most common operations:
 - **Delete** - using a *button* in the *list view* 
 - **Show** - using a *button* in the *list view* 
 
-These are the basic operations an admin can execute on an Eloquent model, thanks to Backpack. We do have additional operations (Reorder, Revisions, Clone, BulkDelete, BulkClone), and you can easily _create a custom operation_, but let’s not get ahead of ourselves. Baby steps. **Let's go through the most important features of the operations you'll be using _all the time_: ListEntries, Create and Update**.
+These are the basic operations an admin can execute on an Eloquent model, thanks to Backpack. We do have additional operations (Reorder, Revisions, Clone, BulkDelete, BulkClone), and you can easily _create a custom operation_, but let's not get ahead of ourselves. Baby steps. **Let's go through the most important features of the operations you'll be using _all the time_: ListEntries, Create and Update**.
 
 <a name="create-and-update-operations"></a>
 ## Create & Update Operations
@@ -98,7 +98,7 @@ A typical *field definition array* will need at least three things:
 - ```label``` - the human-readable label for the input (will be generated from ```name``` if not given);
 
 
-You can use [one of the 44+ field types we’ve provided](/docs/{{version}}/crud-fields#default-field-types), or easily [create a custom field type](/docs/{{version}}/crud-fields#creating-a-custom-field-type) if you have some super-specific need that we haven’t covered yet, or even [overwrite how a field type works](#overwriting-default-field-types). Take a few minutes and [browse the 44+ field types](/docs/{{version}}/crud-fields#default-field-types), to understand how the definition array differs from one to another and how many use cases you have already covered.
+You can use [one of the 44+ field types we've provided](/docs/{{version}}/crud-fields#default-field-types), or easily [create a custom field type](/docs/{{version}}/crud-fields#creating-a-custom-field-type) if you have some super-specific need that we haven't covered yet, or even [overwrite how a field type works](#overwriting-default-field-types). Take a few minutes and [browse the 44+ field types](/docs/{{version}}/crud-fields#default-field-types), to understand how the definition array differs from one to another and how many use cases you have already covered.
 
 Let's take another example, slightly more complicated than the ```text``` fields we used above. Something you'll encounter all the time is relationship fields. So let's say the ```Tag``` model has an **n-n relationship** with an Article model:
 
@@ -245,4 +245,4 @@ $this->crud->removeButton($name);
 $this->crud->removeButtonFromStack($name, $stack);
 ```
 
-**That’s it for today!** Thanks for sticking with us this long. This has been the most important and longest lesson. You can go ahead and [install Backpack](/docs/{{version}}/installation) now, as you’ve already gone through the most important features. Or [read the next lesson](/docs/{{version}}/getting-started-advanced-features), about advanced features.
+**That's it for today!** Thanks for sticking with us this long. This has been the most important and longest lesson. You can go ahead and [install Backpack](/docs/{{version}}/installation) now, as you've already gone through the most important features. Or [read the next lesson](/docs/{{version}}/getting-started-advanced-features), about advanced features.

--- a/4.0/getting-started-crud-operations.md
+++ b/4.0/getting-started-crud-operations.md
@@ -60,9 +60,9 @@ class TagCrudController extends CrudController {
 ```
 
 In the example above, we've enabled the most common operations:
-- **Create** - using a create form (aka “*add form*”)
-- **List** - using AJAX DataTables (aka “*list view*”, aka “*table view*”)
-- **Update** - using an update form (aka “*edit form*”)
+- **Create** - using a create form (aka "*add form*")
+- **List** - using AJAX DataTables (aka "*list view*", aka "*table view*")
+- **Update** - using an update form (aka "*edit form*")
 - **Delete** - using a *button* in the *list view* 
 - **Show** - using a *button* in the *list view* 
 

--- a/4.0/getting-started-license-and-support.md
+++ b/4.0/getting-started-license-and-support.md
@@ -16,7 +16,7 @@ Take a look at:
 <a name="license"></a>
 ## License
 
-Backpack is **free for non-commercial use**, but needs a license code in order to prevent “_unlicensed use_” notification bubbles and interruption of service. You can get a license code for your project:
+Backpack is **free for non-commercial use**, but needs a license code in order to prevent "_unlicensed use_" notification bubbles and interruption of service. You can get a license code for your project:
 - ```free```, if you're using it for non-commercial purposes; [apply here](https://backpackforlaravel.com/pricing);
 - ```free```, if you've contributed to Backpack on Github; [apply here](https://backpackforlaravel.com/pricing);
 - ```€69 EUR/project```, if you're making money using it for a project; [buy here](https://backpackforlaravel.com/pricing);

--- a/4.0/getting-started-license-and-support.md
+++ b/4.0/getting-started-license-and-support.md
@@ -25,12 +25,12 @@ Backpack is **free for non-commercial use**, but needs a license code in order t
 **Freelancers** or companies **who make money using Backpack** - for themselves, their employers or their clients, **should [purchase a commercial license here](https://backpackforlaravel.com/pricing)**.
 
 
->**You don't need a license code on LOCALHOST.** If you’re just trying Backpack on your own machine, you don’t need a license code. You only need a license code when you take your application to production.
+>**You don't need a license code on LOCALHOST.** If you're just trying Backpack on your own machine, you don't need a license code. You only need a license code when you take your application to production.
 
 <a name="support"></a>
 ## Support
 
-With thousands of developers using Backpack, a lot of them non-commercial, and such a small price, **we can’t offer official support for the packages**. We've been doing this since 2016, we actively maintain the packages, we try to squash any bugs ASAP and add new features all the time, but we unfortunately can't spend time on back-and-forth on implementation issues in your project. But. We do have good documentation and have been blessed with a **great community**, where people help each other out. If Backpack becomes your tool of preference, I highly recommend you join our gang. Help others get started, create cool stuff, or even influence the direction of Backpack: 
+With thousands of developers using Backpack, a lot of them non-commercial, and such a small price, **we can't offer official support for the packages**. We've been doing this since 2016, we actively maintain the packages, we try to squash any bugs ASAP and add new features all the time, but we unfortunately can't spend time on back-and-forth on implementation issues in your project. But. We do have good documentation and have been blessed with a **great community**, where people help each other out. If Backpack becomes your tool of preference, I highly recommend you join our gang. Help others get started, create cool stuff, or even influence the direction of Backpack: 
 
 - **[StackOverflow tag](https://stackoverflow.com/questions/tagged/backpack-for-laravel) for support requests** (If you need help creating something using Backpack, post your question on StackOverflow using the ```backpack-for-laravel``` tag. We've been blessed with a great community, that is happy to help. Who doesn't like getting StackOverflow points?)
 - **[Gitter Chatroom](https://gitter.im/BackpackForLaravel/Lobby) for quick questions** (If you have an urgent matter that won't take much time to answer, use our 24/7 Gitter chatroom. Be considerate, everyone's probably working on their own project right now.)

--- a/4.1/add-ons-custom-operation.md
+++ b/4.1/add-ons-custom-operation.md
@@ -163,22 +163,22 @@ Second, add that new Github Repo as a remote, and push your code to your new Git
 ```bash
 git remote add origin git@github.com:yourusername/yourrepository.git
 git push -u origin master
-git tag -a 1.0.0 -m 'First version’
+git tag -a 1.0.0 -m 'First version'
 git push --tags
 ```
 
-The tags are the way you will version your package, so it’s important you do it.
+The tags are the way you will version your package, so it's important you do it.
 
 <a name="put-it-on-packagist"></a>
 ### Put it on Packagist
 
 In order for people to be able to install your package using composer, your package needs to be registerd with Packagist, Composer's free package registry.
 
-On [Packagist.org](https://packagist.org/), submit a new package. Enter you package’s GitHub URL and click Check. If any errors occur, follow the onscreen instructions. When you’re done, you’re taken to your package’s packagist page.
+On [Packagist.org](https://packagist.org/), submit a new package. Enter you package's GitHub URL and click Check. If any errors occur, follow the onscreen instructions. When you're done, you're taken to your package's packagist page.
 
 **Congrats, you have a working package online**, you can now install it using Composer.
 
-Note: On the package page, you might get a notice like this: _This package is not auto-updated. Please set up the [GitHub Service Hook](https://packagist.org/profile/) for Packagist so that it gets updated whenever you push!_ Let’s take care of that. Click that link, get your API token and go to your package’s GitHub page, in Settings / Webhooks & Services / Add a new service. Search for Packagist. Enter your username and the token and hit Submit. Your error in Packagist should dissapear in 5–10 minutes.
+Note: On the package page, you might get a notice like this: _This package is not auto-updated. Please set up the [GitHub Service Hook](https://packagist.org/profile/) for Packagist so that it gets updated whenever you push!_ Let's take care of that. Click that link, get your API token and go to your package's GitHub page, in Settings / Webhooks & Services / Add a new service. Search for Packagist. Enter your username and the token and hit Submit. Your error in Packagist should dissapear in 5–10 minutes.
 
 <a name="feedback-and-promotion"></a>
 ### Feedback and Promotion

--- a/4.1/add-ons-custom-operation.md
+++ b/4.1/add-ons-custom-operation.md
@@ -163,7 +163,7 @@ Second, add that new Github Repo as a remote, and push your code to your new Git
 ```bash
 git remote add origin git@github.com:yourusername/yourrepository.git
 git push -u origin master
-git tag -a 1.0.0 -m ‘First version’
+git tag -a 1.0.0 -m 'First version’
 git push --tags
 ```
 

--- a/4.1/crud-fields.md
+++ b/4.1/crud-fields.md
@@ -7,7 +7,7 @@
 
 Field types define how the admin can manipulate an entry's values. They're used by the Create and Update operations.
 
-Think of the field type as the type of input: ```<input type=”text” />```. But for most entities, you won't just need text inputs - you'll need datepickers, upload buttons, 1-n relationship, n-n relationships, textareas, etc.
+Think of the field type as the type of input: ```<input type="text" />```. But for most entities, you won't just need text inputs - you'll need datepickers, upload buttons, 1-n relationship, n-n relationships, textareas, etc.
 
 We have a lot of default field types, detailed below. If you don't find what you're looking for, you can [create a custom field type](/docs/{{version}}/crud-fields#creating-a-custom-field-type). Or if you just want to tweak a default field type a little bit, you can [overwrite default field types](/docs/{{version}}/crud-fields#overwriting-default-field-types).
 
@@ -1128,7 +1128,7 @@ If your related entry can have hundreds, thousands or millions of entries, it's 
     // AJAX OPTIONALS:
     // 'data_source' => url("fetch/category"), // url to controller search function (with /{id} should return model)
     // 'minimum_input_length' => 2, // minimum characters to type before querying results
-    // 'dependencies'         => [‘category’], // when a dependency changes, this select2 is reset to null
+    // 'dependencies'         => ['category’], // when a dependency changes, this select2 is reset to null
     // 'include_all_form_fields'  => false, // optional - only send the current field through AJAX (for a smaller payload if you're not using multiple chained select2s)
  ],
 ```

--- a/4.1/crud-fields.md
+++ b/4.1/crud-fields.md
@@ -1128,7 +1128,7 @@ If your related entry can have hundreds, thousands or millions of entries, it's 
     // AJAX OPTIONALS:
     // 'data_source' => url("fetch/category"), // url to controller search function (with /{id} should return model)
     // 'minimum_input_length' => 2, // minimum characters to type before querying results
-    // 'dependencies'         => ['category’], // when a dependency changes, this select2 is reset to null
+    // 'dependencies'         => ['category'], // when a dependency changes, this select2 is reset to null
     // 'include_all_form_fields'  => false, // optional - only send the current field through AJAX (for a smaller payload if you're not using multiple chained select2s)
  ],
 ```

--- a/4.1/crud-how-to.md
+++ b/4.1/crud-how-to.md
@@ -236,8 +236,8 @@ $this->crud->addField([ // select2_from_ajax: 1-n relationship
     'placeholder'          => 'Select an article', // placeholder for the select
     'include_all_form_fields' => true, //sends the other form fields along with the request so it can be filtered.
     'minimum_input_length' => 0, // minimum characters to type before querying results
-    'dependencies'         => ['category’], // when a dependency changes, this select2 is reset to null
-    // 'method'                    => 'GET’, // optional - HTTP method to use for the AJAX call (GET, POST)
+    'dependencies'         => ['category'], // when a dependency changes, this select2 is reset to null
+    // 'method'                    => 'GET', // optional - HTTP method to use for the AJAX call (GET, POST)
 ]);
 ```
 
@@ -247,7 +247,7 @@ $this->crud->addField([ // select2_from_ajax: 1-n relationship
 
 ```php
 Route::get('api/article', 'App\Http\Controllers\Api\ArticleController@index');
-Route::get('api/article/{id}', 'App\Http\Controllers\Api\ArticleController@show’);
+Route::get('api/article/{id}', 'App\Http\Controllers\Api\ArticleController@show');
 ```
 
 **DIFFERENT HERE**: Nothing.

--- a/4.1/crud-how-to.md
+++ b/4.1/crud-how-to.md
@@ -156,9 +156,9 @@ php artisan backpack:filemanager:install
 ```
 
 If you've chosen to install [backpack/filemanager](https://github.com/Laravel-Backpack/FileManager), you'll have elFinder integrated into:
-- TinyMCE (as “tinymce” field type)
-- CKEditor (as “ckeditor” field type)
-- CRUD (as “browse” and "browse_multiple" field types)
+- TinyMCE (as "tinymce" field type)
+- CKEditor (as "ckeditor" field type)
+- CRUD (as "browse" and "browse_multiple" field types)
 - stand-alone, at the */admin/elfinder* route;
 
 For the integration, we use [barryvdh/laravel-elfinder](https://github.com/barryvdh/laravel-elfinder).
@@ -219,9 +219,9 @@ Say you want to show two selects:
 
 ```php
 $this->crud->addField([    // SELECT2
-    'label'         => ‘Category',
+    'label'         => 'Category',
     'type'          => 'select',
-    'name'          => ‘category',
+    'name'          => 'category',
     'entity'        => 'category',
     'attribute'     => 'name',
 ]);
@@ -236,8 +236,8 @@ $this->crud->addField([ // select2_from_ajax: 1-n relationship
     'placeholder'          => 'Select an article', // placeholder for the select
     'include_all_form_fields' => true, //sends the other form fields along with the request so it can be filtered.
     'minimum_input_length' => 0, // minimum characters to type before querying results
-    'dependencies'         => [‘category’], // when a dependency changes, this select2 is reset to null
-    // ‘method'                    => ‘GET’, // optional - HTTP method to use for the AJAX call (GET, POST)
+    'dependencies'         => ['category’], // when a dependency changes, this select2 is reset to null
+    // 'method'                    => 'GET’, // optional - HTTP method to use for the AJAX call (GET, POST)
 ]);
 ```
 

--- a/4.1/faq.md
+++ b/4.1/faq.md
@@ -17,7 +17,7 @@ You don't need a license code AT ALL, if you're just installing Backpack on loca
 
 Yes, you do need a license code. But not a _separate_ license code. If you've already purchased a license code, you should use the same code for both your staging and production instances - even if the domains are different.
 
-If you're interested in a license code to test your project online, _before_ you purchase a Backpack license - take note that we don't do that. We do not issue licenses for testing an already built app on a staging domain. If you’ve reached a point where you put your project on a staging server, that should mean Backpack has already helped you or your company save dozens or hundreds of hours of work - so that qualifies as commercial use. We recommend you purchase a license code - you can use the same license code on both your stanging and production domain.
+If you're interested in a license code to test your project online, _before_ you purchase a Backpack license - take note that we don't do that. We do not issue licenses for testing an already built app on a staging domain. If you've reached a point where you put your project on a staging server, that should mean Backpack has already helped you or your company save dozens or hundreds of hours of work - so that qualifies as commercial use. We recommend you purchase a license code - you can use the same license code on both your stanging and production domain.
 
 An alternative to be able to test a project online, without paying anything, would be to put your project online and bear the annoying notification bubbles. If you don't mind the notification bubbles, you can get a general idea of what's working and what's not. It's not ideal, but it's free.
 

--- a/4.1/getting-started-advanced-features.md
+++ b/4.1/getting-started-advanced-features.md
@@ -30,7 +30,7 @@ Here are some other cool things Backpack makes easy for you. We recommend going 
 --
 
 - **ListEntries**
-    - you can add a “+” button next to each entry, to allow the admin to easily preview some quick information that was too big to fit inside a columns - we call it [details row](/docs/{{version}}/crud-operation-list-entries#details-row)
+    - you can add a "+" button next to each entry, to allow the admin to easily preview some quick information that was too big to fit inside a columns - we call it [details row](/docs/{{version}}/crud-operation-list-entries#details-row)
     - export all visible items in the table by adding [export buttons](/docs/{{version}}/crud-operation-list-entries#export-buttons)
     - [custom search logic](/docs/{{version}}/crud-columns#custom-search-logic) for the columns in the list view
 

--- a/4.1/getting-started-advanced-features.md
+++ b/4.1/getting-started-advanced-features.md
@@ -4,7 +4,7 @@
 
 **Duration:** 5 min
 
-Here are some other cool things Backpack makes easy for you. We recommend going through them one by one, just browsing. You might not need the feature _right now_, but when _you do_, you’ll know how to find it.
+Here are some other cool things Backpack makes easy for you. We recommend going through them one by one, just browsing. You might not need the feature _right now_, but when _you do_, you'll know how to find it.
 
 ---
 
@@ -40,7 +40,7 @@ Additionally, here are a few more ways you can customize your CRUDs:
 - [Custom Content Class for each CRUD](/docs/{{version}}/crud-how-to#resize-the-content-wrapper-for-an-operation)
 - [Custom CSS or JS](/docs/{{version}}/crud-how-to#customize-css-and-js-for-default-crud-operations) for each CRUD Operation
 
-**That’s it for today!** Told you we’re done with long lessons :-) Hopefully some of the above have peaked your interest and you’ve clicked to see what Backpack can do. In the [next lesson](/docs/{{version}}/getting-started-license-and-support) we’ll go through a few other Backpack packages, that cover some recurring use cases.
+**That's it for today!** Told you we're done with long lessons :-) Hopefully some of the above have peaked your interest and you've clicked to see what Backpack can do. In the [next lesson](/docs/{{version}}/getting-started-license-and-support) we'll go through a few other Backpack packages, that cover some recurring use cases.
 
 
 <br>

--- a/4.1/getting-started-basics.md
+++ b/4.1/getting-started-basics.md
@@ -4,21 +4,21 @@
 
 **Duration:** 5 minutes
 
-> **Are you already comfortable with Laravel?** In order to understand this series and make use of Backpack, you’ll need to have a decent understanding of the Laravel framework. If you don’t, please go ahead and [watch this excellent intro series on Laracasts](https://laracasts.com/series/laravel-from-scratch-2018) and accomodate yourself with Laravel first.
+> **Are you already comfortable with Laravel?** In order to understand this series and make use of Backpack, you'll need to have a decent understanding of the Laravel framework. If you don't, please go ahead and [watch this excellent intro series on Laracasts](https://laracasts.com/series/laravel-from-scratch-2018) and accomodate yourself with Laravel first.
 
 
 <a name="what-is-backpack"></a>
 ## What is Backpack?
 A software that helps Laravel professionals build administration panels - secure areas where administrators login and create, read, update and delete application information. It is *not* a CMS, it is more a framework that lets you *build your own* CMS. You can install it in your existing project or in a totally new project. 
 
-It’s designed to be flexible enough to allow you to **build admin panels for everything from simple presentation websites to CRMs, ERPs, eCommerce, eLearning, etc**. We can vouch for that, because we have built all that stuff using Backpack already.
+It's designed to be flexible enough to allow you to **build admin panels for everything from simple presentation websites to CRMs, ERPs, eCommerce, eLearning, etc**. We can vouch for that, because we have built all that stuff using Backpack already.
 
 <a name="how-to-use-backpack"></a>
 ## What's a CRUD?
 
 A **CRUD** is what we call a section of your admin panel that lets the admin _Create, Read, Update or Delete_ entries of a certain entity (or Model). So you can have a CRUD for Products, a CRUD for Articles, a CRUD for Categories, or whatever else you might want to create, read, update or delete.
 
-For the purpose of this series, we’ll show examples on the ```Tag``` entity. This is what a Tag CRUD could look like:
+For the purpose of this series, we'll show examples on the ```Tag``` entity. This is what a Tag CRUD could look like:
 
 ![Tag CRUD - List Entries Operation](https://backpackforlaravel.com/uploads/docs-4-0/getting_started/tag_crud_list_entries.png)
 
@@ -46,13 +46,13 @@ Backpack comes with a basic authentication system, that's separate from Laravel'
 
 ![Backpack 3.5 Authentication Screens](https://backpackforlaravel.com/uploads/docs-4-0/getting_started/auth_screens.png)
 
-After you [install Backpack](/docs/{{version}}/installation) (don't do it now), you’ll be able to log into your admin panel at ```http://yourapp/admin```. You can change the URL prefix from ```admin``` to something else in your ```config/backpack/base.php``` file, along with a bunch of other configuration options. [Click here](https://github.com/Laravel-Backpack/CRUD/blob/master/src/config/backpack/base.php) to browse the configuration file and see what it can do for you.
+After you [install Backpack](/docs/{{version}}/installation) (don't do it now), you'll be able to log into your admin panel at ```http://yourapp/admin```. You can change the URL prefix from ```admin``` to something else in your ```config/backpack/base.php``` file, along with a bunch of other configuration options. [Click here](https://github.com/Laravel-Backpack/CRUD/blob/master/src/config/backpack/base.php) to browse the configuration file and see what it can do for you.
 
 
 <a name="backpack-crud"></a>
 ### CRUDs
 
-This is where it gets interesting. As soon as you [install Backpack](/docs/{{version}}/installation) in your project, you can create **CRUDs** for your admins to easily manipulate DB information. Let’s browse through a simple example, of creating a CRUD administration panel for a Tag entity:
+This is where it gets interesting. As soon as you [install Backpack](/docs/{{version}}/installation) in your project, you can create **CRUDs** for your admins to easily manipulate DB information. Let's browse through a simple example, of creating a CRUD administration panel for a Tag entity:
 
 ```zsh
 # STEP 1. create migration
@@ -65,7 +65,7 @@ php artisan backpack:crud tag #use singular, not plural
 
 This will create a simple CRUD panel, which you should now be able to see in the Sidebar.
 
-For a simple entry like this, the generated CRUD panel will even work "as is", no need for customizations. But don’t expect this for more complex entities. They will usually have particularities and need customization. That’s where Backpack shines - modifying anything in the CRUD Panel is easy and intuitive, once you understand how it works.
+For a simple entry like this, the generated CRUD panel will even work "as is", no need for customizations. But don't expect this for more complex entities. They will usually have particularities and need customization. That's where Backpack shines - modifying anything in the CRUD Panel is easy and intuitive, once you understand how it works.
 
 The code above would generate:
 - a **migration** file
@@ -80,7 +80,7 @@ It will also add:
 
 You might have noticed that **no views** are generated. That's because in most cases you _don't need_ custom views with Backpack. All your custom code is in the controller, model or request, so the default views are loaded, from the pacakge. If you do, however, need to customize a view, it is [ridiculously easy](/docs/{{version}}/crud-how-to#customize-views-for-each-crud-panel).
 
-Also, we won’t be covering the **migration**, **model** and **request** files here, as they are in no way custom. The only thing you need to make sure is that the Model is properly configured (db table, relationships, ```$fillable``` or ```$guarded``` properties, etc) and that it uses our ```CrudTrait```. What we _will_ be covering is ```TagCrudController``` - which is where most of your logic will reside. Here’s a copy of a simple one you might use to achieve the above:
+Also, we won't be covering the **migration**, **model** and **request** files here, as they are in no way custom. The only thing you need to make sure is that the Model is properly configured (db table, relationships, ```$fillable``` or ```$guarded``` properties, etc) and that it uses our ```CrudTrait```. What we _will_ be covering is ```TagCrudController``` - which is where most of your logic will reside. Here's a copy of a simple one you might use to achieve the above:
 
 ```php
 <?php namespace App\Http\Controllers\Admin;
@@ -137,7 +137,7 @@ You should notice:
 - The ```setup()``` method defines the basics of the CRUD panel;
 - Each operation is set up inside a ```setupXxxOperation()``` method;
 
-**That’s all for today! **If you want to learn more, go ahead and [read the next lesson](/docs/{{version}}/getting-started-crud-operations) of this series.
+**That's all for today! **If you want to learn more, go ahead and [read the next lesson](/docs/{{version}}/getting-started-crud-operations) of this series.
 
 
 <br>

--- a/4.1/getting-started-basics.md
+++ b/4.1/getting-started-basics.md
@@ -65,7 +65,7 @@ php artisan backpack:crud tag #use singular, not plural
 
 This will create a simple CRUD panel, which you should now be able to see in the Sidebar.
 
-For a simple entry like this, the generated CRUD panel will even work “as is”, no need for customizations. But don’t expect this for more complex entities. They will usually have particularities and need customization. That’s where Backpack shines - modifying anything in the CRUD Panel is easy and intuitive, once you understand how it works.
+For a simple entry like this, the generated CRUD panel will even work "as is", no need for customizations. But don’t expect this for more complex entities. They will usually have particularities and need customization. That’s where Backpack shines - modifying anything in the CRUD Panel is easy and intuitive, once you understand how it works.
 
 The code above would generate:
 - a **migration** file

--- a/4.1/getting-started-crud-operations.md
+++ b/4.1/getting-started-crud-operations.md
@@ -4,7 +4,7 @@
 
 **Duration:** 10 minutes
 
-Let’s bring back the example in our first lesson. The Tags CRUD:
+Let's bring back the example in our first lesson. The Tags CRUD:
 
 ![Tag CRUD - List Entries Operation](https://backpackforlaravel.com/uploads/docs-4-0/getting_started/tag_crud_list_entries.png)
 
@@ -66,7 +66,7 @@ In the example above, we've enabled the most common operations:
 - **Delete** - using a *button* in the *list view* 
 - **Show** - using a *button* in the *list view* 
 
-These are the basic operations an admin can execute on an Eloquent model, thanks to Backpack. We do have additional operations (Reorder, Revisions, Clone, BulkDelete, BulkClone), and you can easily _create a custom operation_, but let’s not get ahead of ourselves. Baby steps. **Let's go through the most important features of the operations you'll be using _all the time_: ListEntries, Create and Update**.
+These are the basic operations an admin can execute on an Eloquent model, thanks to Backpack. We do have additional operations (Reorder, Revisions, Clone, BulkDelete, BulkClone), and you can easily _create a custom operation_, but let's not get ahead of ourselves. Baby steps. **Let's go through the most important features of the operations you'll be using _all the time_: ListEntries, Create and Update**.
 
 <a name="create-and-update-operations"></a>
 ## Create & Update Operations
@@ -98,7 +98,7 @@ A typical *field definition array* will need at least three things:
 - ```label``` - the human-readable label for the input (will be generated from ```name``` if not given);
 
 
-You can use [one of the 44+ field types we’ve provided](/docs/{{version}}/crud-fields#default-field-types), or easily [create a custom field type](/docs/{{version}}/crud-fields#creating-a-custom-field-type) if you have some super-specific need that we haven’t covered yet, or even [overwrite how a field type works](#overwriting-default-field-types). Take a few minutes and [browse the 44+ field types](/docs/{{version}}/crud-fields#default-field-types), to understand how the definition array differs from one to another and how many use cases you have already covered.
+You can use [one of the 44+ field types we've provided](/docs/{{version}}/crud-fields#default-field-types), or easily [create a custom field type](/docs/{{version}}/crud-fields#creating-a-custom-field-type) if you have some super-specific need that we haven't covered yet, or even [overwrite how a field type works](#overwriting-default-field-types). Take a few minutes and [browse the 44+ field types](/docs/{{version}}/crud-fields#default-field-types), to understand how the definition array differs from one to another and how many use cases you have already covered.
 
 Let's take another example, slightly more complicated than the ```text``` fields we used above. Something you'll encounter all the time is relationship fields. So let's say the ```Tag``` model has an **n-n relationship** with an Article model:
 
@@ -245,7 +245,7 @@ $this->crud->removeButton($name);
 $this->crud->removeButtonFromStack($name, $stack);
 ```
 
-**That’s it for today!** Thanks for sticking with us this long. This has been the most important and longest lesson. You can go ahead and [install Backpack](/docs/{{version}}/installation) now, as you’ve already gone through the most important features. Or [read the next lesson](/docs/{{version}}/getting-started-advanced-features), about advanced features.
+**That's it for today!** Thanks for sticking with us this long. This has been the most important and longest lesson. You can go ahead and [install Backpack](/docs/{{version}}/installation) now, as you've already gone through the most important features. Or [read the next lesson](/docs/{{version}}/getting-started-advanced-features), about advanced features.
 
 
 <br>

--- a/4.1/getting-started-crud-operations.md
+++ b/4.1/getting-started-crud-operations.md
@@ -60,9 +60,9 @@ class TagCrudController extends CrudController {
 ```
 
 In the example above, we've enabled the most common operations:
-- **Create** - using a create form (aka “*add form*”)
-- **List** - using AJAX DataTables (aka “*list view*”, aka “*table view*”)
-- **Update** - using an update form (aka “*edit form*”)
+- **Create** - using a create form (aka "*add form*")
+- **List** - using AJAX DataTables (aka "*list view*", aka "*table view*")
+- **Update** - using an update form (aka "*edit form*")
 - **Delete** - using a *button* in the *list view* 
 - **Show** - using a *button* in the *list view* 
 

--- a/4.1/getting-started-license-and-support.md
+++ b/4.1/getting-started-license-and-support.md
@@ -16,7 +16,7 @@ Take a look at:
 <a name="license"></a>
 ## License
 
-Backpack is **free for non-commercial use**, but needs a license code in order to prevent “_unlicensed use_” notification bubbles and interruption of service. You can get a license code for your project:
+Backpack is **free for non-commercial use**, but needs a license code in order to prevent "_unlicensed use_" notification bubbles and interruption of service. You can get a license code for your project:
 - ```free```, if you're using it for non-commercial purposes; [apply here](https://backpackforlaravel.com/pricing);
 - ```free```, if you've contributed to Backpack on Github; [apply here](https://backpackforlaravel.com/pricing);
 - ```€69 EUR/project```, if you're making money using it for a project; [buy here](https://backpackforlaravel.com/pricing);

--- a/4.1/getting-started-license-and-support.md
+++ b/4.1/getting-started-license-and-support.md
@@ -25,12 +25,12 @@ Backpack is **free for non-commercial use**, but needs a license code in order t
 **Freelancers** or companies **who make money using Backpack** - for themselves, their employers or their clients, **should [purchase a commercial license here](https://backpackforlaravel.com/pricing)**.
 
 
->**You don't need a license code on LOCALHOST.** If you’re just trying Backpack on your own machine, you don’t need a license code. You only need a license code when you take your application to production.
+>**You don't need a license code on LOCALHOST.** If you're just trying Backpack on your own machine, you don't need a license code. You only need a license code when you take your application to production.
 
 <a name="support"></a>
 ## Support
 
-With thousands of developers using Backpack, a lot of them non-commercial, and such a small price, **we can’t offer official support for the packages**. We've been doing this since 2016, we actively maintain the packages, we try to squash any bugs ASAP and add new features all the time, but we unfortunately can't spend time on back-and-forth on implementation issues in your project. But. We do have good documentation and have been blessed with a **great community**, where people help each other out. If Backpack becomes your tool of preference, I highly recommend you join our gang. Help others get started, create cool stuff, or even influence the direction of Backpack: 
+With thousands of developers using Backpack, a lot of them non-commercial, and such a small price, **we can't offer official support for the packages**. We've been doing this since 2016, we actively maintain the packages, we try to squash any bugs ASAP and add new features all the time, but we unfortunately can't spend time on back-and-forth on implementation issues in your project. But. We do have good documentation and have been blessed with a **great community**, where people help each other out. If Backpack becomes your tool of preference, I highly recommend you join our gang. Help others get started, create cool stuff, or even influence the direction of Backpack: 
 
 - **[StackOverflow tag](https://stackoverflow.com/questions/tagged/backpack-for-laravel) for support requests** (If you need help creating something using Backpack, post your question on StackOverflow using the ```backpack-for-laravel``` tag. We've been blessed with a great community, that is happy to help. Who doesn't like getting StackOverflow points?)
 - **[Gitter Chatroom](https://gitter.im/BackpackForLaravel/Lobby) for quick questions** (If you have an urgent matter that won't take much time to answer, use our 24/7 Gitter chatroom. Be considerate, everyone's probably working on their own project right now.)


### PR DESCRIPTION
This PR standardize the quotation mark.

```
“ | ” => "
‘ | ’ => '
```

It fixes several situations like this;
![image](https://user-images.githubusercontent.com/1838187/98975459-0a72d600-250e-11eb-9508-46ef132bc7ea.png)

Or this;
![image](https://user-images.githubusercontent.com/1838187/98975530-21192d00-250e-11eb-9dc1-49e8dab69052.png)

Both examples here; https://backpackforlaravel.com/docs/4.1/crud-how-to#manually-install-backpack