### PR TITLE
Missing one of default actions

### DIFF
--- a/4.1/crud-save-actions.md
+++ b/4.1/crud-save-actions.md
@@ -10,7 +10,7 @@
 <a name="defaults"></a>
 ## Default Save Actions
 
-There are three save actions registered by Backpack by default. They are:
+There are four save actions registered by Backpack by default. They are:
   - ```save_and_back``` (Save your entity and go back to previous URL)
   - ```save_and_edit``` (Save and edit the current entry)
   - ```save_and_new``` (Save and go to create new entity page)

--- a/4.1/crud-save-actions.md
+++ b/4.1/crud-save-actions.md
@@ -14,6 +14,7 @@ There are three save actions registered by Backpack by default. They are:
   - ```save_and_back``` (Save your entity and go back to previous URL)
   - ```save_and_edit``` (Save and edit the current entry)
   - ```save_and_new``` (Save and go to create new entity page)
+  - ```save_and_preview``` (Save and go to show the current entity)
 
 <a name="save-actions-api"></a>
 ## Save Actions API


### PR DESCRIPTION
added `save_and_preview` to save actions

Same fix should be done in 4.2-dev doc