### PR TITLE
Small fixes to customize colors doc

### DIFF
--- a/4.2-dev/base-how-to.md
+++ b/4.2-dev/base-how-to.md
@@ -223,7 +223,7 @@ npm i noty --save-dev
 npm i animate.css@3.7.2 --save-dev
 ```
 
-Then create a SCSS file for that custom bundle you want. We recommend doing it in `resources/sass/custom-backpack-bundle.scss`. Then customize this file to your liking:
+Then create a SCSS file for that custom bundle you want. We recommend doing it in `resources/scss/custom-backpack-bundle.scss`. Then customize this file to your liking:
 
 ```scss
 // create a bundle CSS file for the an alternative Backstrap style (blue instead of purple for primary color)
@@ -286,7 +286,7 @@ Your result should say "_webpack compiled successfully_". If so, you can now use
 ```diff
     'styles' => [
 -        'packages/backpack/base/css/bundle.css',
-+        'css/custom-backpack-bundle.css',
++        'packages/backpack/base/css/custom-backpack-bundle.css',
 ```
 
 

--- a/4.2-dev/base-how-to.md
+++ b/4.2-dev/base-how-to.md
@@ -286,7 +286,7 @@ Your result should say "_webpack compiled successfully_". If so, you can now use
 ```diff
     'styles' => [
 -        'packages/backpack/base/css/bundle.css',
-+        'packages/backpack/base/css/custom-backpack-bundle.css',
++        'css/custom-backpack-bundle.css',
 ```
 
 


### PR DESCRIPTION
- Fixed the path to `custom-backpack-bundle.css` to be aligned with mix instructions
- Fixed the path segment from `sass` to `scss` to pair with mix instructions