### PR TITLE
Set image attribute when creating new class object

### DIFF
--- a/4.1/crud-fields.md
+++ b/4.1/crud-fields.md
@@ -908,6 +908,10 @@ Class Product extends Model
             $public_destination_path = Str::replaceFirst('public/', '', $destination_path);
             $this->attributes[$attribute_name] = $public_destination_path.'/'.$filename;
         }
+	else
+        {
+            return $this->attributes['image'] = $value;
+        }
     }
     
 // ..


### PR DESCRIPTION
I had problem with SQL error, that image attribute doesn't have default value when seeding my my table. For example:
$obj = new \App\Models\Product();
$obj->name = 'name';
$obj->image = 'image path';
$obj->save();