### PR TITLE
Update color_picker field example

### DIFF
--- a/4.1/crud-fields.md
+++ b/4.1/crud-fields.md
@@ -544,7 +544,29 @@ Show a pretty colour picker using [Bootstrap Colorpicker](https://itsjavi.com/bo
     'default'              => '#000000',
 
     // optional
-    'color_picker_options' => ['customClass' => 'custom-class']
+    'color_picker_options' => [ // https://itsjavi.com/bootstrap-colorpicker/module-options.html
+        'horizontal' => true,
+        'extensions' => [
+            [
+                'name' => 'swatches', // extension name to load
+                'options' => [ // extension options
+                    'colors' => [
+                        'black' => '#000000',
+                        'gray' => '#888888',
+                        'white' => '#ffffff',
+                        'red' => 'red',
+                        'default' => '#777777',
+                        'primary' => '#337ab7',
+                        'success' => '#5cb85c',
+                        'info' => '#5bc0de',
+                        'warning' => '#f0ad4e',
+                        'danger' => '#d9534f'
+                    ],
+                    'namesAsValues' => false
+                ]
+            ]
+        ]
+    ]
 ],
 ```
 

--- a/4.1/crud-fields.md
+++ b/4.1/crud-fields.md
@@ -545,17 +545,13 @@ Show a pretty colour picker using [Bootstrap Colorpicker](https://itsjavi.com/bo
 
     // optional
     'color_picker_options' => [ // https://itsjavi.com/bootstrap-colorpicker/module-options.html
+        'customClass' => 'custom-class',
         'horizontal' => true,
         'extensions' => [
             [
                 'name' => 'swatches', // extension name to load
                 'options' => [ // extension options
                     'colors' => [
-                        'black' => '#000000',
-                        'gray' => '#888888',
-                        'white' => '#ffffff',
-                        'red' => 'red',
-                        'default' => '#777777',
                         'primary' => '#337ab7',
                         'success' => '#5cb85c',
                         'info' => '#5bc0de',

--- a/4.1/crud-fields.md
+++ b/4.1/crud-fields.md
@@ -544,7 +544,11 @@ Show a pretty colour picker using [Bootstrap Colorpicker](https://itsjavi.com/bo
     'default'              => '#000000',
 
     // optional
-    'color_picker_options' => [ // https://itsjavi.com/bootstrap-colorpicker/module-options.html
+    // Anything your define inside `color_picker_options` will be passed as JS
+    // to the JavaScript plugin. For more information about the options available
+    // please see the plugin docs at:
+    //  ### https://itsjavi.com/bootstrap-colorpicker/module-options.html
+    'color_picker_options' => [
         'customClass' => 'custom-class',
         'horizontal' => true,
         'extensions' => [


### PR DESCRIPTION
Given example is not clearly indicating that every option in the plugin can be used.

I've tried to include more real life example where theme colors can be defined with swatches. Also included a link to plugin's docs so users can check further options available.

![image](https://user-images.githubusercontent.com/17077712/106618784-87937180-6578-11eb-8d1b-9ab99e48f580.png)