### PR TITLE
Remove breaking else

### DIFF
--- a/4.1/crud-fields.md
+++ b/4.1/crud-fields.md
@@ -916,10 +916,6 @@ Class Product extends Model
             $public_destination_path = Str::replaceFirst('public/', '', $destination_path);
             $this->attributes[$attribute_name] = $public_destination_path.'/'.$filename;
         }
-	else
-        {
-            return $this->attributes[$attribute_name] = $value;
-        }
     }
     
 // ..


### PR DESCRIPTION
In 4.1, this else would make the image save as `https://blabla.com/uploads/image.jpg` in the database instead of the expected `uploads/image.jpg` when you edit an entry and don't change image field.