### PR TITLE
Update fakes documentation for translatable attributes

### DIFF
--- a/4.1/crud-fields.md
+++ b/4.1/crud-fields.md
@@ -148,7 +148,7 @@ In case you want to store insignificant information for an entry that doesn't ne
 - are on a new ```$fakeColumns``` property (create it now);
 - are casted as array in ```$casts```;
 
->If you need your fakes to also be translatable, remember to also place ```extras``` in your model's ```$translatable``` property.
+>If you need your fakes to also be translatable, remember to also place ```extras``` in your model's ```$translatable``` property and remove it from ```$casts```.
 
 Example:
 ```php


### PR DESCRIPTION
Documentation for fakes was confusing because after some testing I came up finding out that for translatable attributes to work as fakes they can't be in `$casts`.