### PR TITLE
Corrected select2_multiple filter information

### DIFF
--- a/4.1/crud-filters.md
+++ b/4.1/crud-filters.md
@@ -206,7 +206,7 @@ $this->crud->addFilter([
 <a name="select2_multiple"></a>
 ### Select2_multiple
 
-Shows a select2 and allows the user to select one or more items from the list or search for an item. Useful when the values list is long (over 10 elements) and your user should be able to select multiple elements. You can decide yourself if the query for each element should use 'where' or 'orWhere', in the third parameter of the ```addFilter()``` method.
+Shows a select2 and allows the user to select one or more items from the list or search for an item. Useful when the values list is long (over 10 elements) and your user should be able to select multiple elements.
 
 ![Backpack CRUD Select2_multiple Filter](https://backpackforlaravel.com/uploads/docs-4-0/filters/select2_multiple.png)
 
@@ -224,9 +224,7 @@ $this->crud->addFilter([
       4 => 'Not available',
     ];
 }, function($values) { // if the filter is active
-    // foreach (json_decode($values) as $key => $value) {
-    //     $this->crud->addClause('where', 'published', $value);
-    // }
+    // $this->crud->addClause('whereIn', 'published', json_decode($values));
 });
 ```
 

--- a/4.1/crud-filters.md
+++ b/4.1/crud-filters.md
@@ -224,7 +224,7 @@ $this->crud->addFilter([
       4 => 'Not available',
     ];
 }, function($values) { // if the filter is active
-    // $this->crud->addClause('whereIn', 'published', json_decode($values));
+    // $this->crud->addClause('whereIn', 'status', json_decode($values));
 });
 ```
 


### PR DESCRIPTION
When we use **_select2_multiple_** filter (if the query for each element should use `orWhere`, in the third parameter of the addFilter() method.) with another filter **_select2_**
1. If we filter with one value in both filter it's working perfectly
2. But if we use one value in **_select2_** filter and more than one value in **_select2_multiple_** filter then it didn't working correctly.
So for this problem if we use `whereIn` then it's working every scenarios and i guess it's best option as well
More than that there is no point to use `where` in the **_select2_multiple_**

I change from:
![before](https://user-images.githubusercontent.com/25341255/99379751-146e4d80-28ef-11eb-84ba-356b9c71faff.png)
To:
![after](https://user-images.githubusercontent.com/25341255/99379869-39fb5700-28ef-11eb-9ccc-360f306218a9.png)

