### PR TITLE
renamed fields and pivotFields to subfields; added MUCH clearer docs for relationship field

### DIFF
--- a/4.2-dev/crud-how-to.md
+++ b/4.2-dev/crud-how-to.md
@@ -5,11 +5,37 @@
 In addition the usual CRUD functionality, Backpack also allows you to do a few more complicated things:
 
 
-<a name="how-to"></a>
-## How To
+<a name="routes"></a>
+## Routes
 
-<a name="customize-views-for-each-crud-panel"></a>
-### Customize Views for each CRUD Panel
+<a name="how-to-add-extra-crud-routes"></a>
+### How to add extra CRUD routes
+
+Starting with Backpack\CRUD 4.0, routes are defined inside the Controller, in methods that look like ```setupOperationNameRoutes()```; you can use this naming convention to setup extra routes, for your custom operations:
+
+```php
+protected function setupModerateRoutes($segment, $routeName, $controller) {
+  Route::get($segment.'/{id}/moderate', [
+      'as'        => $routeName.'.moderate',
+      'uses'      => $controller.'@moderate',
+      'operation' => 'moderate',
+  ]);
+
+  Route::post($segment.'/{id}/moderate', [
+      'as'        => $routeName.'.saveModeration',
+      'uses'      => $controller.'@saveModeration',
+      'operation' => 'moderate',
+  ]);
+}
+```
+
+If you want the route to point to a different controller, you can add the route in ```routes/backpack/custom.php``` instead.
+
+<a name="views"></a>
+## Views
+
+<a name="how-to-customize-views-for-each-crud-panel"></a>
+### How to customize views for each CRUD panel
 
 Backpack loads its views through a double-fallback mechanism:
 - by default, it will load the views in the vendor folder (the package views);
@@ -24,8 +50,8 @@ $this->crud->setReorderView('your-view');
 $this->crud->setDetailsRowView('your-view');
 ```
 
-<a name="customize-css-and-js-for-default-crud-operations"></a>
-### Add CSS and JS to a page or operation
+<a name="how-to-customize-css-and-js-for-default-crud-operations"></a>
+### How to add CSS or JS to a page or operation
 
 If you want to add extra CSS or JS to a certain page, use the `script` and `style` widgets to add a new file of that type onpage, either from your CrudController or a custom blade file:
 
@@ -57,31 +83,47 @@ You can limit where that CSS/JS is added by making the `Widget::add()` call in t
 - if you want it to be loaded on all pages for all CRUDs, you can create a CustomCrudController that extends our CrudController, do it there and then make sure all your CRUDs extend `CustomCrudController`;
 - if you want it to be loaded on all pages (even non-CRUD like dashboards) you can add the CSS/JS file on all pages by adding it in your `config/backpack/base.php`, under `scripts` and `styles`;
 
-<a name="add-extra-crud-routes"></a>
-### Add Extra CRUD Routes
 
-Starting with Backpack\CRUD 4.0, routes are defined inside the Controller, in methods that look like ```setupOperationNameRoutes()```; you can use this naming convention to setup extra routes, for your custom operations:
+<a name="columns"></a>
+## Columns
 
-```php
-protected function setupModerateRoutes($segment, $routeName, $controller) {
-  Route::get($segment.'/{id}/moderate', [
-      'as'        => $routeName.'.moderate',
-      'uses'      => $controller.'@moderate',
-      'operation' => 'moderate',
-  ]);
+<a name="how-to-use-the-same-column-name-multiple-times-in-a-crud"></a>
+### How to use the same column name multiple times in a CRUD
 
-  Route::post($segment.'/{id}/moderate', [
-      'as'        => $routeName.'.saveModeration',
-      'uses'      => $controller.'@saveModeration',
-      'operation' => 'moderate',
-  ]);
-}
+If you try to add multiple columns with the same ```name```, by default Backpack will only show the last one. That's because ```name``` is also used as a key in the ```$column``` array. So when you ```addColumn()``` with the same name twice, it just overwrites the previous one.
+
+In order to insert two columns with the same name, use the ```key``` attribute on the second column (or both columns). If this attribute is present for a column, Backpack will use ```key``` instead of ```name```. Example:
+
+```diff
+        $this->crud->addColumn([
+           'label' => "Location",
+           'type' => 'select',
+           'name' => 'location_id',
+           'entity' => 'location',
+           'attribute' => 'title',
+           'model' => "App\Models\Location"
+        ]);
+
+        $this->crud->addColumn([
+           'label' => "Location Type",
+           'type' => 'radio_location_type',
+           'options' => [
+               1 => "Country",
+               2 => "Region"
+           ],
+           'name' => 'location_id',
++          'key' => 'location_type',
+           'entity' => 'location',
+           'attribute' => 'type',
+           'model' => "App\Models\Location"
+        ]);
 ```
 
-If you want the route to point to a different controller, you can add the route in ```routes/backpack/custom.php``` instead.
+<a name="fields"></a>
+## Fields
 
-<a name="publish-a-column-field-filter-button-to-modify"></a>
-### Publish a column / field / filter / button and modify it
+<a name="how-to-publish-a-column-field-filter-button-to-modify"></a>
+### How to publish a column / field / filter / button and modify it
 
 All Backpack packages allow you to easily overwrite and customize the views. If you want Backpack to pick up _your_ file, instead of the one in the package, you can do that by just placing a file with the same name in your views. So if you want to overwrite the select2 field (```vendor/backpack/crud/src/resources/views/fields/select2.blade.php```) to change some functionality, you need to create ```resources/views/vendor/backpack/crud/fields/select2.blade.php```. You can do that manually, or use this command:
 ```shell
@@ -91,8 +133,8 @@ This will look for the blade file and copy it inside the folder, so you can edit
 
 >**Please note:** Once you place a file with the same name inside your project, Backpack will pick that one up instead of the one in the package. That means that even though the file in the package is updated, you won't be getting those updates, since you're not using that file. Blade modifications are almost never breaking changes, but it's a good thing to receive updates with zero effort. Even small ones. So please overwrite the files as little as possible. Best to create your own custom fields/column/filters/buttons, whenever you can.
 
-<a name="filter-the-options-in-a-select-field"></a>
-### Filter the options in a select field
+<a name="how-to-filter-the-options-in-a-select-field"></a>
+### How to filter the options in a select field
 
 This also applies to: select2, select2_multiple, select2_from_ajax, select2_from_ajax_multiple.
 
@@ -134,81 +176,9 @@ class CompanyUser extends User
 }
 ```
 
-<a name="use-the-same-column-name-multiple-times-in-a-crud"></a>
-### Use the same column name multiple times in a CRUD
 
-If you try to add multiple columns with the same ```name```, by default Backpack will only show the last one. That's because ```name``` is also used as a key in the ```$column``` array. So when you ```addColumn()``` with the same name twice, it just overwrites the previous one.
-
-In order to insert two columns with the same name, use the ```key``` attribute on the second column (or both columns). If this attribute is present for a column, Backpack will use ```key``` instead of ```name```. Example:
-
-```diff
-        $this->crud->addColumn([
-           'label' => "Location",
-           'type' => 'select',
-           'name' => 'location_id',
-           'entity' => 'location',
-           'attribute' => 'title',
-           'model' => "App\Models\Location"
-        ]);
-
-        $this->crud->addColumn([
-           'label' => "Location Type",
-           'type' => 'radio_location_type',
-           'options' => [
-               1 => "Country",
-               2 => "Region"
-           ],
-           'name' => 'location_id',
-+          'key' => 'location_type',
-           'entity' => 'location',
-           'attribute' => 'type',
-           'model' => "App\Models\Location"
-        ]);
-```
-
-<a name="use-the-media-library"></a>
-### Use the Media Library (File Manager)
-
-The default Backpack installation doesn't come with a file management component. Because most projects don't need it. But we've created a first-party add-on that brings the power of [elFinder](http://elfinder.org/) to your Laravel projects. To install it, [follow the instructions on the add-ons page](https://github.com/Laravel-Backpack/FileManager). It's as easy as running:
-
-```bash
-# require the package
-composer require backpack/filemanager
-
-# then run the installation process
-php artisan backpack:filemanager:install
-```
-
-If you've chosen to install [backpack/filemanager](https://github.com/Laravel-Backpack/FileManager), you'll have elFinder integrated into:
-- TinyMCE (as "tinymce" field type)
-- CKEditor (as "ckeditor" field type)
-- CRUD (as "browse" and "browse_multiple" field types)
-- stand-alone, at the */admin/elfinder* route;
-
-For the integration, we use [barryvdh/laravel-elfinder](https://github.com/barryvdh/laravel-elfinder).
-
-![Backpack CRUD ListEntries](https://backpackforlaravel.com/uploads/docs-4-0/media_library.png)
-
-<a name="manually-install-backpack-crud"></a>
-### Manually install Backpack
-
-If the automatic installation doesn't work for you and you need to manually install CRUD, here are all the commands it is running:
-
-1) In your terminal:
-
-``` bash
-composer require backpack/crud:"4.2.x-dev as 4.1.99"
-```
-
-2) Instead of running ```php artisan backpack:install``` you can run:
-```bash
-php artisan vendor:publish --provider="Backpack\CRUD\BackpackServiceProvider" --tag="minimum"
-php artisan migrate
-php artisan backpack:publish-middleware
-```
-
-<a name="load-fields-from-a-different-folder"></a>
-### Load fields from a different folder
+<a name="how-to-load-fields-from-a-different-folder"></a>
+### How to load fields from a different folder
 
 If you're developing a package, you might need Backpack to pick up fields from your package folder, instead of having to publish them upon installation.
 
@@ -228,8 +198,8 @@ function () { // if the filter is active (the GET parameter "draft" exits)
 ```
 This will make Backpack look for the ```resources/views/custom_filters/complex.blade.php```, and pick that up before anything else.
 
-<a name="add-a-select-that-depends-on-another-field"></a>
-### Add a select2 field that depends on another field
+<a name="how-to-add-a-select-that-depends-on-another-field"></a>
+### How to add a select2 field that depends on another field
 
 The ```select2_from_ajax``` and ```select2_from_ajax_multiple``` fields allow you to filter the results of a select2, depending on what has already been selected in a form. Say you have to select2 fields. When the AJAX call is made to the second field, all other variables in the page also get passed - that means you can filter the results of the second select2.
 
@@ -290,8 +260,8 @@ class ArticleController extends Controller
     public function index(Request $request)
     {
         $search_term = $request->input('q');
-        
-        // NOTE: this is a Backpack helper that parses your form input into an usable array. 
+
+        // NOTE: this is a Backpack helper that parses your form input into an usable array.
         // you still have the original request as `request('form')`
         $form = backpack_form_input();
 
@@ -326,12 +296,372 @@ class ArticleController extends Controller
 **DIFFERENT HERE**: We use ```$form``` to determine what other variables have been selected in the form, and modify the result accordingly.
 
 
-<a name="resize-the-content-wrapper-for-an-operation"></a>
-### Change the content class for an operation
+<a name="what-field-should-i-use-for-a-relationship"></a>
+### What field should I use for a relationship?
 
-If you want to make the contents of an operation take more / less space from the window, you can do that:
+With so many field types, it can be a little overwhelming to understand what field type to use for a _particular_ Eloquent relationship. Here's a quick summary of all possible relationships, and the interface you might want for them. Click on the relationship you're interested in, for more details and an example:
 
-(A) for all CRUDs by specifying the custom content class in your ```config/backpack/crud.php```:
+
+- **[hasOne (1-1)](#hasone-1-1-relationship)** ✅
+    - (A) show a subform - add a `relationship` field with `subfields`
+    - (B) show a separate field for each attribute on the related entry - add any field type, with dot notation for the field name (`passport.title`)
+- **[belongsTo (n-1)](#belongsto-n-1-relationship)** ✅
+    - show a select2 (single) - add a `relationship` field
+- **[hasMany (1-n)](#hasmany-1-n-relationship)** ✅
+    - (A) show a select2_multiple - add a `relationship` field
+    - (B) show a subform - add a `relationship` field with `subfields`
+- **[belongsToMany (n-n)](#belongstomany-n-n-relationship)** ✅
+    - (A) show a select2_multiple - add a `relationship` field
+    - (B) show a subform - add a `relationship` field and define `subfields`
+- **[morphOne (1-1)](#morphone-1-1-polymorphic-relationship)** ✅
+    - (A) show a subform - add a `relationship` field with `subfields`
+    - (B) show a separate field for each attribute on the related entry - add any field type, with dot notation for the field name (`passport.title`)
+- **[morphMany (1-n)](#morphmany-1-n-polymorphic-relationship)** ✅
+    - (A) show a select2_multiple - add a `relationship` field
+    - (B) show a subform - add a `relationship` field with `subfields`
+- **[morphToMany (n-n)](#morphtomany-n-n-polymorphic-relationship)** ✅
+    - (A) show a select2_multiple - add a `relationship` field
+    - (B) show a subform - add a `relationship` field and define `subfields`
+- **[hasOneThrough (1-1-1)](#hasonethrough-1-1-1-relationship)** ❌
+    - it's read-only, no sense having a field for it;
+- **[hasManyThrough (1-1-n)](#hasmanythrough-1-1-n-relationship)** ❌
+    - it's read-only, no sense having a field for it;
+- **[Has One Of Many (1-n turned into 1-1)](#has-one-of-many-1-1-relationship-out-of-1-n-relationship)** ❌
+    - it's read-only, no sense having a field for it;
+- **[Morph One Of Many (1-n turned into 1-1)](#morph-one-of-many-1-1-relationship-out-of-1-n-relationship)** ❌
+    - it's read-only, no sense having a field for it;
+- **[morphTo (n-1)](#morphto-n-1-relationship)** ❌
+    - never needed, UI would be very difficult to understand & use;
+- **[morphedByMany (n-n inverse)](#morphedbymany-n-n-inverse-relationship)** ❌
+    - never needed, UI would be very difficult to understand & use;
+
+
+<a name="hasone"></a>
+#### hasOne (1-1 relationship)
+
+- example:
+    - `User -> hasOne -> Phone`
+    - the foreign key is stored on the Phone (`user_id` on `phones` table)
+- what to use:
+    - the `relationship` field with `subfields` defined for each column on the related entry
+- how to use:
+    - [the `hasOne` relationship should be properly defined](https://laravel.com/docs/eloquent-relationships#one-to-one) in the User model;
+
+```php
+// inside UserCrudController::setupCreateOperation()
+CRUD::field('phone')->type('relationship')->subfields([
+    'prefix',
+    'number',
+    [
+        'name' => 'type',
+        'type' => 'select_from_array',
+        'options' => ['mobile' => 'Mobile Phone', 'landline' => 'Landline', 'fax' => 'Fax'],
+    ]
+]);
+```
+
+<a name="hasone"></a>
+#### hasOne (1-1 relationship) - one field for each attribute of the related entry
+
+- example:
+    - `User -> hasOne -> Phone`
+    - the foreign key is stored on the Phone (`user_id` on `phones` table)
+- what to use:
+    -  any field (eg. `text`, `number`, `textarea`), with the field name prefixed by the relationship name (dot notation);
+- how to use:
+    - [the `hasOne` relationship should be properly defined](https://laravel.com/docs/eloquent-relationships#one-to-one) in the User model;
+    - you can easily add fields for each individual attribute on the related entry; you just need to specify in the field name that the value should not be stored on the _main model_, but on _a related model_; you can do that using dot notation (`relationship_name.column_name`); note that the prefix (before the dot) is the **Relation** name, not the table name;
+    - all fields types should work fine - depending on your needs you could choose to add a [`text`](#text) field, [`number`](#number) field, [`textarea`](#textarea) field, [`select`](#select) field etc.;
+
+```php
+// inside UserCrudController::setupCreateOperation()
+CRUD::field('phone.number')->type('number');
+CRUD::field('phone.prefix')->type('text');
+CRUD::field('phone.type')->type('select_from_array')->options(['mobile' => 'Mobile Phone', 'landline' => 'Landline', 'fax' => 'Fax']);
+```
+
+<a name="belongsto"></a>
+#### belongsTo (n-1 relationship)
+
+- example:
+    - `Phone -> User`
+    - a Phone belongs to one User; a Phone can only belong to one User
+    - the foreign key is stored on the Phone (`user_id` on `phones` table)
+- how to use:
+    - [the `belongsTo` relationship should be properly defined](https://laravel.com/docs/eloquent-relationships#one-to-many-inverse) in the Phone model;
+    - you can easily add a dropdown to let the admin pick which User the Phone belongs; you can use any of the dropdown fields, but for convenience we've made a list here, and broken them down depending on aproximately how many entries the dropdown will have:
+        - for 0-10 dropdown items - we recommend you use the [`relationship`](#relationship) or [`select`](#select) field;
+        - for 0-500 dropdown items - we recommend you use the [`relationship`](#relationship) or [`select2`](#select2) field;
+        - for 500-1.000.000+ dropdown items - we recommend you load the dropdown items using AJAX, by using the [`relationship`](#relationship) field and Fetch operation (alternatively, use the [`select2_from_ajax`](#select2-from-ajax) field);
+
+```php
+// inside PhoneCrudController::setupCreateOperation()
+CRUD::field('user'); // notice the name is the relationship name and backpack will auto-infer the field type as [`relationship`](#relationship)
+CRUD::field('user_id')->type('select')->model('App\Models\User')->attribute('name')->entity('user'); // notice the name is the foreign key attribute
+CRUD::field('user_id')->type('select2')->model('App\Models\User')->attribute('name')->entity('user'); // notice the name is the foreign key attribute
+```
+
+- notes:
+    - if you choose to use the [`relationship`](#relationship) field, you could also use [the InlineCreate operation](/docs/{{version}}/crud-operation-inline-create), which will add a [+ Add Item] button next to the dropdown, to let the admin create a User in a modal, without leaving the current Create Phone form;
+
+<a name="hasmany"></a>
+#### hasMany (1-n relationship)
+
+- example:
+    - `Post -> HasMany -> Comment`
+    - the foreign key is stored on the Comment (`post_id` on `comments` table)
+- what to use:
+    - use the `relationship` field;
+- how to use:
+    - [the `hasMany` relationship should be properly defined](https://laravel.com/docs/eloquent-relationships#one-to-many) in the Post model;
+
+```php
+// inside PostCrudController::setupCreateOperation()
+CRUD::field('comments'); // when unselected, will set foreign key to null
+CRUD::field('comments')->fallback_id(3); // when unselected, will set foreign key to 3
+CRUD::field('comments')->force_delete(true);  // when unselected, will delete the related entry
+```
+
+- notes:
+    - when a related entry is unselected (removed), Backpack will:
+        - set the foreign key to `null`, if that db column is nullable (eg. `post_id`);
+        - set the foreign key to a default value, if you define a `fallback_id` on the field;
+        - delete related entry entirely, if you define `'force_delete' => false` on the field;
+    - you can use [the InlineCreate operation](/docs/{{version}}/crud-operation-inline-create) to show a [+ Add Item] button next to the dropdown; for it to work `post_id` on comments table need to nullable or have a default setup in database;
+
+
+<a name="hasmany-1-n-relationship-with-subform-to-create-update-and-delet"></a>
+#### hasMany (1-n relationship) with subform to create, update and delete related entries
+
+If you want the admin to not only _select_ an entry, but also create them, edit their attributes or delete related entries.
+
+- example:
+    - `Post -> HasMany -> Comment`
+    - the foreign key is stored on the Comment (`post_id` on `comments` table)
+- what to use:
+    - use the `relationship` field;
+- how to use:
+    - [the `hasMany` relationship should be properly defined](https://laravel.com/docs/eloquent-relationships#one-to-many) in the Post model;
+
+```php
+// inside PostCrudController::setupCreateOperation()
+CRUD::field('comments')->subfields([['name' => 'body']]);
+// where body is a text field in the comment table.
+```
+
+<a name="belongstomany"></a>
+#### belongsToMany (n-n relationship)
+
+Note: Starting in 4.2, `BelongsToMany` relation had been improved to simplify the scenario where your pivot table has extra database columns (in addition to the foreign keys).
+
+- example:
+    - `User -> BelongsToMany -> Role`
+    - the foreign keys are stored on a pivot table (usually the `user_roles` table has both `user_id` and `role_id`)
+- how to use:
+    - [the `belongsToMany` relationship should be properly defined](https://laravel.com/docs/eloquent-relationships#many-to-many) in both the User and Role models;
+    - you can add a dropdown on your User to pick the Roles that are connected to it; for that, use the [`relationship`](#relationship), [`select_multiple`](#select-multiple), [`select2_multiple`](#select2-multiple) or  [`select2_from_ajax_multiple`](#select2-from-ajax-multiple) fields;
+
+```php
+// inside UserCrudController::setupCreateOperation()
+CRUD::field('roles');
+
+// inside RoleCrudController::setupCreateOperation()
+CRUD::field('users');
+```
+
+- notes:
+    - if you choose to use the [`relationship`](#relationship) field type, you can also use [the InlineCreate operation](/docs/{{version}}/crud-operation-inline-create), which will add a `[+ Add Item]` button next to the dropdown, to let the admin create a User/Role in a modal, without leaving the current Create User/Role form;
+
+##### EXTRA: Saving aditional attributes to the pivot table
+
+If your pivot table has additional database columns (eg. not only `user_id` and `role_id` but also `notes` or `supervisor`, you can use the `relationship` field to show a subform, instead of a `select2`, and show `subfields` for each of those attributes you want edited on the pivot table. For the example above (`User -> BelongsToMany -> Roles`) you should do the following:
+
+
+**Step 1.** Setup the pivot fields in your relation definition:
+
+```php
+// inside App\Models\User
+public function roles() {
+    return $this->belongsToMany('App\Models\Role')->withPivot('notes', 'some_other_field'); // `notes` and `some_other_field` are aditional fields in the pivot table that you plan to show in the form.
+}
+```
+
+**Step 2.** Setup the pivot fields in your relation definition:
+
+```php
+// inside UserCrudController::setupCreateOperation()
+CRUD::field('roles')->subfields([
+    ['name' => 'notes', 'type' => 'textarea'],
+    ['name' => 'some_other_field']
+]);
+```
+
+And you are done: a subform will shown, with a select for the pivot connected entity field and the defined fields and Backpack will take care of the saving process.
+
+**Need to change the pivot `select` field?** You can add any configuration to the pivot field as you would do in a [relationship](#relationship) select field, the only difference is is that it should go inside the `pivotSelect` key:
+```php
+CRUD::field('users')->subfields([ ['name' => 'notes'] ])
+    ->pivotSelect([
+        'ajax' => true,
+        'data_source' => backpack_url('role/fetch/user'),
+        'placeholder' => 'some placeholder',
+        'wrapper' => [
+            'class' => 'col-md-6'
+        ]
+    ]);
+```
+
+<a name="morphone"></a>
+#### morphOne (1-1 polymorphic relationship)
+
+- example:
+    - Post/User -> morphOne -> Video.
+    - The User model and the Post model have 1 Video each.
+    - [the `morphOne` relationship should be properly defined](https://laravel.com/docs/8.x/eloquent-relationships#one-to-one-polymorphic-relations) in both the Post/User and Video models;
+
+You can add a subform for the related entry to be created/edited/deleted from the main form:
+
+```php
+CRUD::field('video.description')->type('relationship')->subfields([
+    'url',
+    [
+        'name' => 'description',
+        'type' => 'ckeditor',
+    ]
+]);
+```
+
+Backpack will take care of the saving process and deal with the morphable relation.
+
+
+<a name="morphone"></a>
+#### morphOne (1-1 polymorphic relationship) one field for each related entry attribute
+
+- example:
+    - Post/User -> morphOne -> Video.
+    - The User model and the Post model have 1 Video each.
+    - [the `morphOne` relationship should be properly defined](https://laravel.com/docs/8.x/eloquent-relationships#one-to-one-polymorphic-relations) in both the Post/User and Video models;
+
+You can add any type of field to change the attribute on the related entry, but make sure to prefix the field name with the name of the relationship:
+
+```php
+CRUD::field('video.description')->type('ckeditor');
+CRUD::field('video.url');
+```
+
+Backpack will take care of the saving process and deal with the morphable relation.
+
+
+<a name="morphmany"></a>
+#### morphMany (1-n polymorphic relationship)
+
+This is in all aspects similar to [HasMany](#hasmany) relation, the difference is that it's stored in a pivot table.
+- example:
+    - Video/Post -> morphMany -> Comment.
+    - The Video model and the Post model can have multiple Comment model but the comment belongs to only one of them.
+    - [the `morphMany` relationship should be properly defined](https://laravel.com/docs/8.x/eloquent-relationships#one-to-many-polymorphic-relations) in both the Post/Video and Comment models;
+
+There is no sense in using this a `select` when using a polymorphic relation because the items that could/would be select might belong to different entities. So you should setup this relation as you would setup a [HasMany creatable](#hasmany-creatable).
+
+```php
+// inside PostCrudController::setupCreateOperation() and inside VideoCrudController::setupCreateOperation()
+CRUD::field('comments')->subfields([['name' => 'comment_text']]); //note comment_text is a text field in the comment table.
+```
+
+
+<a name="morphtomany"></a>
+#### morphToMany (n-n polymorphic relationship)
+
+This is in all aspects similar to [BelongsToMany](#belongstomany) relation, the difference is that it stores the `morphable` entity in the pivot table:
+    - Video/Post -> belongsToMany -> Tag.
+    - The Video model and the Post model can have multiple Tag model and each Tag model can belong to one or more of them.
+    - [the `morphToMany` relationship should be properly defined](https://laravel.com/docs/8.x/eloquent-relationships#many-to-many-polymorphic-relations) in both the Post/Video and Tag models;
+
+Please read the relationship [BelongsToMany](#belongstomany) documentation, everything is the same in regards to fields definition and Backpack will take care of the morphable relation saving.
+
+
+#### hasOneThrough (1-1-1 relationship)
+
+- This is a "read-only" relationship. It does not make sense to add a field for it.
+
+
+#### hasManyThrough (1-1-n relationship)
+
+- This is a "read-only" relationship. It does not make sense to add a field for it.
+
+
+#### Has One of Many (1-1 relationship out of 1-n relationship)
+
+- This is a "read-only" relationship. It does not make sense to add a field for it. Please use the general-purpose relationship towards this entity (the 1-n relationship, without `latestOfMany()` or `oldestOfMany()`).
+
+
+#### Morph One of Many (1-1 relationship out of 1-n relationship)
+
+- This is a "read-only" relationship. It does not make sense to add a field for it. Please use the general-purpose relationship towards this entity (the 1-n relationship, without `latestOfMany()` or `oldestOfMany()`).
+
+#### MorphTo (n-1 relationship)
+
+- We do not provide an interface to edit this relationship. We never needed it, nobody ever asked for it and it would be very difficult to create an interface that is easy-to-use and easy-to-understand for the admin. If you find yourself needing this, please let us know by opening an issue on Github.
+
+#### MorphedByMany (n-n inverse relationship)
+
+- We do not provide an interface to edit this relationship. We never needed it, nobody ever asked for it and it would be very difficult to create an interface that is easy-to-use and easy-to-understand for the admin. If you find yourself needing this, please let us know by opening an issue on Github.
+
+
+<a name="operations"></a>
+## Operations
+
+
+<a name="overwrite-a-method-on-the-crud-panel-object"></a>
+### Add an Uneditable Input inside Create or Update Operation
+
+You might want to add a new attribute to the Model that gets saved. Let's say you want to add an `updated_by` indicator to the Update operation, containing the ID of the user currently logged in (`backpack_user()->id`).
+
+**Option 1.** Sure, in your `ProductCrudController::setupUpdateOperation()` can do `CRUD::field('updated_by')->type('hidden')->value(backpack_user()->id);`, but because that hidden field is inside the HTML, it opens up the possiblity that a malicious actor will edit the value of the input, in the browser.
+
+
+**Option 2.** You can change the `strippedRequest` closure inside your `ProductCrudController::setup()`:
+```php
+public function setupUpdateOperation()
+{
+    CRUD::setOperationSetting('strippedRequest', function ($request) {
+        // keep the recommended Backpack stripping (remove anything that doesn't have a field)
+        // but add 'updated_by' too
+        $input = $request->only(CRUD::getAllFieldNames());
+        $input['updated_by'] = backpack_user()->id;
+
+        return $input;
+    });
+}
+```
+
+**Option 3.** You can change the same `strippedRequest` closure inside the `ProductFormRequest` that contains your validation:
+```php
+    protected function prepareForValidation()
+    {
+        \CRUD::set('update.strippedRequest', function ($request) {
+            // keep the recommended Backpack stripping (remove anything that doesn't have a field)
+            // but add 'updated_by' too
+            $input = $request->only(\CRUD::getAllFieldNames());
+            $input['updated_by'] = backpack_user()->id;
+
+            return $input;
+        });
+    }
+```
+
+
+<a name="how-to-make-the-form-smaller-or-bigger"></a>
+### How to make the form smaller or bigger
+
+In practice, what you want is to change the class on the main `<div>` of the Create/Update operation. To learn how to do that, please take a look at the next section - how to make an operation wider or narrower.
+
+<a name="how-to-make-an-operation-wider-or-narrower"></a>
+### How to make an operation wider or narrower
+
+If you want to make the contents of an operation take more / less space from the window, you can easily do that. You just need to change the class on the main `<div>` of that operation, what we call the "content class". Depending on the scope of your change (for one or all CRUDs) here's how you can do that:
+
+(A) for all CRUDs, by specifying the custom content class in your ```config/backpack/crud.php```:
 
 ```php
     // Here you may override the css-classes for the content section of the create view globally
@@ -371,8 +701,53 @@ $this->crud->setRevisionsTimelineContentClass('col-md-8 col-md-offset-2');
 ```
 
 
+<a name="miscellaneous"></a>
+## Miscellaneous
+
+<a name="use-the-media-library"></a>
+### Use the Media Library (File Manager)
+
+The default Backpack installation doesn't come with a file management component. Because most projects don't need it. But we've created a first-party add-on that brings the power of [elFinder](http://elfinder.org/) to your Laravel projects. To install it, [follow the instructions on the add-ons page](https://github.com/Laravel-Backpack/FileManager). It's as easy as running:
+
+```bash
+# require the package
+composer require backpack/filemanager
+
+# then run the installation process
+php artisan backpack:filemanager:install
+```
+
+If you've chosen to install [backpack/filemanager](https://github.com/Laravel-Backpack/FileManager), you'll have elFinder integrated into:
+- TinyMCE (as "tinymce" field type)
+- CKEditor (as "ckeditor" field type)
+- CRUD (as "browse" and "browse_multiple" field types)
+- stand-alone, at the */admin/elfinder* route;
+
+For the integration, we use [barryvdh/laravel-elfinder](https://github.com/barryvdh/laravel-elfinder).
+
+![Backpack CRUD ListEntries](https://backpackforlaravel.com/uploads/docs-4-0/media_library.png)
+
+<a name="how-to-manually-install-backpack-crud"></a>
+### How to manually install Backpack
+
+If the automatic installation doesn't work for you and you need to manually install CRUD, here are all the commands it is running:
+
+1) In your terminal:
+
+``` bash
+composer require backpack/crud:"4.2.x-dev as 4.1.99"
+```
+
+2) Instead of running ```php artisan backpack:install``` you can run:
+```bash
+php artisan vendor:publish --provider="Backpack\CRUD\BackpackServiceProvider" --tag="minimum"
+php artisan migrate
+php artisan backpack:publish-middleware
+```
+
+
 <a name="overwrite-a-method-on-the-crud-panel-object"></a>
-### Overwrite a Method on the CrudPanel Object 
+### Overwrite a Method on the CrudPanel Object
 
 Starting with Backpack v4, you can use a custom CrudPanel object instead of the one in the package. In your custom CrudPanel object, you can overwrite any method you want, but please note that this means that you're overwriting core components, and will be making it more difficult to upgrade to newer versions of Backpack.
 
@@ -388,40 +763,3 @@ Details and implementation [here](https://github.com/Laravel-Backpack/CRUD/pull/
 
 
 
-<a name="overwrite-a-method-on-the-crud-panel-object"></a>
-### Add an Uneditable Input inside Create or Update Operation 
-
-You might want to add a new attribute to the Model that gets saved. Let's say you want to add an `updated_by` indicator to the Update operation, containing the ID of the user currently logged in (`backpack_user()->id`).
-
-**Option 1.** Sure, in your `ProductCrudController::setupUpdateOperation()` can do `CRUD::field('updated_by')->type('hidden')->value(backpack_user()->id);`, but because that hidden field is inside the HTML, it opens up the possiblity that a malicious actor will edit the value of the input, in the browser. 
-
-
-**Option 2.** You can change the `strippedRequest` closure inside your `ProductCrudController::setup()`:
-```php
-public function setupUpdateOperation() 
-{
-    CRUD::setOperationSetting('strippedRequest', function ($request) {
-        // keep the recommended Backpack stripping (remove anything that doesn't have a field)
-        // but add 'updated_by' too
-        $input = $request->only(CRUD::getAllFieldNames());
-        $input['updated_by'] = backpack_user()->id;
-
-        return $input;
-    });
-}
-```
-
-**Option 3.** You can change the same `strippedRequest` closure inside the `ProductFormRequest` that contains your validation:
-```php
-    protected function prepareForValidation()
-    {
-        \CRUD::set('update.strippedRequest', function ($request) {
-            // keep the recommended Backpack stripping (remove anything that doesn't have a field)
-            // but add 'updated_by' too
-            $input = $request->only(\CRUD::getAllFieldNames());
-            $input['updated_by'] = backpack_user()->id;
-
-            return $input;
-        });
-    }
-```


### PR DESCRIPTION
This PR:
- adds docs for all functionality inside the `relationship` field in 4.2 (including `hasOne` which wasn't coded yet);
- adds examples for each relationship type inside the CRUD FAQ page (not 100% happy with these but we can polish later);
- renames `fields` and `pivotFields` for `relationship` and `repeatable` into `subfields`;

@pxpm please take note of this naming change. I'm 99% sure `subfields` is a better name for this:
- it makes clear that you're talking about fields inside another field;
- it's general enough to be used by both `repeatable` and `relationship`;
- it's general enough to be used both when defining `pivotFields` and fields on a related entry;
- it fixes the confusing `CRUD::field('relationship')->fields([])` definition that I hadn't noticed;
- it not only provides a good way to define the subfields, but also a way to distinguish between them in the docs (you say `fields` you're talking about main fields, you say `subfields` you're talking about fields inside other fields);

We should make this as fool-proof as possible though, so the plan is:
- [ ] `repeatable` to rename `fields` into `subfields` in the blade file;
- [ ] `relationship` to rename `fields` and `pivotFields` into `subfields` in the blade file;

That way, we don't make a breaking change in `repeatable`, but going forward we recommend everybody use `subfields`.

When talking to people (and in the docs) we'll use the terms `subfields` and `subform`.