### PR TITLE
V5 docs

### DIFF
--- a/5.x-dev/add-ons-community.md
+++ b/5.x-dev/add-ons-community.md
@@ -1,0 +1,19 @@
+# Community Add-ons
+
+---
+
+We've been blessed with a wonderful, supportive community, where developers help each other out. Some of them have even created add-ons, so that we can all reuse functionality across our projects:
+
+| Name          | Description   | License  |
+| ------------- |:-------------:| --------:|
+| [BackpackBlog](https://github.com/AbbyJanke/BackpackBlog)      | blog front-end and back-end | - |
+| [BackpackMeta](https://github.com/AbbyJanke/BackpackMeta)      | helps create meta options for extending core functions      |   - |
+| [LogViewer](https://github.com/eduardoarandah/backpacklogviewer) | advanced logging interface - brings the ArcaneDev/LogViewer package to Backpack admin panels    | [MIT](https://github.com/eduardoarandah/backpacklogviewer/blob/master/LICENSE.md) |
+| [UserManager](https://github.com/eduardoarandah/UserManager) | manage the default Laravel users table (no permissions, no groups)      |  [MIT](https://github.com/eduardoarandah/UserManager/blob/master/LICENSE) |
+| [laravel-backpack-redirection-manager](https://github.com/novius/laravel-backpack-redirection-manager) | manage missing page redirections      | [AGPL-3](https://github.com/eduardoarandah/backpacklogviewer/blob/master/LICENSE.md) |
+| [laravel-backpack-translation-manager](https://github.com/novius/laravel-backpack-translation-manager) | manage translations stored in the database   |  - |
+| [estarter-ecommerce-for-laravel](https://github.com/updivision/estarter-ecommerce-for-laravel) | complete e-commerce back-end (products, categories, clients, orders)      |  [YUMMY](https://github.com/updivision/estarter-ecommerce-for-laravel/blob/master/LICENSE.md) |
+| [laravel-generators](https://github.com/webfactor/laravel-generators) | CLI to generate migrations, factories, seeders, CRUDs, lang files, route files      |  [MIT](https://github.com/webfactor/laravel-generators/blob/master/LICENSE.md) |
+| [laravel-backpack-gallery-crud](https://gitlab.com/seandowney/laravel-backpack-gallery-crud) | manage photo galleries      |  [MIT](https://gitlab.com/seandowney/laravel-backpack-gallery-crud/blob/master/LICENSE.md) |
+| [signature-field-for-backpack](https://github.com/iMokhles/signature-field-for-backpack) | field type that lets admins draw their signature      |  [MIT](https://github.com/iMokhles/signature-field-for-backpack/blob/master/license.md) |
+| [DynamicFieldHintsForBackpack](https://github.com/DoDSoftware/DynamicFieldHintsForBackpack) | automatically add db comments as field hints      |  [MIT](https://github.com/DoDSoftware/DynamicFieldHintsForBackpack/blob/master/license.md) |

--- a/5.x-dev/add-ons-custom-operation.md
+++ b/5.x-dev/add-ons-custom-operation.md
@@ -1,0 +1,197 @@
+# Create an Add-On for a Custom Operation
+
+-----
+
+This tutorial will help you package a custom operation into a Composer package, so that you (or other people) can use it in multiple Laravel projects. If you haven't already, please [create your custom operation](/docs/{{version}}/crud-operations#creating-a-custom-operation) first, and make sure it's working well, before you move it to a package. It's just easier that way.
+
+
+<a name="create-the-package"></a>
+## Part A. Create The Package
+
+
+<a name="generate-package-folder"></a>
+### Step 1. Generate the package folder
+
+Install this excellent package that will create the boilerplate code for you:
+```sh
+composer require jeroen-g/laravel-packager --dev
+```
+
+Ask the package to generate the boilerplate code for your new package:
+
+```sh
+php artisan packager:new MyName SomeCustomOperation --i
+```
+
+Keep in mind:
+- the ```MyName``` should be your Github handle (or organisation), in studly case (```CompanyName```);
+- the ```SomeCustomOperation``` should be the package name you want, in studly case (```ModerateOperation```);
+- the ```website``` should be a valid URL, so include the protocol too: ```http://example.com```;
+- the ```description``` should be pretty short;
+- the ```license``` is just the license name, if it's a common one (ex: ```MIT```, ```GPLv2```);
+
+This will create a ```/packages/MyName/SomeCustomOperation``` folder in your root directory, which will hold all the code for your package. It has pulled a basic package template, that we need to customize.
+
+It will also modify your project's ```composer.json``` file to point to this new folder.
+
+<a name="define-dependencies"></a>
+### Step 2. Define dependencies
+
+Inside your ```/packages/MyName/SomeCustomOperation/composer.json``` file, make sure you require the version of Backpack your package will support. If unsure, copy-paste the requirement from your project's ```composer.json``` file. 
+
+```diff
+    "require": {
++        "backpack/crud": "^4.0.0"
+-        "illuminate/support": "~5|~6"
+    },
+```
+
+Note: 
+- you can also remove the ```illuminate/support``` requirement in most cases - if Backpack is installed, so is that;
+- feel free to add any other requirements your package might have;
+
+Notice that this ```composer.json``` will also:
+- define your package namespace (in ```autoload/psr-4```);
+- set up Laravel package autoloading (in ```extra/laravel/providers```);
+
+<a name="instruct-laravel-to-use-your-package"></a>
+### Step 3. Instruct your Laravel Project to use your package
+
+```sh
+composer require myname/somecustomoperation
+```
+
+Congratulations! Now you have a basic package, installed in ```packages/MyName/SomeCustomOperation```, that is loaded in your current Laravel project. Note that:
+- The command above added a requirement to your **project's ```composer.json``` file**, to require the package; Because previously Packager has pointed to the packages folder, it will pick it up from there, instead of the Internet;
+- Then your **package's ```composer.json```** file will point to the ```ServiceProvider``` inside your package's ```src``` folder;
+- The ServiceProvider is the class that ties your package to Laravel's inner workings.
+
+> If you want to test that your package is being loaded, you can do a ```dd('got here')``` inside your package's ```ServiceProvider::boot``` method. If you refresh the page, you should see that ```dd()``` statement executed.
+
+
+<a name="move-the-files-needed-for-the-operation"></a>
+### Step 4. Move the files needed for the operation
+
+You can choose whatever folder structure you want for your package. But within Backpack add-ons, we follow the convention that the package folder should look as much as possible like a Laravel project folder. That way, when someone looks at the addon's source code, they instantly understand where everything is.
+
+**Operation Trait** 
+
+Notice a file has already been created, with the operation name, inside your package's ```src``` folder. You can **move your operation trait code** from ```app/Http/Controllers/Admin/Operations``` to this ```src/SomeCustomOperation``` file, but make sure:
+- you use the proper namespace (```MyName\SomeCustomOperation```);
+- you define it as a Trait, not a Class;
+
+**Views**
+
+If your operation has a user interface, consider moving all the views this operation needs inside your package folder, inside a ```resources/views``` folder.
+
+Then in your package's ServiceProvider, make sure inside ```boot()``` that you load the views:
+```php
+        $this->loadViewsFrom(__DIR__.'/../resources/views', 'somecustomoperation');
+```
+
+**Config**
+
+For most custom Operations, there's really no need to define your own config file. You can just instruct people to use the ```config/backpack/crud.php``` file, and define stuff inside ```operations```, inside an array with your operation's name. If this works for you, then:
+- delete the ```config``` folder entirely;
+- inside your ServiceProvider's ```register()``` method, delete the line with ```mergeConfigFrom()```;
+- inside your ServiceProvider's ```bootForConsole()``` method, delete the line that publishes the config file;
+- inside your ServiceProvider's ```bootFromConsole()``` method, include:
+```bash
+        $this->publishes([
+            __DIR__.'/../resources/views' => base_path('resources/views/vendor/backpack'),
+        ], 'somecustomoperation.views');
+```
+
+That way, developers define config values for your custom operation the same way they define them for a default Backpack operation.
+
+**Translations**
+
+If your Operation has an inteface, it most likely also needs a translation file, so that strings are translatable. To add a translation file:
+- inside your ServiceProvider's ```boot()``` method, include:
+```bash
+$this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'backpack');
+```
+- inside your ServiceProvider's ```bootFromConsole()``` method, include:
+```bash
+        $this->publishes([
+            __DIR__.'/../resources/lang' => resource_path('lang/vendor/backpack'),
+        ], 'somecustomoperation');
+```
+- create the ```resources/lang/en``` folder;
+- create a PHP file with a shorter representative name inside that folder, for example ```somecustom.php```, with the translation lines there;
+- you'll be able to use ```trans('somecustomoperation::somecustom.line_key')``` throughout your operation's controller/views;
+
+
+<a name="delete-files-you-dont-need"></a>
+### Step 5. Delete the package files you don't need
+
+- in most cases you won't need a Facade for the operation, so you can delete the ```src/Facades``` folder; if you do that, also remove the alias to that Facade, at the bottom of your package's ```composer.json``` file;
+- in most cases you won't need the ```register()```, ```provides()``` methods in your ServiceProvider; it's best to remove them;
+
+
+<a name="customize-markdown-files"></a>
+### Step 6. Customize Markdown Files
+
+Inside your package folder, go through all markdown files and make them your own. At the very least, go through:
+- LICENSE.md - use the [MIT license](https://opensource.org/licenses/MIT) if unsure;
+- README.md - write a clear description and instructions for how to use your operation; if you include clear documentation and screenshots, more people will use your package, guaranteed;
+
+
+<a name="make-your-first-git-commit"></a>
+### Step 7. Make your first git commit
+
+Inside your package folder, run:
+```bash
+cd packages/myname/somecustomoperation
+git init
+git add .
+git commit -m "first commit"
+```
+
+
+<a name="put-the-package-online"></a>
+## Part B. Put The Package Online
+
+
+<a name="put-it-on-github"></a>
+### Put it on Github
+
+First, [create a new Github Repository](https://github.com/new) for it. Remember to use the same name you defined in your package's ```composer.json```. If in doubt, double-check.
+
+Second, add that new Github Repo as a remote, and push your code to your new Github repo.
+
+```bash
+git remote add origin git@github.com:yourusername/yourrepository.git
+git push -u origin master
+git tag -a 1.0.0 -m 'First version'
+git push --tags
+```
+
+The tags are the way you will version your package, so it's important you do it.
+
+<a name="put-it-on-packagist"></a>
+### Put it on Packagist
+
+In order for people to be able to install your package using composer, your package needs to be registered with Packagist, Composer's free package registry.
+
+On [Packagist.org](https://packagist.org/), submit a new package. Enter your package's GitHub URL and click Check. If any errors occur, follow the onscreen instructions. When you're done, you're taken to your package's packagist page.
+
+**Congrats, you have a working package online**, you can now install it using Composer.
+
+Note: On the package page, you might get a notice like this: _This package is not auto-updated. Please set up the [GitHub Service Hook](https://packagist.org/profile/) for Packagist so that it gets updated whenever you push!_ Let's take care of that. Click that link, get your API token and go to your package's GitHub page, in Settings / Webhooks & Services / Add a new service. Search for Packagist. Enter your username and the token and hit Submit. Your error in Packagist should disappear in 5–10 minutes.
+
+<a name="feedback-and-promotion"></a>
+### Feedback and Promotion
+
+Congratulations on your new Backpack addon! 
+
+To get feedback, ask people to try it on:
+- [our subredddit](https://www.reddit.com/r/BackpackForLaravel/)
+- [our Gitter chatroom](https://gitter.im/BackpackForLaravel/Lobby)
+
+Make sure you write something nice, so people are interested to click.
+
+After you've got some feedback, and a few users have installed your package and everything seems fine, time to promote it big time:
+- post it to [laravel-news.com/links](https://laravel-news.com/links)
+- show it off in the [Laracasts forum](https://laracasts.com/discuss)
+- ask people to try it in [laravel.io](https://laravel.io/forum)

--- a/5.x-dev/add-ons-how-to-create-a-backpack-addon.md
+++ b/5.x-dev/add-ons-how-to-create-a-backpack-addon.md
@@ -1,0 +1,216 @@
+# How to Create an Add-on
+
+---
+
+
+### Intro
+
+There's nothing special about add-ons. They are simple Composer packages. 
+
+But for consistency, we recommend you follow our simple folder structure. Our rule of thumb: **organize your ```src``` folder like it were a Laravel application**. We do this because it's easier for users to understand how the package works, and it makes it easy to copy-paste the code inside their apps and modify, for complicated use cases. That way, add-ons can be kept super-simple, with everybody adding functionality _in their own apps_. Example folder structure:
+- [src]
+    - [app]
+      - [Http]
+      - [Models]
+      - [Requests]
+    - [database]
+      - [migrations]
+      - [seeds]
+    - [routes]
+    - YourPackageNameServiceProvider.php
+- [tests]
+- composer.json
+- CHANGELOG.md
+- LICENSE.md
+- README.md
+
+Requirements:
+- a working installation of the [Backpack demo](https://github.com/laravel-backpack/demo)
+- 1-2 hours
+
+<a name="create-a-package"></a>
+## Step 1. Create a package
+
+### Install Backpack Demo
+
+We're going to use [the Backpack demo project](https://github.com/laravel-backpack/demo) to create a new package. Follow the instructions in [the Installation chapter](https://github.com/laravel-backpack/demo#install). 
+
+Any Laravel & Backpack app would work. But since you're going to require packages that you only need during package development, and make various changes to app files, we recommended you _create_ the package using a Backpack demo. After the package is online (with zero functionality), you will _install_ it in a real application, and _modify_ it right there, in the ```vendor``` folder. You will then delete this Backpack demo project.
+
+
+### Install CLI tool
+
+We're going to use [Jeroen-G/laravel-packager](https://github.com/Jeroen-G/laravel-packager) to generate a new package. Follow the instructions in the Installation chapter. 
+
+### Generate Package Files
+
+Next up, decide what your vendor name will be. This is NOT the package name, it's the name all your packages will reside under. For example, Laravel uses "laravel". Backpack for Laravel uses "backpack". Jeffrey Way uses "way". If unsure, use your github username for the vendor name. That's what people usually do, if they don't run a company / brand.
+
+Then decide what your package name will be. Ex: ```newscrud```, ```usermanager```, etc.
+
+Then run:
+```
+php artisan packager:new myvendor mypackage
+```
+
+This will create a ```/packages/``` folder in your root directory, where your package will be stored, so you can build it. It will also pull [a very basic package template](https://github.com/thephpleague/skeleton), created by thephpleague. Everything you have right now is in ```packages/myvendor/mypackage``` - check it out.
+
+### Customize Generated Files
+
+Now let's customise it and add some boilerplate code, everything that most Laravel Packages will need. Replace everything you need in ```composer.json```, ```CHANGELOG.md```, ```CONTRIBUTING.md```, ```LICENSE.md```, ```README.md```. Make it yours.
+
+If you want to use Laravel package auto-discovery (and why wouldn't you), make sure to include the Laravel providers section in your ```composer.json```'s ```extra``` section, like so:
+```
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        },
+        "laravel": {
+            "providers": [
+                "Backpack\\NewsCRUD\\NewsCRUDServiceProvider"
+            ]
+        }
+    }
+```
+
+In ```/src/``` you'll find your service provider. That's where your package's logic is, but it's empty. Use this Service Provider template and replace ```League``` with your ```myvendor``` and ```Skeleton``` with your ```mypackage```. Your package will probably need some Controllers, routes and config files. 
+
+### Create The Files Your Package Needs
+
+Here are a few commands that could help you do that:
+
+```bash
+# make sure everything is inside your src folder
+cd src/
+
+# to create a controller
+echo "<?php " >app/Http/Controllers/ControllerName.php
+
+# to create a request file
+echo "<?php " >app/Http/Requests/EntityRequest.php
+
+# to create a route file
+echo "<?php " >routes/mypackage.php
+
+# to create a config file
+echo "<?php " >config/mypackage.php
+
+# to create a views folder
+mkdir resources/views/
+```
+
+You use the routes, config and controller files just like you use the ones in your application. Nothing changes there. But remember that all classes should have the package's namespace:
+
+```php
+namespace MyVendor\MyPackage\Http\Controllers;
+```
+
+### Make Sure Your Laravel App Loads The Package
+
+Add your service provider to your app's ```/config/app.php```
+
+If not, add it:
+```
+"MyVendor\MyPackage\MyPackageServiceProvider",
+```
+
+Check that you autoload your package in composer.json:
+```
+"autoload" : {
+  "psr-4": {
+    "Domain\\PackageName\\": "packages/Domain/PackageName/src"
+  }
+},
+```
+
+Let's recreate the autoload
+```
+cd ../../../..
+composer dump-autoload
+```
+
+If you have a config file to publish, do:
+```
+php artisan vendor:publish
+```
+
+Now test it. Start by doing a ```dd('testing)``` in your service provider's ```boot()``` method. If your package is working fine, I recommend you put it online first, even before it does _anything useful_. You'll get the setup out of the way, and be able to focus on code. Plus, you'll be able to install it in a _real_ Backpack application, and edit it from the ```vendor/myvendor/mypackage``` folder (and push to your git remote).
+
+---
+
+<a name="step-2-put-it-on-github"></a>
+## Step 2. Put it on GitHub
+
+```
+cd packages/domain/packagename/
+git init
+git add .
+git commit -m "first commit"
+```
+
+Create [a new GitHub repository](https://github.com/new).
+
+```
+git remote add origin git@github.com:yourusername/yourrepository.git
+git push -u origin master
+git tag -a 1.0.0 -m 'First version'
+git push --tags
+```
+
+Tags are the way you will version your package, so it's important you do it. People will only be able to get updates if you tag them.
+
+---
+
+<a name="step-3-put-it-on-packagist"></a>
+## Step 3. Put it on Packagist
+
+On [Packagist.org](https://packagist.org), submit a new package. Enter your package's GitHub URL and click Check. If any errors occur, follow the onscreen instructions.
+
+When you're done, you'll be taken to your packagist page, where you'll probably get a notice like this:
+
+>This package is not auto-updated. Please set up the [GitHub Service Hook](https://packagist.org/profile/) for Packagist so that it gets updated whenever you push!
+
+Let's take care of that. Click that link, get your API token and go to your package's GitHub page, in ```Settings / Webhooks & Services / Add a new service```. Search for Packagist. Enter your username and the token and hit Submit. Your error in Packagist should disappear in 5–10 minutes.
+
+Congrats! You now have a working package online. You can now require it with composer.
+
+
+---
+
+<a name="step-4-install-in-a-real-project"></a>
+## Step 4. Install in a Real Project
+
+We've instructed you to create the package in a disposable backpack-demo install. If you've done so, you can now install your package **in your _real_ project**:
+
+```bash
+composer require myvendor/mypackage --prefer-source
+```
+
+Using the ```prefer-source``` flag will actually _clone the git repo_ inside your ```vendor/myvendor/mypackage``` directory. So you can do: 
+
+```bash
+cd /vendor/myvendor/mypackage
+git checkout master
+```
+
+Then after each change you want to publish, you would mark that change in your ```CHANGELOG.md``` file and do:
+```bash
+git pull origin master
+git add .
+git commit -am "fixes #14189 - some problem or feature with an id"
+git tag 1.0.3
+git push origin master --tags
+```
+
+---
+
+**That's it. Go build your package!** If you end up with something you like, please share it with the community in the [Gitter Chatroom](https://gitter.im/BackpackForLaravel/Lobby), and add it to [the Community Add-Ons page](/docs/{{version}}/add-ons-community), so other people know about it (_login, then click Edit in the top-right corner of the page_).
+
+You can now delete the Backpack project, and the database you've created for it (if any).
+
+For extra reading credits, these are the resources we've used to create this guide:
+- https://laravel.com/docs/packages
+- https://laracasts.com/discuss/channels/tips/developing-your-packages-in-laravel-5
+- https://github.com/jaiwalker/setup-laravel5-package
+- https://github.com/Jeroen-G/laravel-packager
+- https://laracasts.com/lessons/package-development-101

--- a/5.x-dev/add-ons-official.md
+++ b/5.x-dev/add-ons-official.md
@@ -1,0 +1,20 @@
+# Official Add-ons
+
+In addition to our core packages (Base and CRUD), we've developed a few packages you can install or download, that treat common use cases. 
+
+Premium add-ons (paid separately, on top of your [Backpack license](https://backpackforlaravel.com/pricing)):
+- [Backpack DevTools](https://backpackforlaravel.com/products/devtools) - a GUI to easily generate Migrations, Models, Seeders, Factories and CRUDs, right from your browser window; a power user's dream come true!
+- [Backpack Figma Template](https://backpackforlaravel.com/products/figma-template) - quickly create designs and mockups, using Backpack's design, screens and components; empower your designers to design admin panels that are easy-to-code;
+
+
+Free add-ons:
+  - [PermissionManager](https://github.com/Laravel-Backpack/PermissionManager) - interface to manage users & permissions, using [spatie/laravel-permission](https://github.com/spatie/laravel-permission); ```free```
+  - [Settings](https://github.com/Laravel-Backpack/Settings) - interface to edit site-wide settings; ```free```
+  - [PageManager](https://github.com/Laravel-Backpack/PageManager) - interface to manage content for custom pages, using page templates; ```free```
+  - [MenuCRUD](https://github.com/Laravel-Backpack/MenuCRUD) - interface to create/update/reorder menu items;  ```free```
+  - [NewsCRUD](https://github.com/Laravel-Backpack/NewsCRUD) - interface to manage news articles, categories and tags; ```free```
+  - [LogManager](https://github.com/Laravel-Backpack/LogManager) - interface to preview Laravel log files; ```free```
+  - [BackupManager](https://github.com/Laravel-Backpack/BackupManager) - interface to backup your files & db using [spatie/laravel-backup](https://github.com/spatie/laravel-backup); ```free```
+
+
+>**The free add-ons only provide basic functionality.** What will be enough for _most_ projects. They do not intend to be a complete solution for all use cases. If you need to customize a package for your specific use case, you can easily do that, by copy-pasting their code in your project and modifying it. Every official package has been created with this in mind, has a very simple architecture, uses Backpack best practices. Find the "extend" section in each of their docs for more about this.

--- a/5.x-dev/add-ons-tutorial-using-the-addon-skeleton.md
+++ b/5.x-dev/add-ons-tutorial-using-the-addon-skeleton.md
@@ -1,0 +1,302 @@
+# Create an Add-On using our Addon Skeleton
+
+-----
+
+This tutorial will help you package a Backpack operation or entire CRUD into a Composer package, so that you can use it in multiple Laravel projects. And if you open-source it, others can do the same.
+
+
+<a name="create-working-code"></a>
+## Part A. Build the Functionality in Your Project
+
+Make sure you have working code in your project. Code everything the package will need, the same way you normally do. Before even _thinking_ about turning it into a package, you should have working code. This is easier because:
+- you don't have to do anything new while working on functionality
+- you don't have to think about package namespaces
+- you don't have to think about what to make configurable or translatable
+- you can test the functionality alone (without the package wiring and stuff)
+
+**(optional) Hot tip:** Don't commit the code to your package yet. Or, if you've already done a commit (and it's the last commit), run `git reset HEAD^` to undo the commit (but keep the changes). This is _not necessary_ but we find it super-helpful. If you changes are inside your project, but uncommitted, you can easily see the files that have changed using `git status`, hence... the files that contain the functionality you should move to the package. It's like a progress screen - everything here should disappear - that's how you know you're done. 
+
+**(optional) Bonus points:** You can use a Git client (like [Git Fork](https://git-fork.com/)) instead of `git status`, because that'll also show the atomic changes you've made to route files, sidebar etc... not only the file names:
+
+![Using Git Fork to see the files and changes that need to be moved to a package or Backpack add-on](https://user-images.githubusercontent.com/1032474/101012182-78d61180-356b-11eb-8aa9-85d6959468ea.png)
+
+As you move things to your new package, they'll disappear from here. You know you're done when you only have the changes the users of your package need to make, to use it. Normally that's just a change to the `composer.json` and (maybe) a configuration file.
+
+
+<a name="create-the-package"></a>
+## Part B. Create The Package
+
+
+<a name="generate-package-folder"></a>
+### Step 1. Generate the package folder
+
+Let's install this excellent package that will make everything a lot faster:
+```sh
+composer require jeroen-g/laravel-packager --dev
+```
+
+Let's create our package. Instead of using their skeleton, we're going to use the Backpack [addon-skeleton](https://github.com/Laravel-Backpack/addon-skeleton):
+
+```sh
+php artisan packager:new --i --skeleton="https://github.com/Laravel-Backpack/addon-skeleton/archive/master.zip"
+```
+
+It will then ask you some basic information about the package. Keep in mind:
+- the ```vendor-name``` should probably be your Github handle (or organisation), in kebab-case (ex: `company-name`); it will be used for folder names, but also for Github and Packagist links;
+- the ```package-name``` should be in `kebab-case` too (ex: ```moderate-operation```);
+- the `skeleton`, if you haven't copied the entire command above, should probably be the one we provide: `https://github.com/Laravel-Backpack/addon-skeleton/archive/master.zip`, which has everything you need to quickly create a Backpack add-on, including an innovative `AddonServiceProvider` that "_just works_"; 
+- the ```website``` should be a valid URL, so include the protocol too: ```http://example.com```;
+- the ```description``` should be pretty short; you can change it later in `composer.json`;
+- the ```license``` is just the license name, if it's a common one (ex: ```MIT```, ```GPLv2```); our skeleton assumes you want `MIT` but you can easily change it;
+
+Ok great. The command has:
+- created a ```/packages/vendor-name/package-name``` folder in your root directory;
+- modified your project's ```composer.json``` file to load the files in this new folder;
+
+This new folder should hold all your package files. You're off to a great start, because you're using our package skeleton (aka template), so it's already a _working package_. And it's already got a good file structure. 
+
+Let's take a look at the generated files inside ```/packages/vendor-name/package-name```: 
+
+![Blank Backpack addon as generated using the addon skeleton](https://user-images.githubusercontent.com/1032474/101022657-5992b080-357a-11eb-8f85-8e0718b66fb2.png)
+
+
+You'll notice that it looks _exactly_ like a Laravel project, with a few exceptions: 
+- PHP classes live in `src` instead of `app`;
+- inside that `src` folder you also have an `AddonServiceProvider`; so let's take a moment to explain why it's there, and what it does:
+    - normally a package needs a ServiceProvider to tell Laravel "load the views from here", "load the migrations from here", "load configs from here", things like that; because a Composer package can also be a general PHP package (non-Laravel), normally you have to code a ServiceProvider for your package, that tells Laravel how to use your package - you have to write all that wiring logic;
+    - but thanks to `AddonServiceProvicer`, you don't have to do any of that; it's all done _automatically_ if the files are in the right directories, just like Laravel does itself, in your project's folders; 
+    - the only thing you should worry about is placing your route files in `routes`, your migrations in `database/migrations` etc. and the `AddonServiceProvider` will understand and tell Laravel to load them; easy-peasy;
+
+Excited by how easy it'll be to make it work? Excellent, let's do it.
+
+> If you want to test that your package is being loaded, you can do a ```dd('got here')``` inside your package's ```AddonServiceProvider::boot``` method. If you refresh the page, you should see that ```dd()``` statement executed.
+
+<a name="initialize-git-repo-and-make-first-commit"></a>
+### Step 1. Initialize a git repo and make your first package commit
+
+Let's save what we have so far - the generated files:
+```bash
+# go to the package folder (of course - use your names here)
+cd packages/vendor-name/package-name
+
+# create a new git repo
+git init
+
+# (optional, but recommended)
+# by default the skeleton includes folders for most of the stuff you need
+# so that it's easier to just drag&drop files there; but you really
+# shouldn't have folders that you don't use in your package;
+# so an optional but recommended step here would be to
+# delete all .gitkeep files, so that you leave the 
+# empty folders empty; that way, you can still
+# drag&drop stuff into them, but Git will
+# ignore the empty folders
+find . -name ".gitkeep" -print # shows all .gitkeep files, to double-check
+find . -name ".gitkeep" -exec rm -rf {} \; # deletes all .gitkeep files
+
+# commit the initially generated files
+git add .
+git commit -am "generated package code using laravel-packager and the backpack addon-skeleton" 
+```
+
+Excellent. Now we have _two_ git repos, that we can use as a progress indicator:
+- the _project_ repo, where the files are uncommitted;
+- the _package_ repo, where we'll be moving the functionality;
+
+If you've used a git client you can even place them side-by-side, and see the progress as you move files from the project (left) to the package (right). But you don't _have to_ do that, it's just a nice visual indicator if it's your first package:
+
+![Two git repos - the project and the new package](https://user-images.githubusercontent.com/1032474/101024271-85af3100-357c-11eb-9a51-605b003a0a53.png)
+
+<a name="define-dependencies"></a>
+### Step 2. Define any extra dependencies
+
+Your ```/packages/vendor-name/package-name/composer.json``` file already requires the latest version of Backpack (thanks to the addon skeleton). If your package needs any third-party packages apart from Backpack and Laravel, make sure to add them to the `require` section. Normally this just means cutting&pasting the line from your project's `composer.json` to your package's `composer.json`.
+
+
+<a name="move-the-files-needed-for-the-operation"></a>
+### Step 3. Move the functionality from your project to your package
+
+Time to move files from your _project_ to your _package_. You can use whatever you want for that - drag&drop, the command line, your IDE or editor, whatever you want.
+
+![Moving files from your project to your package](https://user-images.githubusercontent.com/1032474/101025619-821ca980-357e-11eb-82fb-0d0e57ad6e3f.gif)
+
+
+As you do that, your `git status` or git client should show fewer and fewer files in your _project_, and more and more files in your _package_. 
+
+Below we'll take each project directory, one by one, and explain where its files should go. But this should all pretty intuitive:
+
+#### Files inside your project's ```app``` directory
+
+Move from the subdirectory there to the same subdirectory inside your package's `src`; that means:
+    - controllers go inside `src/Http/Controllers`;
+    - requests go inside `src/Http/Requests`;
+    - models go inside `src/Models`;
+    - commands go inside `src/Commands`;
+    - etc.
+
+IMPORTANT: Since you're moving PHP classes, **after moving them you must also change their namespaces**. Your class is no longer `App\Http\Controllers\Admin\ExampleCrudController` but `VendorName\PackageName\Http\Controllers\ExampleCrudController`. 
+
+I'd love to tell you you can it using a search&replace, but... no. In this case search&replace is not worth it, because it might also replace other stuff you don't want replaced. So it's best to just go ahead:
+- open all the files you've moved;
+- manually replace stuff like `App\Http` with `VendorName\PackageName\Http`;
+
+#### Files inside your project's `config` directory
+
+If you _won't_ be using config files, just delete the entire `config` package directory.
+
+If you _will_ be using config files, to let the users of your package publish it and change how stuff works that way, it's super-simple to use:
+- you already have a file generated in `/packages/vendor-name/package-name/config/package-name.php`;
+- cut&paste any config values you want over here; if you add for example `config_key`, it'll be available in your classes using `config('vendor-name.package-name.config_key')`;
+
+If you don't have any configs right now, but will want to add later, that's ok too. Do it later.
+
+#### Files inside your project's `database` directory
+
+You have the same directory in your package, just move them there. 
+
+That means:
+- `database/migrations`
+- `database/seeds` or `database/seeders`
+- `database/factories`
+
+
+#### Files inside your project's `resources\views` directory
+
+You have the same directory in your package, just move them there. Views moved in your package folder will be automatically available in the `vendor-name.package-name` namespace, so you can load them using `view('vendor-name.package-name::path.to.file')`.
+
+For views that need to be changed by the user upon installation, and cannot be moved to the package (for example, menu items inside `sidebar_content.blade.php`), add the changes the user needs to do inside your package's `readme.md` file, under Installation.
+
+#### Files inside your project's `resources\lang` directory
+
+If your package won't support translations yet, just skip this.
+
+If it will, notice you already have a lang file created for English, in your package - `/packages/vendor-name/package-name/resources/lang/en/package-name.php`. Populate that file with the language lines you need, by cutting&pasting from your project. They'll be available as `lang('vendor-name.package-name::package-name.line_key')` so you need to also find&replace your old keys with the new ones.
+
+#### Files inside your project's `routes` directory
+
+If your package only adds a view (ex: a field, a column, a filter, a widget) then it probably wont't need a route, you can just delete the entire `routes` directory in your package.
+
+If you package _does_ need routes (like when it provides an entire CRUD), you'll find there's already a file in your `/packages/vendor-name/package-name/route/package-name.php`, waiting for your routes, with a few helpful comments. Just cut&paste the routes from your project inside that file.
+
+#### Helper functions inside your project's `bootstrap\helpers.php` file
+
+If you've added any functions there that you need inside the package, you'll notice there's already a `/packages/vendor-name/package-name/bootstrap/helpers.php` file waiting for you. Cut&paste them there.
+
+If your package does not any extra need helper functions, just delete the entire `bootstrap` directory in the package.
+
+<a name="test-that-it-works"></a>
+### Step 4. Test that the package works
+
+That's pretty much it. You've created your package! 🥳 All the files your package need are inside your package, and the only remaining changes in your project (as reflected by `git status`) should be the minimal changes that users need to do to install your package.
+
+Go ahead and test it in the browser. Make sure the functionality that was working inside your _project_ is still working now that it's inside a _package_. You might have forgotten something - we all do sometimes.
+
+<a name="delete-files-you-dont-need"></a>
+### Step 5. Delete the package files you don't need
+
+Now that you know your package is working, go through the package folder and delete whatever your package isn't actually using: empty directories, empty files, placeholder files. Clean it up a little bit.
+
+
+<a name="customize-markdown-files"></a>
+### Step 6. Customize Markdown Files
+
+Inside your package folder, go through all markdown files and make them your own. At the very least, open the `README.md` file and spend a little time on it, give it some love:
+- write a clear description;
+- add a screenshot if appropriate;
+- write clear installation instructions (step-by-step) for how to use your package;
+- answer any questions users might have about what the package does;
+- link to whatever dependencies or resources your add-on uses, so that they check out their docs instead of bugging you about it;
+
+If you plan to make this package public, take the `README.md` seriously, because it's a HUGE factor in how popular your package can become. If you include clear documentation and screenshots, more people will use your package - guaranteed.
+
+
+<a name="put-the-package-online"></a>
+## Part C. Put The Package Online
+
+
+First, [create a new Github Repository](https://github.com/new) for it. Remember to use the same name you defined in your package's ```composer.json```. If in doubt, double-check.
+
+Second, add that new Github Repo as a remote, and push your code to your new Github repo.
+
+```bash
+# save your working files to Git
+git add .
+git commit -am "working code for v1.0.0"
+
+# add the remote to Github 
+git remote add origin git@github.com:yourusername/yourrepository.git
+git branch -M main
+git push -u origin main
+git tag -a 1.0.0 -m 'First version'
+git push --tags
+```
+
+The tags are the way you will version your package, so it's important you do it.
+
+
+<a name="make-the-package-public"></a>
+## Part D. Make the package public (on Packagist)
+
+In order for people to be able to install your package using Composer, your package needs to be registered with [Packagist.org](https://packagist.org/), Composer's free package registry.
+
+On [Packagist.org](https://packagist.org/), submit a new package. Enter your package's GitHub URL and click Check. If any errors occur, follow the onscreen instructions. When you're done, you're taken to your package's packagist page.
+
+**Congrats, you have a working package online**, you can now install it using Composer.
+
+Note: On the package page, you might get a notice like this: _This package is not auto-updated. Please set up the [GitHub Service Hook](https://packagist.org/profile/) for Packagist so that it gets updated whenever you push!_ Let's take care of that. Click that link, get your API token and go to your package's GitHub page, in Settings / Webhooks & Services / Add a new service. Search for Packagist. Enter your username and the token and hit Submit. Your error in Packagist should disappear in 5–10 minutes.
+
+
+<a name="install-the-repo-from-github"></a>
+## Part E. Install the repo from Github 
+
+If you look close to your project's `composer.json` file, you'll notice your project is loading the package from `packages/vendor-name/package-name`. Which is fine, it's worked fine until now. But it's now time to install the package like your users will, and have it in `vendor/vendor-name/package-name`. That way:
+- you test that your users are able to install the package;
+- you don't commit anything extra inside your project;
+- you can _easily_ make changes to your package, from whatever project you're using it in;
+
+To do that, go ahead and do this to uninstall your package from your project:
+```bash
+cd ../../.. # so that you're inside your project, not package
+
+# discard the changes in your composer files
+# and delete the files from packages/vendor-name/package-name
+php artisan packager:remove vendor-name package-name
+```
+
+And now install it exactly the same as your users will:
+- if it's closed-source, add the Github repo to your `composer.json` then move on to the next step; do NOT do this if your package is open-source:
+
+```json
+    "repositories": {
+        "vendor-name/package-name": {
+            "type": "vcs",
+            "url": "https://github.com/vendor-name/package-name"
+        }
+    }
+```
+
+- both for closed-source and open-source (on Packagist), install it using Composer's `--prefer-source` flag, so that it pulls the actual Github repo:
+
+```bash
+composer require vendor-name/package-name --prefer-source
+```
+
+That's it. It should be working fine now, but from the `vendor/vendor-name/package-name` directory. You can `cd vendor/vendor-name/package-name` and you'll see that you can `git checkout master`, make changes, tag releases, push to github, everything.
+
+
+<a name="feedback-and-promotion"></a>
+### Feedback and Promotion
+
+Congratulations on your new Backpack addon! 
+
+To get feedback, ask people to try it on:
+- [our addons repo](https://github.com/laravel-backpack/addons)
+- [our subredddit](https://www.reddit.com/r/BackpackForLaravel/)
+- [our Gitter chatroom](https://gitter.im/BackpackForLaravel/Lobby)
+
+Make sure you write something nice, so people are interested to click.
+
+After you've got some feedback, and a few users have installed your package and everything seems fine, time to promote it big time:
+- post it to [laravel-news.com/links](https://laravel-news.com/links)
+- show it off in the [Laracasts forum](https://laracasts.com/discuss)
+- ask people to try it in [laravel.io](https://laravel.io/forum)

--- a/5.x-dev/add-ons-tutorial.md
+++ b/5.x-dev/add-ons-tutorial.md
@@ -1,0 +1,232 @@
+# How to Create a Backpack Add-on
+
+---
+
+
+### Intro
+
+So you've created a custom field, column, filter, or an entire CRUD. Great! If you want to re-use it across projects, or you think _other people_ would like to use it too, there's a good way to do that. 
+
+The process below will involve creating a new package on Github, Composer & Packagist - which is a little challenging to wrap your head around, the first time you do it. But if you were able to create a custom field, you will be able to do that too. And in doing this, you'll learn the basics of creating and maintaining a PHP package. That's something that not all PHP developers can do, so it's pretty cool, I think. 
+
+> If you already know how to create & maintain a PHP package, this tutorial might be too easy for you. Try to skim it, because we give useful tips. But you can also just go to [:DigitallyHappy/toggle-field-for-backpack](https://github.com/DigitallyHappy/toggle-field-for-backpack), clone the repo and make the changes you see fit.
+
+Requirements:
+- a working installation of Laravel & Backpack 4 (alternative: you can install the [Backpack demo](https://github.com/laravel-backpack/demo));
+- a Github account (free or paid);
+- 15-30 minutes;
+
+
+<a name="scope-and-constants"></a>
+## Step 0. Scope and Constants
+
+**Decide what your package is going to do.** Try to keep the package as small as possible. If you're trying to share multiple fields/columns/etc, we recommend you create a different package for each field type. This will make it:
+- easier for you to communicate what the package does;
+- easier for you to maintain a field type (or abandon it);
+- more likely for people to install & use your package;
+
+In the tutorial below, we'll assume you're trying to share one custom field - ```dummy.blade.php```. But the process will be the same no matter what you're building, starting from the skeletons packages below.
+
+Once you know what you're building, there are a few constants which you need to decide upon. Names that once you've chosen, it will be _possible_, but _very difficult_ to change:
+
+**Package Name.** Try to find a name that is as explicit as possible. So that users, just by reading the name, will pretty much understand what the package does. Also, try to include "_for Backpack_" - that way it will stand out to developers who use Backpack (your target audience). 
+- Good Examples: ```json-editor-field-for-backpack```, ```user-column-for-backpack```, ```users-crud-for-backpack```;
+- Bad Examples: ```custom-field``` (too general), ```cbf``` (too cryptic), ```aurora``` (this is not the place to be creative :smile: );
+Since in this example we're trying to build a package for the new ```dummy``` field type, we'll choose ```dummy-field-for-backpack``` as the package name.
+
+**Vendor Name.** You noticed how every time you install a composer package, it's ```composer install something/package-name```? Well that's what that "something" is - the _vendor name_. It's usually the name of the company or person behind the project. The easiest to remember would be your github username, or your company's github username. But, if you're not happy with those, you _can_ choose a different vendor name - basically a brand name, under which you build packages. This could be the place to be creative :smile:, if you don't have a company name already. In the example below we'll use ```company-name```.
+
+**Class Namespace.** When people reference your package's classes, this is what they see first. It's a good practice to use VendorName/PackageName as the namespace for your package. But notice it's no longer kebab-case (using dashes - ```my-company/dummy-field-for-backpack```), it is PascalCase (```MyCompany/DummyFieldForBackpack```).
+
+
+<a name="fork-the-skeleton-package"></a>
+## Step 1. Clone the skeleton package
+
+To get your package online ASAP, we've prepared a few "skeleton" packages, that you can fork and modify:
+- [:DigitallyHappy/toggle-field-for-backpack](https://github.com/DigitallyHappy/toggle-field-for-backpack) - field add-on example;
+- TODO - column add-on example;
+- TODO - filter add-on example;
+- TODO - button add-on example;
+- TODO - CRUD add-on example;
+- TODO - multiple CRUD add-on example;
+- TODO - CRUD with dependencies add-on example;
+
+Pick the skeleton package that's as similar as possible to what you want to build. On its Github page, under if you click the green **Clone or Download** button, you'll get the path to that repo. In your project, let's clone that repo:
+```bash
+# git clone {REPO URL} packages/{VENDOR NAME}/{PACKAGE NAME}
+git clone git@github.com:DigitallyHappy/toggle-field-for-backpack.git packages/my-company/dummy-field-for-backpack
+```
+
+<a name="make-it-your-own"></a>
+## Step 2. Make it your own
+
+Take a look at the files you've copied - it's a very simple package. In you package's root folder we have:
+- ```README.md``` - your package's "home page" on Github; this should hold all the information needed to use your package;
+- ```composer.json``` - configuration file that tells Composer (the PHP package installer) more about your package;
+- ```CHANGELOG.md``` - where you should write every time you make changes to the field; 
+- ```LICENSE.md``` - so that people know how they're allowed to use your package (MIT is the default); 
+
+Take a look at all of them and modify to fit your needs. It should be faster to modify by hand, and pretty intuitive. But, if it's the first time you create a PHP package, you can use the process below, to make sure you don't mess up anything, since making a casing mistake somewhere (```my-vendor``` instead of ```MyVendor```) could take you very long to debug:
+- **namespace**  - find ```DigitallyHappy\ToggleFieldForBackpack``` and replace with your _VendorName\PackageName_ (ex: ```MyCompany\DummyFieldForBackpack```);
+- **escaped namespace**  - find ```DigitallyHappy\\ToggleFieldForBackpack``` and replace with your _VendorName\\PackageName_ (ex: ```MyCompany\\DummyFieldForBackpack```);
+- **vendor and package name** - find ```digitallyhappy/toggle-field-for-backpack``` and replace with your _vendor-name/package-name_ (ex: ```my-company/dummy-field-for-backpack```);
+- **package name** - find ```toggle-field-for-backpack``` and replace with your _package-name_ (ex: ```dummy-field-for-backpack```);
+- **vendor name** - find ```digitallyhappy``` and replace with your _vendor-name_ (ex: ```my-company```);
+- **author name** - find ```Cristian Tabacitu``` and replace with your name (ex: ```John Doe```);
+- **author email** - find ```hello@tabacitu.ro``` and replace with your email (ex: ```john@example.com```);
+- **author website** - find ```https://tabacitu.ro``` and replace with your website or Github page (ex: ```http://example.com```);
+- open ```changelog.md``` and keep only the 1.0.0 version; put today's date;
+- open ```composer.json``` and change the description of your package;
+- open ```readme.md``` and change the text to better describe _your_ package; don't worry about the screenshot, we'll change that one in a future step;
+
+In ```/src/``` you'll find your service provider, which does one thing: it loads the views in your ```src/resources/views``` under the ```dummy-field-for-backpack``` view namespace. So that anybody who installs your package can use a view that your package includes, by referencing ```dummy-field-for-backpack::path.to.view```.
+
+Also in ```/src/``` you'll notice ```src/resources/views/fields/toggle.blade.php```. This is the example field, which you can rename and use to start coding you field. Or if you already have your field ready, you can just delete this file, and copy-paste the finished blade file from your project
+
+<a name="step-3-put-it-on-github"></a>
+## Step 3. Put it on GitHub
+
+```
+# make sure you replace the below with your actual vendor name and package name
+cd packages/my-company/dummy-field-for-backpack/
+git add .
+git commit -m "turned the skeleton package into dummy-field package"
+```
+
+Create [a new GitHub repository](https://github.com/new). Then get the Git URL the same way you did for the Toggle package, from the green "Clone or Download" button. With that Git URL:
+
+```
+# remove the old origin (pointing to the toggle package)
+git remote rm origin
+
+# add a remote pointing to YOUR github repo
+git remote add origin git@github.com:yourusername/yourrepository.git
+
+# refresh the new origin remote everywhere
+git config master.remote origin
+git config master.merge refs/heads/master
+
+# push your code to your github repo
+git push -u origin master
+
+# tag your release as 1.0.0
+git tag -a 1.0.0 -m 'First version'
+
+# push your tags to the Repo - this is very important to Packagist;
+git push --tags
+```
+
+You might not have used git tags until now. Tags are the way you will version your package, so it's important you do it. For every new version, you need to:
+- write your changes inside the ```changelog.md``` file, so people can easily see what's new;
+- tag your release with the proper tag, so that Packagist will know you've pushed a new version;
+
+---
+
+<a name="step-4-put-it-on-packagist"></a>
+## Step 4. Put it on Packagist
+
+On [Packagist.org](http://packagist.org), create an account if you don't have one already, then click "Submit package" in the top-right corner. Enter your package's GitHub URL and click Check. If any errors occur, follow the onscreen instructions.
+
+When you're done, you'll be taken to your packagist page, where you'll probably get a notice like this:
+
+>This package is not auto-updated. Please set up the [GitHub Service Hook](https://packagist.org/profile/) for Packagist so that it gets updated whenever you push!
+
+Let's take care of that. Click [that link](https://packagist.org/profile/), click "Show API Token", copy it and go to _your package's GitHub page_, in ```Settings / Webhooks & Services / Add a new service```. Search for Packagist. Enter your username and the token and hit Submit. Your error in Packagist should disappear in 5–10 minutes.
+
+Congrats! You now have a working package online. You can now require it with composer.
+
+
+---
+
+<a name="step-5-install-it"></a>
+## Step 5. Install it
+
+Since your package is now online, you can now install it using composer.
+
+```bash
+# go to the root of you Laravel app
+cd ../../..
+
+# delete the folder from packages
+rm -r packages
+
+composer require my-company/dummy-field-for-backpack --prefer-source
+```
+
+Notice we've installed it using the ```prefer-source``` flag. This will actually _clone the git repo_ inside your ```vendor/myvendor/mypackage``` directory. So you can do: 
+
+```bash
+cd /vendor/my-company/dummy-field-for-backpack
+git checkout master
+```
+
+**That's it. Your package is online and installable!** You have most of the knowledge needed to build and maintain a PHP package.
+
+
+<a name="step-6-double-and-triple-check"></a>
+## Step 6. Double-check, then triple-check
+
+### Are you sure it's working?
+After your package is online and ready to use, double-check that it's working well. Then triple-check. 
+
+### Your README is your home page
+Afterwards go to your README file again, and make sure it's the best it can be. Remember, your README file is the first thing people see when they find your package. If it's not appealing, they won't use it. If it doesn't do a good job of explaining how to use it, they won't use it. Take this seriously. This is where A LOT of packages go wrong - the authors do not spend the right amount of time on their README page.
+
+IMPORTANT. Make sure your README has a nice screenshot of the functionality you're offering. The easier it is for a developer to see the benefit of using your package, the more likely it is for them to install it. There's a trick in uploading images to Github, then using them in your README file. Go to your package's Github page, and add an issue. In that issue's body, drag&drop the screenshot image. Github will upload it, and give it an URL. Copy-paste that URL, submit the issue (you can also already close the issue), then use that image URL inside your README file. Boom! Free image hosting.
+
+By now you should have made some changes to your files, inside your ```vendor/my-company/dummy-field-for-backpack``` directory.
+
+After each change you want to publish, you should:
+1. Write about that change in your ```CHANGELOG.md``` file. Increment the version sticking to SEMVER.
+
+2. Commit and push your changes, remembering to also create a new tag with the version. 
+```bash
+git pull origin master
+git add .
+git commit -am "fixes #14189 - some problem or feature with an id from Github"
+git tag 1.0.1
+git push origin master --tags
+```
+
+<a name="step-7-feedback-and-promotion"></a>
+## Step 7. Feedback and Promotion
+
+Congratulations on your new Backpack addon! 
+
+To get feedback, ask people to try it on:
+- [our subredddit](https://www.reddit.com/r/BackpackForLaravel/)
+- [our Gitter chatroom](https://gitter.im/BackpackForLaravel/Lobby)
+
+Make sure you write something nice, so people are interested to click.
+
+After you've got some feedback, and a few users have installed your package and everything seems fine, time to promote it big time:
+- post it to [laravel-news.com/links](https://laravel-news.com/links)
+- show it off in the [Laracasts forum](https://laracasts.com/discuss)
+- ask people to try it in [laravel.io](https://laravel.io/forum)
+
+
+## Extra Credits
+
+If you're building a bigger package, with one CRUD or more, we recommend you follow the simple folder structure we use across all Backpack packages. Our rule of thumb: **organize your ```src``` folder like it were a Laravel application**. We do this because it's easier for developers to understand how the package works, and it makes it easy to copy-paste the code inside their apps and modify, for complicated use cases. That way, add-ons can be kept super-simple, with everybody adding functionality _in their own apps_. Example folder structure:
+- [src]
+    - [app]
+      - [Http]
+      - [Models]
+      - [Requests]
+    - [database]
+      - [migrations]
+      - [seeds]
+    - [routes]
+    - AddonServiceProvider.php
+- [tests]
+- composer.json
+- CHANGELOG.md
+- LICENSE.md
+- README.md
+
+For extra reading credits, these are the resources we've used to create this guide:
+- https://laravel.com/docs/packages
+- https://laracasts.com/discuss/channels/tips/developing-your-packages-in-laravel-5
+- https://github.com/jaiwalker/setup-laravel5-package
+- https://github.com/Jeroen-G/laravel-packager
+- https://laracasts.com/lessons/package-development-101

--- a/5.x-dev/base-about.md
+++ b/5.x-dev/base-about.md
@@ -1,0 +1,219 @@
+# About Backpack's User Interface
+
+---
+
+Backpack helps you build admin panels faster by:
+- installing our custom HTML theme, [Backstrap](https://backstrap.net), based on Bootstrap 4 and [CoreUI](https://coreui.io);
+- installing [sweetalert](https://sweetalert.js.org/) for triggering pretty Confirm modals;
+- installing [noty](https://ned.im/noty/#/) to show notification bubbles upon error/success/warning/info - triggered from Javascript;
+- installing [prologue/alerts](https://github.com/prologuephp/alerts) for triggering notification bubbles from PHP (both on the same page and using flashdata);
+- providing a separate authentication system for your admins;
+- providing pretty error pages for most common errors;
+- providing a horizontal menu and a side menu you can customize;
+- providing a place for your admin to to change his email/name/password;
+- providing a few helpers you can use throughout your admin panel;
+
+For the simplest projects, you will never need to know how it works, never need to customize anything but the ```config/backpack/base.php``` file. But here's how everything works, below.
+
+<a name="layout-and-design"></a>
+## Layout & Design
+
+<a name="general"></a>
+### General
+
+Backpack pulls in our custom HTML template, [Backstrap](https://www.npmjs.com/package/@digitallyhappy/backstrap), and adds our own CSS file on top, for a few cosmetic improvements. We've chosen to base Backstrap on [CoreUI](https://coreui.io), because it provides design blocks for all common features of an administration panel. When you decide to build custom pages for your Admin Panel, you can just use Backstrap's HTML blocks - no designer needed. You can see all the HTML components Backstrap provides on [backstrap.net](https://backstrap.net), and copy-paste HTML from there, or use [CoreUI](https://coreui.io)'s documentation for details.
+
+<a name="published-views"></a>
+### New Files in Your App
+
+After installation, you'll notice Backpack has added a few files:
+
+**1) View to ```resources/views/vendor/backpack/base/inc/sidebar_content.blade.php```**
+
+This  file is used to show the contents of the menu to the left (sidebar). It's been published there so that you can easily modify its contents, by editing its HTML.
+
+**2) Middleware to ```app/Http/Middleware/CheckIfAdmin.php```**
+
+This middleware is used to test if users have access to admin panel pages. You can (and should customize it) if you have both users and admins in your app.
+
+**3) Route file to ```routes/backpack/custom.php```**
+    
+This route file is for convenience and convention. We recommend you place all your admin panel routes here.
+
+
+<a name="published-views"></a>
+### Published Views
+
+After installation, you'll notice Backpack has added a new blade file in ```resources/views/vendor/backpack/base/```:
+    - ```inc/sidebar_content.blade.php```;
+
+That file is used to show the contents of the menu to the left (sidebar). It's been published there so that you can easily modify its contents, by editing its HTML or adding dynamic content through [widgets](/docs/{{version}}/base-widgets).
+
+<a name="unpublished-views"></a>
+### Unpublished Views
+
+You can change any blade file to your own needs. Determine what file you'd need to modify if you were to edit directly in the project's vendor folder, then go to ```resources/views/vendor/backpack/base``` and create a file with the exact same name. Backpack\Base will use this new file, instead of the one in the package. 
+
+For example:
+- if you want to add an item to the top menu, you could just create a file called ```resources/views/vendor/backpack/base/inc/topbar_left_content.blade.php```; Backpack will now use this file's contents, instead of  ```vendor/backpack/base/src/resources/views/inc/topbar_left_content.php```;
+- if you want to change the contents of the dashboard page, you can just create a file called `resources/views/vendor/backpack/base/dashboard.blade.php` and Backpack will use that one, instead of the one in the package;
+
+You can create blade views from scratch, or you can use our command to publish the view from the package and edit it to your liking:
+```
+php artisan backpack:publish base/dashboard
+```
+
+Then inside the blade files, you can use either plain-old HTML or add dynamic content through [Backpack widgets](/docs/{{version}}/base-widgets).
+
+<a name="folder-structure"></a>
+### Folder Structure
+
+If you'll take a look inside any Backpack package, you'll notice the ```src``` directory is organised like a standard Laravel app. This is intentional. It should help you easily understand how the package works, and how you can overwrite/customize its functionality.
+
+- ```app```
+  - ```Console```
+    - ```Commands```
+  - ```Http```
+    - ```Controllers```
+    - ```Middleware```
+    - ```Requests```
+  - ```Notifications```
+- ```config```
+- ```resources```
+  - ```lang```
+  - ```views```
+- ```routes```
+
+<a name="authentication"></a>
+## Authentication
+
+When installed, Backpack provides a way for admins to login, recover password and register (don't worry, register is only enabled on ```localhost```). It does so with its own authentication controllers, models and middleware. If you have regular end-users (not admins), you can keep the _user_ authentication completely separate from _admin_ authentication. You can change which model, middleware classes Backpack uses, inside the ```config/backpack/base.php``` config file.
+
+> **Backpack uses Laravel's default ```App\User``` model**. This assumes you weren't already using this model, or the ```users``` table, for anything else. Or that you plan to use it for both users & admins. Otherwise, please read below.
+
+<a name="using-a-different-user-model"></a>
+### Using a Different User Model
+
+If you want to use a different User model than ```App\User``` or you've changed its location, please, you can tell Backpack to use _a different_ model in ```config/backpack/base.php``` instead of the ```App\User``` model that Laravel apps usually have. Look for ```user_model_fqn```.
+
+
+<a name="having-both-regular-users-and-admins"></a>
+### Having Both Regular Users and Admins
+
+If you already use the ```users``` table to store end-users (not admins), you will need a way to differentiate admins from regular users. Backpack does not force one method on you. Here are two methods we recommend, below:
+- (A) adding an ```is_admin``` column to your ```users``` table, then changing the ```app/Http/Middleware/CheckIfAdmin::checkIfUserIsAdmin()``` method to test that attribute exists, and is true;
+- (B) using the [PermissionManager](https://github.com/Laravel-Backpack/PermissionManager) extension - this will also add groups and permissions; Then tell Backpack to use _your new permission middleware_ to check if a logged in user is an admin, inside ```config/backpack/base.php```;
+
+<a name="routes"></a>
+### Routes
+
+By default, all administration panel routes will be behind an ```/admin/``` prefix, and under an ```CheckIfAdmin``` middleware. You can change that inside ```config/backpack/base.php```. 
+
+Inside your _admin controllers or views_, please:
+- use ```backpack_auth()``` instead of ```auth()```;
+- use ```backpack_user()``` instead of ```auth()->user```;
+- use ```backpack_url()``` instead of ```url()```;
+
+This will make sure you're using the model, prefix & middleware that you've defined in ```config/backpack/base.php```. In case you decide to make changes there later, you won't need to change anything else. There are also [other backpack helpers you can use](#helpers).
+
+<a name="admin-account"></a>
+## Admin Account
+
+When logged in, the admin can click his/her name to go to his "account" page. There, they will be able to do a few basic operations: change name, email or password.
+
+<a name="change-name-and-email"></a>
+### Change Name and Email
+
+Changing name and email is done inside ```Backpack\Base\app\Http\Controllers\Auth\MyAccountController```, using the ```getAccountInfoForm()``` and ```postAccountInfoForm()``` methods. If you want to change how this works, we recommend you create a ```routes/backpack/base.php``` file, copy-paste all Backpack\Base routes there and change whatever routes you need, to point to _your own controller_, where you can do whatever you want.
+
+If you only want to add a few new inputs, you can do that by creating a file in ```resources/views/vendor/backpack/base/my_account.blade.php``` that uses code from the same file in the Backpack package, but adds the inputs you need. Remember to also make these fields ```$fillable``` in your User model.
+
+<a name="change-password"></a>
+### Change Password
+
+Password changing is done inside ```Backpack\Base\app\Http\Controllers\Auth\MyAccountController```. If you want to change how this works, we recommend you create a ```routes/backpack/base.php``` file, copy-paste all Backpack\Base routes there and change whatever you need. You can then point the route to your own controller, where you can do whatever you want.
+
+
+<a name="helpers"></a>
+## Helpers
+
+You can use these helpers anywhere in your app (models, views, controllers, requests, etc), except the config files, since the config files are loaded _before_ the helpers.
+
+- **```backpack_url($path)```** - Use this helper instead of ```url()``` to generate paths with the admin prefix prepended.
+- **```backpack_auth()```** - Returns the Auth facade, using the current Backpack guard. Basically a shorthand for ```\Auth::guard(backpack_guard_name())```. Use this instead of ```auth()``` inside your admin panel pages.
+- **```backpack_middleware()```** - Returns the key for the admin middleware. Default is ```admin```.
+- ```backpack_authentication_column()``` - Returns the username column. The Laravel and Backpack default is ```email```.
+- ```backpack_users_have_email()``` - Tests that the ```email``` column exists on the users table and returns true/false.
+- ```backpack_avatar($user)``` - Receives a user object and returns a path to an avatar image, according to the preferences in the config file (gravatar, placeholder or custom).
+- ```backpack_guard_name()``` - Returns the guard used for Backpack authentication.
+- ```backpack_user()``` - Returns the current Backpack user, if logged in. Basically a shorthand for ```\Auth::guard(backpack_guard_name())->user()```. Use this instead of ```auth()->user()``` inside your admin pages.
+
+<a name="error-pages"></a>
+## Error Pages
+
+When installing Backpack, a few error views are published into ```resources/views/errors```, if you don't already have other files there. This is because Laravel does not provide error pages for all HTTP error codes. Having these files in your project will make sure that, if a user gets an HTTP error, at least it will look decent. Error pages are provided for the following error codes: ```400```, ```401```, ```403```, ```404```, ```405```, ```408```, ```429```, ```500```, ```503```.
+
+
+<a name="custom-pages"></a>
+## Custom Pages
+
+To create a new page for your admin panel, you can follow the same process you would if you created a normal Laravel page (a Route, View and maybe a Controller). Just make sure that:
+- the route file is under the `admin` middleware;
+- the view extends one of our layout files (so that you get the design and the topbar+sidebar layout;
+
+### Add a custom page to your admin panel (dynamic page)
+
+```php
+
+# Step 1. Create a route for it (we recommend you place it in your `routes/backpack/custom.php` for simplicity)
+
+Route::get('example-page', 'PageController@example');
+
+# Step 2. Create the controller (we recommend you place it in your `app/Http/Controllers/Admin`)
+
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+
+class PageController extends Controller
+{
+    public function example()
+    {
+        $data['something'] = 'Something';
+        
+        return view('admin.example_page', $data);
+    }
+}
+
+# Step 3. Create the view (we recommend you place it in your `resources/views/admin`:
+
+@extends(backpack_view('blank'))
+
+@section('content')
+    <h1>Example page</h1>
+@endsection
+```
+
+### Add a custom page to your admin panel (static page)
+
+Alternatively, if you are not getting any information from the database, and are just creating a quick static page, here's a quicker way:
+
+
+```php
+
+# Step 1. Create a route for it (we recommend you place it in your `routes/backpack/custom.php` for simplicity)
+
+Route::get('example-page', function () { return view('admin.example_page'); });
+
+# Step 2. Create that view (we recommend you place it in your `resources/views/admin`:
+
+@extends(backpack_view('blank'))
+
+@section('content')
+    <h1>Example page</h1>
+@endsection
+
+```
+

--- a/5.x-dev/base-alerts.md
+++ b/5.x-dev/base-alerts.md
@@ -1,0 +1,63 @@
+# Alerts
+
+---
+
+<a name="about"></a>
+## About
+
+When building custom functionality, you'll probably need to give feedback to the admin for something that happened in the background. You can easily do that in Backpack by triggering alerts (aka notification bubbles, aka notifications). You can do that both from Javascript and from PHP - and they will look exactly the same. In fact, Backpack operations use this same API. By using Alerts in your custom pages too, you make sure your alerts look the same across your admin panel - and your UI will be consistent.
+
+
+<a name="notification-bubbles-in-php"></a>
+### Triggering Alerts in PHP
+
+We use [prologue/alerts](https://github.com/prologuephp/alerts#adding-alerts-through-alert-levels) to trigger notifications. Check out its documentation for the entire syntax. 
+
+Most of the time, all you need to do is trigger a notification of a certain type, or trigger a notification using flash data, so that it shows after a redirect:
+
+```php
+public function foo() 
+{
+  \Alert::add('info', 'This is a blue bubble.');
+  \Alert::add('warning', 'This is a yellow/orange bubble.');
+  \Alert::add('error', 'This is a red bubble.');
+  \Alert::add('success', '<strong>Got it</strong><br>This is HTML in a green bubble.');
+  \Alert::add('primary', 'This is a dark blue bubble.');
+  \Alert::add('secondary', 'This is a grey bubble.');
+  \Alert::add('light', 'This is a light grey bubble.');
+  \Alert::add('dark', 'This is a black bubble.');
+  
+  // the layout will make sure to show your notifications
+  return view('some_view');
+}
+
+public function bar()
+{
+  \Alert::add('success', 'You have successfully logged in')->flash();
+ 
+  // please note the above flash() method; this will store your notification in a session variable, so that you can redirect to another page, but the notification will still be shown (on the page you redirect to)
+  return Redirect::to('some-url');
+}
+```
+
+<a name="notification-bubbles-in-javascript"></a>
+### Triggering Alerts in JavaScript
+
+We use [Noty](https://ned.im/noty/#/) to show notifications from JavaScript, on the same page. Check out its docs for detailed use. Most of the time you'll only need to do:
+
+```php
+new Noty({
+    type: "success",
+    text: 'Some notification text',
+}).show();
+
+// available types: 
+// - success
+// - info
+// - warning/notice
+// - error/danger
+// - primary
+// - secondary
+// - dark
+// - light
+```

--- a/5.x-dev/base-breadcrumbs.md
+++ b/5.x-dev/base-breadcrumbs.md
@@ -1,0 +1,89 @@
+# Breadcrumbs
+
+---
+
+<a name="about"></a>
+## About
+
+Breadcrumbs show a path to the current page in the top-right corner of the screen, and can be a useful part of the UI for deeply nested admin panels.
+
+Breadcrumbs are loaded in the default layout _before_ the ```header``` section. 
+
+<a name="enable-disable-breadcrumbs"></a>
+## Enable / Disable Breadcrumbs
+
+You can hide or show breadcrumbs on ALL of your admin panel pages by changing a boolean variable in your ```config/backpack/base.php```:
+
+```php
+    // Show / hide breadcrumbs on admin panel pages.
+    'breadcrumbs' => true,
+```
+
+<a name="how-breadcrumbs-work"></a>
+## How Breadcrumbs Work
+
+The ```inc.breadcrumbs``` view will show all breadcrumbs from the ```$breadcrumbs``` variable, if it's present on the page. The ```$breadcrumbs``` variable should be a simple associative array ```[ $label1 => $link1, $label2 => $link2 ]```. Examples:
+
+```php
+  $breadcrumbs = [
+      trans('backpack::crud.admin') => backpack_url('dashboard'),
+      trans('backpack::base.dashboard') => false,
+  ];
+  
+  $breadcrumbs = [
+      trans('backpack::crud.admin') => backpack_url('dashboard'),
+      trans('backpack::base.dashboard') => false,
+  ];
+  
+  $breadcrumbs = [
+      'Admin' => route('dashboard'),
+      'Dashboard' => false,
+  ];
+```
+
+Notice the last item should NOT have a link, it should be ```false```.
+
+<a name="how-to-define-breadcrumbs"></a>
+## How to Define Breadcrumbs
+
+<a href="define-breadcrumbs-in-the-controller"></a>
+### Define Breadcrumbs Inside the Controller
+
+Make sure a ```$breadcrumbs``` variable is present inside your views:
+```php
+    /**
+     * Show the admin dashboard.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function dashboard()
+    {
+        $this->data['title'] = trans('backpack::base.dashboard'); // set the page title
+        $this->data['breadcrumbs'] = [
+            trans('backpack::crud.admin') => backpack_url('dashboard'),
+            trans('backpack::base.dashboard') => false,
+        ];
+
+        return view('backpack::dashboard', $this->data);
+    }
+```
+
+<a href="define-breadcrumbs-in-the-view"></a>
+### Define Breadcrumbs Inside the View
+
+Make sure a ```$breadcrumbs``` variable is present:
+
+```php
+@extends('backpack::layout')
+
+@php
+  $breadcrumbs = [
+      'Admin' => backpack_url('dashboard'),
+      'Dashboard' => false,
+  ];
+@endphp
+
+@section('content')
+    some other content here
+@endsection
+```

--- a/5.x-dev/base-how-to.md
+++ b/5.x-dev/base-how-to.md
@@ -1,0 +1,637 @@
+# FAQs for the admin UI
+
+---
+
+
+<a name="look-and-feel"></a>
+## Look and feel
+
+<a name="customize-menu-or-sidebar"></a>
+### Customize the menu or sidebar
+
+During installation, Backpack publishes a few files in you ```resources/views/vendor/backpack/base/inc``` folder. In there, you'll also find:
+- ```sidebar_content.php```
+- ```topbar_left_content.php```
+- ```topbar_right_content.php```
+
+Change those files as you please.
+
+<a name="customize-dashboard"></a>
+### Customize the dashboard
+
+The dashboard is shown from ```Backpack\Base\app\Http\Controller\AdminController.php::dashboard()```. If you take a look at that method, you'll see that the only thing it does is to set a title, breadcrumbs, and return a view: ```backpack::dashboard```.
+
+In order to place something else inside that view, like [widgets](/docs/{{version}}/base-widgets), simply publish that view in your project, and Backpack will pick it up, instead of the one in the package. Create a ```resources/views/vendor/backpack/base/dashboard.blade.php``` file:
+
+```html
+@extends(backpack_view('blank'))
+
+@php
+    $widgets['before_content'][] = [
+        'type'        => 'jumbotron',
+        'heading'     => trans('backpack::base.welcome'),
+        'content'     => trans('backpack::base.use_sidebar'),
+        'button_link' => backpack_url('logout'),
+        'button_text' => trans('backpack::base.logout'),
+    ];
+@endphp
+
+@section('content')
+  <p>Your custom HTML can live here</p>
+@endsection
+```
+
+To use information from the database, you can:
+- [use view composers](https://laravel.com/docs/5.7/views#view-composers) to push variables inside this view, when it's loaded;
+- load all your dashboard information using AJAX calls, if you're loading charts, reports, etc, and the DB queries might take a long time;
+- use the full namespace for your models, like ```\App\Models\Product::count()```;
+
+Take a look at the [widgets](/docs/{{version}}/base-widgets) we have - you can easily use those in your dashboard. You can also add whatever HTML you want inside the content block - check the [Backstrap HTML Template](https://backstrap.net/widgets.html) for design components you can copy-paste to speed up your custom HTML.
+
+<a name="customize-general-layout-design"></a>
+### Customizing the design of the menu / sidebar / footer
+
+In ```config/backpack/base.php``` you'll notice there are variables where you can change exactly what CSS classes are placed on the HTML elements that represent the header, body, sidebar and footer:
+
+```php
+    // Horizontal navbar classes. Helps make the admin panel look similar to your project's design.
+    'header_class' => 'app-header bg-light border-0 navbar',
+        // Try adding bg-dark, bg-primary, bg-secondary, bg-danger, bg-warning, bg-success, bg-info, bg-blue, bg-light-blue, bg-indigo, bg-purple, bg-pink, bg-red, bg-orange, bg-yellow, bg-green, bg-teal, bg-cyan
+        // You might need to add "navbar-dark" too if the background color is a dark one.
+        // Add header-fixed if you want the header menu to be sticky
+    
+    // Body element classes.
+    'body_class' => 'app aside-menu-fixed sidebar-lg-show',
+        // Try sidebar-hidden, sidebar-fixed, sidebar-compact, sidebar-lg-show
+    
+
+    // Sidebar element classes.
+    'sidebar_class' => 'sidebar sidebar-pills bg-light',
+        // Remove "sidebar-transparent" for standard sidebar look 
+        // Try "sidebar-light" or "sidebar-dark" for dark/light links
+        // You can also add a background class like bg-dark, bg-primary, bg-secondary, bg-danger, bg-warning, bg-success, bg-info, bg-blue, bg-light-blue, bg-indigo, bg-purple, bg-pink, bg-red, bg-orange, bg-yellow, bg-green, bg-teal, bg-cyan
+
+    // Footer element classes.
+    'footer_class' => 'app-footer',
+```
+
+Our default design might not be pleasant for your, or you might need to make the UI integrate better into your project. We totally understand. You can use the classes above to make it look considerably different.
+
+You'll find a few examples below - but you should use which classes you want to get the result you need.
+
+<a href="ui-with-dark-sidebar"></a>
+#### Backstrap
+
+Transparent top menu, transparent sidebar, transparent footer. This is the default. This is what _we_ think is best for most users, from our 8+ years of experience building admin panels. Prioritising _content_ over _menus_.
+
+![Backstrap design](https://backpackforlaravel.com/uploads/docs-4-0/ui/examples/default.png)
+
+```php
+    'header_class' => 'app-header bg-light border-0 navbar',
+    'body_class' => 'app aside-menu-fixed sidebar-lg-show',
+    'sidebar_class' => 'sidebar sidebar-pills bg-light',
+    'footer_class' => 'app-footer',
+```
+
+<a href="inspired-by-coreui"></a>
+#### Inspired by CoreUI
+
+White top menu, dark sidebar.
+
+![CoreUI design](https://backpackforlaravel.com/uploads/docs-4-0/ui/examples/coreui.png)
+
+```php
+    'header_class' => 'app-header navbar',
+    'body_class' => 'app aside-menu-fixed sidebar-lg-show',
+    'sidebar_class' => 'sidebar',
+    'footer_class' => 'app-footer d-none',
+```
+
+<a href="inspired-by-github"></a>
+#### Inspired by Github
+
+Black top menu, white sidebar.
+
+![CoreUI design](https://backpackforlaravel.com/uploads/docs-4-0/ui/examples/github.png)
+
+```php
+    'header_class' => 'app-header bg-dark navbar',
+    'body_class' => 'app aside-menu-fixed sidebar-lg-show',
+    'sidebar_class' => 'sidebar bg-white sidebar-pills',
+    'footer_class' => 'app-footer d-none',
+```
+
+<a href="blue-top-menu"></a>
+#### Blue Top Menu
+
+Blue top menu, dark sidebar.
+
+![Construction or warning design](https://backpackforlaravel.com/uploads/docs-4-0/ui/examples/blue.png)
+
+```php
+    'header_class' => 'app-header navbar navbar-color bg-primary border-0',
+    'body_class' => 'app aside-menu-fixed sidebar-lg-show',
+    'sidebar_class' => 'sidebar', // add "bg-white sidebar-pills" for light sidebar
+    'footer_class' => 'app-footer d-none',
+```
+
+
+<a href="inspired-by-contruction"></a>
+#### Construction / Warning
+
+Yellow top menu, dark sidebar.
+
+![Construction or warning design](https://backpackforlaravel.com/uploads/docs-4-0/ui/examples/construction.png)
+
+```php
+    'header_class' => 'app-header navbar navbar-light bg-warning',
+    'body_class' => 'app aside-menu-fixed sidebar-lg-show',
+    'sidebar_class' => 'sidebar', // add "bg-white sidebar-pills" for light sidebar
+    'footer_class' => 'app-footer d-none',
+```
+
+<a href="red-top-menu"></a>
+#### Red Top Menu
+
+Red top menu, dark sidebar.
+
+![Construction or warning design](https://backpackforlaravel.com/uploads/docs-4-0/ui/examples/red.png)
+
+```php
+    'header_class' => 'app-header navbar navbar-color bg-error border-0',
+    'body_class' => 'app aside-menu-fixed sidebar-lg-show',
+    'sidebar_class' => 'sidebar', // add "bg-white sidebar-pills" for light sidebar
+    'footer_class' => 'app-footer d-none',
+```
+
+<a href="pink-top-menu"></a>
+#### Pink Top Menu
+
+Pink top menu, transparent sidebar.
+
+![Construction or warning design](https://backpackforlaravel.com/uploads/docs-4-0/ui/examples/pink.png)
+
+```php
+    'header_class' => 'app-header navbar navbar-color bg-error border-0',
+    'body_class' => 'app aside-menu-fixed sidebar-lg-show',
+    'sidebar_class' => 'sidebar sidebar-pills bg-light',
+    'footer_class' => 'app-footer d-none',
+```
+
+
+<a href="green-top-menu"></a>
+#### Green Top Menu
+
+Green top menu, white sidebar.
+
+![Construction or warning design](https://backpackforlaravel.com/uploads/docs-4-0/ui/examples/green.png)
+
+```php
+    'header_class' => 'app-header navbar navbar-color bg-green border-0',
+    'body_class' => 'app aside-menu-fixed sidebar-lg-show',
+    'sidebar_class' => 'sidebar sidebar-pills bg-white',
+    'footer_class' => 'app-footer d-none',
+```
+
+
+<a name="change-colors"></a>
+### Change the colors
+
+#### Change primary color from purple to blue
+
+We thought you might want to do this. Purple isn't for everybody. That's why Backpack 4.1.57+ comes with two bundle CSS files: `bundle.css` and `blue-bundle.css`. That second file does exactly what you expect - changes the primary color from electric purple to blue. That's it. In order to use it, go to your `config/backpack/base.php` and use that file instead:
+
+```diff    
+'styles' => [
+-        'packages/backpack/base/css/bundle.css',
++        'packages/backpack/base/css/blue-bundle.css',
+```
+
+That's it. Now go to your browser and refresh, you should see blue buttons and text everywhere, instead of purple.
+
+#### Custom colors for primary, secondary, success, warning etc.
+
+This assumes you have:
+- Backpack 4.1.57+ (check with `php artisan backpack:version`) and its assets published (otherwise run `php artisan vendor:publish --provider="Backpack\CRUD\BackpackServiceProvider" --tag=public --force`);
+- a working Laravel install with NPM and Laravel Mix;
+
+Add Backstrap, Noty and Animate.css as dev-dependencies to your project:
+```
+npm install --dev
+npm i @digitallyhappy/backstrap --save-dev
+npm i noty --save-dev
+npm i animate.css@3.7.2 --save-dev
+```
+
+Then create a SCSS file for that custom bundle you want. We recommend doing it in `resources/scss/custom-backpack-bundle.scss`. Then customize this file to your liking:
+
+```scss
+// create a bundle CSS file for the an alternative Backstrap style (blue instead of purple for primary color)
+
+@import "node_modules/@digitallyhappy/backstrap/src/scss/_backstrap_colors";
+
+$primary:       $black !default; // <--- For eg. This will make all buttons and texts black instead of purple
+$secondary:     $gray-300 !default;
+$success:       $green !default;
+$info:          $blue !default;
+$warning:       $yellow !default;
+$danger:        $red !default;
+$light:         $gray-200 !default;
+$dark:          $black !default;
+
+$hover-color: rgba(105, 171, 239, 0.12);
+$border-color: rgba(0, 40, 100, 0.12);
+$muted-bg-color: rgba(0, 0, 0, 0.02);
+
+$theme-colors: () !default;
+$theme-colors: map-merge(
+  (
+    "primary":    $primary,
+    "default":    $secondary,
+    "secondary":  $secondary,
+    "success":    $success,
+    "info":       $info,
+    "notice":     $info,
+    "warning":    $warning,
+    "danger":     $danger,
+    "error":      $danger,
+    "light":      $light,
+    "dark":       $dark
+  ),
+  $theme-colors
+);
+
+@import "node_modules/@digitallyhappy/backstrap/src/scss/_backstrap_miscellaneous";
+
+@import "node_modules/@coreui/coreui/scss/coreui";
+@import "node_modules/@digitallyhappy/backstrap/src/scss/_custom";
+@import "node_modules/animate.css/source/_base";
+@import "node_modules/noty/src/noty";
+```
+
+Now add the command to your `webpack.mix.js` file to compile this new SASS file:
+
+```js
+// create a custom Backpack bundle CSS, with custom colors
+mix.sass('resources/scss/custom-backpack-bundle.scss', 'public/packages/backpack/base/css/')
+    .options({
+      processCssUrls: false
+    });
+```
+
+And run `npm run dev`. If SASS is not a dev-requirement in your project already, Mix will add it automatically and ask you to run `npm run dev` again. Do that if necessary.
+
+Your result should say "_webpack compiled successfully_". If so, you can now use that new bundle file in all your Backpack pages by going to `config/backpack/base.php` and changing the main bundle CSS file that Backpack uses... with your own:
+
+```diff
+    'styles' => [
+-        'packages/backpack/base/css/bundle.css',
++        'css/custom-backpack-bundle.css',
+```
+
+
+<a name="create-a-new-theme"></a>
+### Create a new theme / child theme
+
+You can create a theme with your own HTML. Create a folder with all the views you want to overwrite, then change ```view_namespace``` inside your ```config/backpack/base.php``` to point to that folder. All views will be loaded from _that_ folder if they exist, then from ```resources/views/vendor/backpack/base```, then from the Base package.
+
+You can use child themes to:
+- create packages for your Backpack admin panels to look different (and re-use across projects)
+- use a different CSS framework (ex: Tailwind, Bulma)
+
+
+<a name="add-custom-javascript"></a>
+### Add custom Javascript to all admin panel pages
+
+In ```config/backpack/base.php``` you'll notice this config option:
+
+```php
+    // JS files that are loaded in all pages, using Laravel's asset() helper
+    'scripts' => [
+        // Backstrap includes jQuery, Bootstrap, CoreUI, PNotify, Popper
+        'packages/backpack/base/js/bundle.js?v='.\PackageVersions\Versions::getVersion('backpack/base'),
+
+        // examples (everything inside the bundle, loaded from CDN)
+        // 'https://code.jquery.com/jquery-3.4.1.min.js',
+        // 'https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js',
+        // 'https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js',
+        // 'https://unpkg.com/@coreui/coreui/dist/js/coreui.min.js',
+        // 'https://cdnjs.cloudflare.com/ajax/libs/pace/1.0.2/pace.min.js',
+        // 'https://unpkg.com/sweetalert/dist/sweetalert.min.js',
+        // 'https://cdnjs.cloudflare.com/ajax/libs/noty/3.1.4/noty.min.js'
+
+        // examples (VueJS or React)
+        // 'https://unpkg.com/vue@2.4.4/dist/vue.min.js',
+        // 'https://unpkg.com/react@16/umd/react.production.min.js',
+        // 'https://unpkg.com/react-dom@16/umd/react-dom.production.min.js',
+    ],
+```
+
+You can add files to this array, and they'll be loaded in all admin panels pages.
+
+<a name="add-custom-css"></a>
+### Add custom CSS to all admin panel pages
+
+In ```config/backpack/base.php``` you'll notice this config option:
+
+```php
+    // CSS files that are loaded in all pages, using Laravel's asset() helper
+    'styles' => [
+        'packages/@digitallyhappy/backstrap/css/style.min.css',
+
+        // Examples (the fonts above, loaded from CDN instead)
+        // 'https://maxcdn.icons8.com/fonts/line-awesome/1.1/css/line-awesome-font-awesome.min.css',
+        // 'https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic',
+    ],
+```
+
+You can add files to this array, and they'll be loaded in all admin panels pages.
+
+<a name="customize-overlays-css"></a>
+### Customize the look and feel of the admin panel (using CSS)
+
+If you want to change the look and feel of the admin panel, you can create a custom CSS file wherever you want. We recommend you do it inside ```public/packages/myname/mycustomthemename/css/style.css``` folder so that it's easier to turn into a theme, if you decide later to share or re-use your CSS in other projects.
+
+In ```config/backpack/base.php``` add your file to this config option:
+
+```php
+    // CSS files that are loaded in all pages, using Laravel's asset() helper
+    'styles' => [
+        'packages/@digitallyhappy/backstrap/css/style.min.css',
+         // ...
+        'packages/myname/mycustomthemename/css/style.css',
+    ],
+```
+
+This config option allows you to add CSS files that add style _on top_ of Backstrap, to make it look different. You can create a CSS file anywhere inside your ```public``` folder, and add it here.
+
+<a name="how-to-add-vue-js-on-all-Backpack-pages"></a>
+### How to add VueJS to all Backpack pages
+
+You can add any script you want inside all Backpack's pages by just adding it in your ```config/backpack/base.php``` file:
+
+```php
+
+    // JS files that are loaded in all pages, using Laravel's asset() helper
+    'scripts' => [
+        // Backstrap includes jQuery, Bootstrap, CoreUI, PNotify, Popper
+        'packages/backpack/base/js/bundle.js',
+
+        // examples (everything inside the bundle, loaded from CDN)
+        // 'https://code.jquery.com/jquery-3.4.1.min.js',
+        // 'https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js',
+        // 'https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js',
+        // 'https://unpkg.com/@coreui/coreui/dist/js/coreui.min.js',
+        // 'https://cdnjs.cloudflare.com/ajax/libs/pace/1.0.2/pace.min.js',
+        // 'https://unpkg.com/sweetalert/dist/sweetalert.min.js',
+        // 'https://cdnjs.cloudflare.com/ajax/libs/noty/3.1.4/noty.min.js'
+
+        // examples (VueJS or React)
+        // 'https://unpkg.com/vue@2.4.4/dist/vue.min.js',
+        // 'https://unpkg.com/react@16/umd/react.production.min.js',
+        // 'https://unpkg.com/react-dom@16/umd/react-dom.production.min.js',
+    ],
+```
+
+You should be able to load Vue.JS by just uncommenting that one line. Or providing a link to a locally stored VueJS file.
+
+
+<a name="customize-translations"></a>
+### Customize the translated strings (aka overwrite the language files)
+
+Backpack uses Laravel translations across the admin panel, to easily translate strings (ex: `{{ trans('backpack::base.already_have_an_account') }}`). If you don't like a translation, you're welcome to submit a PR to correct it for all users of your language. If you only want to correct it inside your app, or need to add a new translation string, you can *create a new file in your `resources/lang/vendor/backpack/en/base.php`* (similarly, `crud.php` or any other file). Any language strings that are inside your app, in the right folder, will be preferred over the ones in the package.
+
+Alternatively, if you need to customize A LOT of strings, you can use: 
+```bash
+php artisan vendor:publish --provider="Backpack\CRUD\BackpackServiceProvider" --tag="lang"
+```
+which will publish ALL lang files, for ALL languages, inside `resources/lang/vendor/backpack`. But it's highly unlikely you need to modify all of them. In case you do publish all languages, please delete the ones you didn't change. That way, you only keep what's custom in your custom files, and it'll be easier to upgrade those files in the future.
+
+
+<a name="use-the-same-html-and-css-for-front-end"></a>
+### Use the HTML & CSS for the front-end (Backstrap for front-facing website)
+
+If you like how Backpack looks and feels you can use the same interface to power your front-end, simply by making sure your blade view extend Backpack's layout file, instead of a layout file you'd create. Make sure your blade views extend `backpack_view('blank')` or create a layout file similar to our `layouts/top_left.blade.php` that better fits your needs. Then use it across your app:
+
+```php
+@extends(backpack_view('blank'))
+
+<div>Something</div>
+```
+
+It's a good idea to go through our main layout file - [`layouts/top_left.blade.php`](https://github.com/Laravel-Backpack/CRUD/blob/master/src/resources/views/base/layouts/top_left.blade.php) - to understand how it works and how you can use it to your advantage. Most notably, you can:
+- use our `before_styles` and `after_styles` sections to easily _include_ CSS there - `@section('after_styles')`;
+- use our `before_styles` and `after_styles` stacks to easily _push_ CSS there - `@push('after_styles')`;
+- use our `before_scripts` and `after_scripts` sections to easily _include_ JS there - `@section('after_scripts')`;
+- use our `before_scripts` and `after_scripts` stacks to easily _push_ JS there - `@push('after_scripts')`;
+
+
+
+<a name="authentication"></a>
+## Authentication
+
+<a name="customize-auth-controllers"></a>
+### Customizing the Auth controllers
+
+In ```config/backpack/base.php``` you'll find these configuration options:
+
+```php
+    // Set this to false if you would like to use your own AuthController and PasswordController
+    // (you then need to setup your auth routes manually in your routes.php file)
+    'setup_auth_routes' => true,
+```
+
+You can change both ```setup_auth_routes``` to ```false```. This means Backpack\Base won't register the Auth routes any more, so you'll have to manually register them in your route file, to point to the Auth controllers you want. If you're going to use the Auth controllers that Laravel generates, these are the routes you can use:
+```php
+Route::group(['middleware' => 'web', 'prefix' => config('backpack.base.route_prefix')], function () {
+    Route::auth();
+    Route::get('logout', 'Auth\LoginController@logout');
+});
+```
+
+<a name="customize-routes"></a>
+### Customize the routes
+
+#### Custom routes - option 1
+
+You can place a new routes file in your ```app/routes/backpack/base.php```. If a file is present there, no default Backpack\Base routes will be loaded, only what's present in that file. You can use the routes file ```vendor/backpack/base/src/resources/views/base.php``` as an example, and customize whatever you want.
+
+#### Custom routes - option 2
+
+In ```config/backpack/base.php``` you'll find these configuration options:
+
+```php
+
+    /*
+    |--------------------------------------------------------------------------
+    | Routing
+    |--------------------------------------------------------------------------
+    */
+
+    // The prefix used in all base routes (the 'admin' in admin/dashboard)
+    'route_prefix' => 'admin',
+
+    // Set this to false if you would like to use your own AuthController and PasswordController
+    // (you then need to setup your auth routes manually in your routes.php file)
+    'setup_auth_routes' => true,
+
+    // Set this to false if you would like to skip adding the dashboard routes
+    // (you then need to overwrite the login route on your AuthController)
+    'setup_dashboard_routes' => true,
+```
+
+In order to completely customize the auth routes, you can change both ```setup_auth_routes``` and ```setup_dashboard_routes``` to ```false```. This means Backpack\Base won't register any routes any more, so you'll have to manually register them in your route file. Here's what you can use to get started:
+```php
+Route::group(['middleware' => 'web', 'prefix' => config('backpack.base.route_prefix', 'namespace' => 'Backpack\Base\app\Http\Controllers')], function () {
+    Route::auth();
+    Route::get('logout', 'Auth\LoginController@logout');
+    Route::get('dashboard', 'AdminController@dashboard');
+    Route::get('/', 'AdminController@redirect');
+});
+```
+
+<a name="use-sparate-login-for-users-and-admins"></a>
+### Use separate login/register forms for users and admins
+
+This is a default in Backpack v4.
+
+Backpack's authentication uses a completely separate authentication driver, provider, guard and password broker. They're all named ```backpack```, and registered in the vendor folder, invisible to you. 
+
+If you need a separate login for user, just go ahead and create it. [Add the Laravel authentication, like instructed in the Laravel documentation](https://laravel.com/docs/5.7/authentication#authentication-quickstart): ```php artisan make:auth```. You'll then have:
+- the user login at ```/login``` -> using the AuthenticationController Laravel provides
+- the admin login at ```/admin/login``` -> using the AuthenticationControllers Backpack provides
+
+The user login will be using Laravel's default authentication driver, provider, guard and password broker, from ```config/auth.php```.
+
+Backpack's authentication driver, provider, guard and password broker can easily be overwritten by creating a driver/provider/guard/broker with the ```backpack``` name inside your ```config/auth.php```. If one named ```backpack``` exists there, Backpack will use that instead.
+
+<a name="overwrite-authentication-driver-provider-guard-or-password-broker"></a>
+### Overwrite Backpack authentication driver, provider, guard or password broker
+
+Backpack's authentication uses a completely separate authentication driver, provider, guard and password broker. Backpack adds them to what's defined in ```config/auth.php``` on runtime, and they're all named ```backpack```.
+
+To change a setting in how Backpack's driver/provider/guard or password broker works, create a driver/provider/guard/broker with the ```backpack``` name inside your ```config/auth.php```. If one named ```backpack``` exists there, Backpack will use that instead.
+
+<a name="use-separate-sessions-for-admins-and-users"></a>
+### Use separate sessions for admin&user authentication
+
+This is a default in Backpack v4.
+
+<a name="login-with-username-instead-of-email"></a>
+### Login with username instead of email
+
+1. Create a ```username``` column in your users table and add it in ```$fillable``` on your ```User``` model. Best to do this with a migration.
+2. Remove the UNIQUE and NOT NULL constraints from ```email``` on your table. Best to do this with a migration. Alternatively, delete your ```email``` column and remove it from ```$fillable``` on your ```User``` model. If you already have a CRUD for users, you might also need to delete it from the Request, and from your UserCrudController. 
+3. Change your ```config/backpack/base.php``` config options:
+```php
+    // Username column for authentication
+    // The Backpack default is the same as the Laravel default (email)
+    // If you need to switch to username, you also need to create that column in your db
+    'authentication_column' => 'username',
+    'authentication_column_name' => 'Username',
+```
+That's it. This will:
+- use ```username``` for login;
+- use ```username``` for registration;
+- use ```username``` in My Account, when a user wants to change his info;
+- completely disable the password recovery (if you've deleted the ```email``` db column);
+
+
+<a name="use-your-own-user-model-instead-of-backpack-user"></a>
+### Use your own User model instead of App\User
+
+By default, authentication and everything else inside Backpack is done using the ```App\User``` model. If you change the location of ```App\User```, or want to use a different User model for whatever other reason, you can do so by changing ```user_model_fqn``` in ```config/backpack/base.php``` to your new class.
+
+
+<a name="use-your-own-profile-image-avatar"></a>
+### Use your own profile image (avatar)
+
+By default, Backpack will use Gravatar to show the profile image for the currently logged in backpack user. In order to change this, you can use the option in ```config/backpack/base.php```:
+```php
+// What kind of avatar will you like to show to the user?
+// Default: gravatar (automatically use the gravatar for his email)
+//
+// Other options:
+// - placehold (generic image with his first letter)
+// - example_method_name (specify the method on the User model that returns the URL)
+'avatar_type' => 'gravatar',
+```
+
+Please note that this does not allow the user to change his profile image.
+
+
+<a name="add-one-or-more-fields-to-the-register-form"></a>
+### Add one or more fields to the Register form
+
+To add a new field to the Registration page, you should:
+
+**Step 1.** Overwrite the registration route, so it leads to _your_ controller, instead of the one in the package. We recommend you add it your ```routes/backpack/custom.php```, BEFORE the route group where you define your CRUDs:
+
+```php
+Route::get('admin/register', 'App\Http\Controllers\Admin\Auth\RegisterController')->name('backpack.auth.register');
+```
+
+**Step 2.** Create the new RegisterController somewhere in your project, that extends the RegisterController in the package, and overwrites the validation & user creation methods. For example:
+
+```php
+<?php
+namespace App\Http\Controllers\Admin\Auth;
+
+use Backpack\CRUD\app\Http\Controllers\Auth\RegisterController as BackpackRegisterController;
+
+class RegisterController extends BackpackRegisterController 
+{
+    /**
+     * Get a validator for an incoming registration request.
+     *
+     * @param array $data
+     *
+     * @return \Illuminate\Contracts\Validation\Validator
+     */
+    protected function validator(array $data)
+    {
+        $user_model_fqn = config('backpack.base.user_model_fqn');
+        $user = new $user_model_fqn();
+        $users_table = $user->getTable();
+        $email_validation = backpack_authentication_column() == 'email' ? 'email|' : '';
+
+        return Validator::make($data, [
+            'name'                             => 'required|max:255',
+            backpack_authentication_column()   => 'required|'.$email_validation.'max:255|unique:'.$users_table,
+            'password'                         => 'required|min:6|confirmed',
+        ]);
+    }
+
+    /**
+     * Create a new user instance after a valid registration.
+     *
+     * @param array $data
+     *
+     * @return User
+     */
+    protected function create(array $data)
+    {
+        $user_model_fqn = config('backpack.base.user_model_fqn');
+        $user = new $user_model_fqn();
+
+        return $user->create([
+            'name'                             => $data['name'],
+            backpack_authentication_column()   => $data[backpack_authentication_column()],
+            'password'                         => bcrypt($data['password']),
+        ]);
+    }
+}
+```
+Add whatever validation rules & inputs you want, in addition to name and password.
+
+**Step 3.** Add the actual inputs to your HTML. You can easily overwrite the register view by adding this method to the same RegisterController:
+
+```php
+    public function showRegistrationForm()
+    {
+
+        return backpack_view('auth.register');
+    }
+```
+This will make the registration process pick up a view you can create, in ```resources/views/vendor/backpack/base/auth/register.blade.php```. You can copy-paste the original view, and modify as you please. Including adding your own custom inputs.
+

--- a/5.x-dev/base-widgets.md
+++ b/5.x-dev/base-widgets.md
@@ -146,7 +146,7 @@ Widget Preview:
 <hr>
 
 <a name="chart"></a>
-### Chart
+### Chart <span class="badge badge-pill badge-info">PRO</span>
 
 Shows a pie chart / line chart / bar chart inside a Bootstrap card, with the heading and body you specify.
 

--- a/5.x-dev/base-widgets.md
+++ b/5.x-dev/base-widgets.md
@@ -1,0 +1,620 @@
+# Widgets
+
+---
+
+<a name="about"></a>
+## About
+
+Widgets (aka cards, aka charts, aka graphs) provide a simple way to insert blade files into admin panel pages. You can use them to insert cards, charts, notices or custom content into pages.
+
+
+<a name="requirements"></a>
+### Requirements
+
+In order to use the ```Widget``` class, you should make sure your main views (for new admin panel pages) extend the ```backpack::blank``` or ```backpack_view('blank')``` blade template. This template includes two sections where you can push widgets:
+- ```before_content```
+- ```after_content```
+
+
+<a name="how-to-use-widgets"></a>
+### How to Use
+
+You can easily push widgets to these sections, by using the autoloaded ```Widget``` class. You can think of the ```Widget``` class as a global container for widgets, for the current page being rendered. That means you can call the ```Widget``` container inside a ```Controller```, inside a ```view```, or inside a service provider you create - wherever you want.
+
+```php
+use Backpack\CRUD\app\Library\Widget;
+
+Widget::add($widget_definition_array)->to('before_content');
+
+// alternatively, use a fluent syntax to define each widget attribute
+Widget::add()
+    ->to('before_content')
+    ->type('card')
+    ->content(null);
+```
+
+
+<a name="mandatory-attributes"></a>
+### Mandatory Attributes
+
+When passing a widget array, you need to specify at least these attributes:
+```php
+[
+   'type' => 'card' // the kind of widget to show
+   'content' => null // the content of that widget (some are string, some are array) 
+],
+```
+
+<a name="optional-attributes"></a>
+### Optional Attributes
+
+Most widget types also have these attributes present, which you can use to tweak how the widget looks inside the page:
+```php
+'wrapper' => [
+    'class' => 'col-sm-6 col-md-4', // customize the class on the parent element (wrapper)
+    'style' => 'border-radius: 10px;',
+]
+```
+
+<a name="widgets-api"></a>
+### Widgets API
+
+To manipulate widgets, you can use the methods below. The action will be performed on the page being constructed for the current request. And the ```Widget``` class is a global container, so you can add widgets to it both from the Controller, and from the view.
+
+```php
+// to add a widget to a different section than the default 'before_content' section:
+Widget::add($widget_definition_array)->to('after_content');
+Widget::add($widget_definition_array)->section('after_content');
+Widget::add($widget_definition_array)->group('after_content');
+
+// to create a widget, WITHOUT adding it to a section
+Widget::make($widget_definition_array);
+
+// to define the contents of a widget, pass the definition array to the make()/add() methods
+Widget::add($widget_definition_array);
+Widget::make($widget_definition_array);
+// alternatively, define each widget attribute one by one, using a fluent syntax
+Widget::add()
+    ->to('after_content')
+    ->type('card')
+    ->content('something');
+
+// to reference a widget later on, give it a unique 'name'
+Widget::add($widget_definition_array)->name('my_widget');
+
+// you can then easily modify it
+Widget::name('my_widget')->content('some other content'); // change the 'content' attribute
+Widget::name('my_widget')->forget('attribute_name'); // unset a widget attribute
+Widget::name('my_widget')->makeFirst(); // make a widget the first one in its section
+Widget::name('my_widget')->makeLast(); // to make a widget the last one in its section
+Widget::name('my_widget')->remove(); // remove the widget from its section
+```
+
+
+
+<a name="widget-types"></a>
+## Default Widget Types
+
+<a name="alert"></a>
+### Alert
+
+Shows a notification bubble, with the heading and text you specify:
+
+```php
+[
+    'type'         => 'alert',
+    'class'        => 'alert alert-danger mb-2',
+    'heading'      => 'Important information!',
+    'content'      => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Corrupti nulla quas distinctio veritatis provident mollitia error fuga quis repellat, modi minima corporis similique, quaerat minus rerum dolorem asperiores, odit magnam.',
+    'close_button' => true, // show close button or not
+]
+```
+
+For different colors, you can use the following classes: ```alert-success```, ```alert-warning```, ```alert-info```, ```alert-danger``` ```alert-primary```, ```alert-secondary```, ```alert-light```, ```alert-dark```.
+
+Widget Preview:
+
+![Backpack alert widget](https://backpackforlaravel.com/uploads/v4/widgets/alert.png)
+
+<hr>
+
+<a name="card"></a>
+### Card
+
+Shows a Bootstrap card, with the heading and body you specify. You can customize the class name to get cards of different color, size, etc.
+
+```php
+[
+    'type'       => 'card',
+    // 'wrapper' => ['class' => 'col-sm-6 col-md-4'], // optional
+    // 'class'   => 'card bg-dark text-white', // optional
+    'content'    => [
+        'header' => 'Some card title', // optional
+        'body'   => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis non mi nec orci euismod venenatis. Integer quis sapien et diam facilisis facilisis ultricies quis justo. Phasellus sem <b>turpis</b>, ornare quis aliquet ut, volutpat et lectus. Aliquam a egestas elit. <i>Nulla posuere</i>, sem et porttitor mollis, massa nibh sagittis nibh, id porttitor nibh turpis sed arcu.',
+    ]
+]
+```
+
+For different background colors, you can use the following classes: ```bg-success```, ```bg-warning```, ```bg-info```, ```bg-danger``` ```bg-primary```, ```bg-secondary```, ```bg-light```, ```bg-dark```.
+
+Other useful helper classes: ```text-center```, ```text-white```.
+
+Widget Preview:
+
+![Backpack card widget](https://backpackforlaravel.com/uploads/v4/widgets/card.png)
+
+<hr>
+
+<a name="chart"></a>
+### Chart
+
+Shows a pie chart / line chart / bar chart inside a Bootstrap card, with the heading and body you specify.
+
+![Backpack chart widgets](https://backpackforlaravel.com/uploads/docs-4-2/release_notes/chart_widget_small.gif)
+
+To create and use a new widget chart, you need to:
+
+**Step 1.** Install laravel-charts, that offers a single PHP syntax for 6 different charting libraries: 
+```
+composer require consoletvs/charts:"6.*"
+```
+
+**Step 2.** Create a new ChartController:
+
+```
+php artisan backpack:chart WeeklyUsers
+
+```
+
+This will create:
+- a new ChartController inside ```app\Http\Controllers\Admin\Charts\WeeklyUsersChartController```
+- a route towards that ChartController in your ```routes/backpack/custom.php```
+
+**Step 3.** Add the widget that points to that ChartController you just created:
+```php
+Widget::add([ 
+    'type'       => 'chart',
+    'controller' => \App\Http\Controllers\Admin\Charts\WeeklyUsersChartController::class,
+
+    // OPTIONALS
+    
+    // 'class'   => 'card mb-2',
+    // 'wrapper' => ['class'=> 'col-md-6'] ,
+    // 'content' => [
+         // 'header' => 'New Users', 
+         // 'body'   => 'This chart should make it obvious how many new users have signed up in the past 7 days.<br><br>',
+    // ],
+]);
+``` 
+
+**Step 4.** Configure the ChartController you just created:
+- ```public function setup()``` (MANDATORY)
+    - initialize and configure ```$this->chart```, using the methods detailed in the [laravel-charts documentation](https://v6.charts.erik.cat); 
+    - you _can_ define your dataset here, if you want your DB queries to be called upon page load;
+- ```public function data()``` (OPTIONAL, but recommended)
+    - use ```$this->chart->dataset()``` to configure what the chart should contain;
+    - if it's defined, the chart will loads its contents using AJAX;
+
+Optionally:
+- you can _easily_ switch the JavaScript library used, by changing the use statement at the top of this file:
+
+```diff
+-use ConsoleTVs\Charts\Classes\Chartjs\Chart;
++use ConsoleTVs\Charts\Classes\Echarts\Chart;
++use ConsoleTVs\Charts\Classes\Fusioncharts\Chart;
++use ConsoleTVs\Charts\Classes\Highcharts\Chart;
++use ConsoleTVs\Charts\Classes\C3\Chart;
++use ConsoleTVs\Charts\Classes\Frappe\Chart;
+```
+- you can change the path to the JS library; if you don't want it loaded from a CDN, you can define ```$library``` or ```getLibraryFilePath()``` on your ChartController:
+
+```php
+protected $library = 'http://path/to/file';
+
+// or
+
+public function getLibraryFilePath()
+{
+    return asset('path/to/your/js/file');
+
+    // or
+    
+    return [
+        asset('path/to/first/js/file'),
+        asset('path/to/second/js/file'),
+    ];
+}
+```
+
+
+
+**That's it!** Refresh the page to see your new chart widget. Below, you'll find a few examples of how the ChartController can end up looking.
+
+<hr>
+
+**Example 1:** ChartController that loads results using AJAX:
+```php
+<?php
+
+namespace App\Http\Controllers\Admin\Charts;
+
+use App\User;
+use Backpack\CRUD\app\Http\Controllers\ChartController;
+use Backpack\NewsCRUD\app\Models\Article;
+use Backpack\NewsCRUD\app\Models\Category;
+use Backpack\NewsCRUD\app\Models\Tag;
+use ConsoleTVs\Charts\Classes\Chartjs\Chart;
+
+class NewEntriesChartController extends ChartController
+{
+    public function setup()
+    {
+        $this->chart = new Chart();
+
+        // MANDATORY. Set the labels for the dataset points
+        $labels = [];
+        for ($days_backwards = 30; $days_backwards >= 0; $days_backwards--) {
+            if ($days_backwards == 1) {
+            }
+            $labels[] = $days_backwards.' days ago';
+        }
+        $this->chart->labels($labels);
+
+        // RECOMMENDED. 
+        // Set URL that the ChartJS library should call, to get its data using AJAX.
+        $this->chart->load(backpack_url('charts/new-entries'));
+
+        // OPTIONAL.
+        $this->chart->minimalist(false);
+        $this->chart->displayLegend(true);
+    }
+
+    /**
+     * Respond to AJAX calls with all the chart data points.
+     *
+     * @return json
+     */
+    public function data()
+    {
+        for ($days_backwards = 30; $days_backwards >= 0; $days_backwards--) {
+            // Could also be an array_push if using an array rather than a collection.
+            $users[] = User::whereDate('created_at', today()
+                ->subDays($days_backwards))
+                ->count();
+            $articles[] = Article::whereDate('created_at', today()
+                ->subDays($days_backwards))
+                ->count();
+            $categories[] = Category::whereDate('created_at', today()
+                ->subDays($days_backwards))
+                ->count();
+            $tags[] = Tag::whereDate('created_at', today()
+                ->subDays($days_backwards))
+                ->count();
+        }
+
+        $this->chart->dataset('Users', 'line', $users)
+            ->color('rgb(77, 189, 116)')
+            ->backgroundColor('rgba(77, 189, 116, 0.4)');
+
+        $this->chart->dataset('Articles', 'line', $articles)
+            ->color('rgb(96, 92, 168)')
+            ->backgroundColor('rgba(96, 92, 168, 0.4)');
+
+        $this->chart->dataset('Categories', 'line', $categories)
+            ->color('rgb(255, 193, 7)')
+            ->backgroundColor('rgba(255, 193, 7, 0.4)');
+
+        $this->chart->dataset('Tags', 'line', $tags)
+            ->color('rgba(70, 127, 208, 1)')
+            ->backgroundColor('rgba(70, 127, 208, 0.4)');
+    }
+}
+
+```
+
+**Example 2.** Pie chart with both labels and dataset defined in the ```setup()``` method (no AJAX):
+
+```php
+<?php
+
+namespace App\Http\Controllers\Admin\Charts\Pies;
+
+use Backpack\CRUD\app\Http\Controllers\ChartController;
+use ConsoleTVs\Charts\Classes\Chartjs\Chart;
+
+class ChartjsPieController extends ChartController
+{
+    public function setup()
+    {
+        $this->chart = new Chart();
+
+        $this->chart->dataset('Red', 'pie', [10, 20, 80, 30])
+                    ->backgroundColor([
+                        'rgb(70, 127, 208)',
+                        'rgb(77, 189, 116)',
+                        'rgb(96, 92, 168)',
+                        'rgb(255, 193, 7)',
+                    ]);
+
+        // OPTIONAL
+        $this->chart->displayAxes(false);
+        $this->chart->displayLegend(true);
+
+        // MANDATORY. Set the labels for the dataset points
+        $this->chart->labels(['HTML', 'CSS', 'PHP', 'JS']);
+    }
+}
+
+```
+
+<hr>
+
+
+<a name="div"></a>
+### Div
+
+Allows you to include multiple widgets in the div attributes of your choice. For example, you can include multiple widgets in a ```<div class="row"></div>``` with the code below:
+
+```php
+[
+    'type'    => 'div',
+    'class'   => 'row',
+    'content' => [ // widgets 
+        [ 'type' => 'card', 'content' => ['body' => 'One'] ],
+        [ 'type' => 'card', 'content' => ['body' => 'Two'] ],
+        [ 'type' => 'card', 'content' => ['body' => 'Three'] ],
+    ]
+]
+```
+
+Anything you specify on this widget, other than ```type``` and ```content```, has to be a string, and will be considered an attribute of the "div" element.
+
+<hr>
+
+<a name="jumbotron"></a>
+### Jumbotron
+
+Shows a Bootstrap jumbotron component, with the heading and body you specify.
+
+```php
+[
+    'type'        => 'jumbotron',
+    'heading'     => 'Welcome!',
+    'content'     => 'Use the sidebar to the left to create, edit or delete content.',
+    'button_link' => backpack_url('logout'),
+    'button_text' => 'Logout',
+]
+```
+
+Widget Preview:
+
+![Backpack card widget](https://backpackforlaravel.com/uploads/v4/widgets/jumbotron.png)
+
+<hr>
+
+<a name="progress"></a>
+### Progress
+
+Shows a colorful card to signify the progress towards a goal. You can customize the class name to get cards of different color, size, etc.
+
+```php
+[
+    'type'        => 'progress',
+    'class'       => 'card text-white bg-primary mb-2',
+    'value'       => '11.456',
+    'description' => 'Registered users.',
+    'progress'    => 57, // integer
+    'hint'        => '8544 more until next milestone.',
+]
+```
+
+For different background colors, you can use the following classes: ```bg-success```, ```bg-warning```, ```bg-info```, ```bg-danger``` ```bg-primary```, ```bg-secondary```, ```bg-light```, ```bg-dark```.
+
+Other useful helper classes: ```text-center```, ```text-white```.
+
+Widget Preview:
+
+![Backpack card widget](https://backpackforlaravel.com/uploads/v4/widgets/progress.png)
+
+<hr>
+
+<a name="progress-white"></a>
+### Progress White
+
+Shows a white card to signify the progress towards a goal. You can customize the class name to get progress bars of different color.
+
+```php
+[
+    'type'          => 'progress_white',
+    'class'         => 'card mb-2',
+    'value'         => '11.456',
+    'description'   => 'Registered users.',
+    'progress'      => 57, // integer
+    'progressClass' => 'progress-bar bg-primary',
+    'hint'          => '8544 more until next milestone.',
+]
+```
+
+For different progress bar colors, you can use the following classes: ```bg-success```, ```bg-warning```, ```bg-info```, ```bg-danger``` ```bg-primary```, ```bg-secondary```, ```bg-light```, ```bg-dark```.
+
+Widget Preview:
+
+![Backpack card widget](https://backpackforlaravel.com/uploads/v4/widgets/progress_white.png)
+
+<hr>
+
+<a name="script"></a>
+### Script
+
+Loads a JavaScript file from a location you specify using a `<script>` element.
+
+```php
+[
+    'type'     => 'script',
+    'content'  => 'assets/js/custom-script.js',
+    // optional
+    // 'stack'    => 'before_scripts', // default is after_scripts
+]
+```
+
+You can also specify a link (`https://path-to-file.com/file.js`) as the content, and it will load the file from CDN. In that case you might also want to add additional attributes, which you can easily do, for example:
+
+```php
+Widget::add()->type('script')
+     ->content('https://code.jquery.com/ui/1.12.0/jquery-ui.min.js')
+     ->integrity('sha256-0YPKAwZP7Mp3ALMRVB2i8GXeEndvCq3eSl/WsAl1Ryk=')
+     ->crossorigin('anonymous');
+```
+
+<hr>
+
+<a name="style"></a>
+### Style
+
+Loads a CSS file from a location you specify using a `<link>` element.
+
+```php
+[
+    'type'     => 'style',
+    'content'  => 'assets/css/custom-script.css',
+    // optional
+    // 'stack'    => 'before_styles', // default is after_styles
+]
+```
+
+You can also specify a link (`https://path-to-file.com/file.css`) as the content, and it will load the file from CDN. In that case you might also want to add additional attributes, which you can easily do, for example:
+
+```php
+Widget::add()->type('style')
+     ->content('https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.58/dist/themes/light.css')
+     ->integrity('sha256-0YPKAwZP7Mp3ALMRVB2i8GXeEndvCq3eSl/WsAl1Ryk=')
+     ->crossorigin('anonymous');
+```
+
+<hr>
+
+<a name="view"></a>
+### View
+
+Loads a blade view from a location you specify. Any attributes you give it will be available in the ```$widget``` variable inside that view.
+
+```php
+[
+    'type'     => 'view',
+    'view'     => 'path.to.custom.view',
+    'someAttr' => 'some value',
+]
+```
+
+It helps load blade files that are not specifically created to be widgets, that live in a different path than ```resources/views/vendor/backpack/base/widgets```, as if they were widgets.
+
+<hr>
+
+<a name="overwriting-default-widget-types"></a>
+## Overwriting Default Widget Types
+
+You can overwrite a widget type by placing a file with the same name in your ```resources\views\vendor\backpack\base\widgets``` directory. When a file is there, Backpack will pick that one up, instead of the one in the package. You can do that from command line using ```php artisan backpack:publish base/widgets/widget-name```
+
+Examples:
+- creating a ```resources\views\vendor\backpack\base\widgets\card.blade.php``` file would overwrite the ```card``` widget functionality;
+- ```php artisan backpack:publish base/widgets/card``` will take the view from the package and copy it to the directory above, so you can edit it;
+
+>Keep in mind that when you're overwriting a default widget type, you're forfeiting any future updates for that widget. We can't push updates to a file that you're no longer using.
+
+<a name="creating-a-custom-widget-type"></a>
+## Creating a Custom Widget Type
+
+Widgets consist of only one file - a blade file with the same name as the widget type (ex: ```card.blade.php```). You can create one by placing a new blade file inside ```resources\views\vendor\backpack\base\widgets```. Be careful to choose a distinctive name, otherwise you might be overwriting a default widget type (see above).
+
+For example, you can create a ```well.blade.php```:
+```php
+@includeWhen(!empty($widget['wrapper']), 'backpack::widgets.inc.wrapper_start')
+    <div class="{{ $widget['class'] ?? 'well mb-2' }}">
+        {!! $widget['content'] !!}
+    </div>
+@includeWhen(!empty($widget['wrapper']), 'backpack::widgets.inc.wrapper_end')
+```
+
+You can then use the ```well``` widget in a Controller or View:
+```php
+@extends(backpack_view('blank'))
+
+@php
+    Widget::add([
+        'type'    => 'well',
+        'wrapper' => ['class' => 'col-sm-12'],
+        'content' => 'This text will be in a div with the class "<i>well</i>".',
+    ]);
+@endphp
+
+@section('content')
+@endsection
+```
+
+To use information from the database, you can:
+- use the full namespace for your models, like ```\App\Models\Product::count()```;
+- load all your dashboard information using AJAX calls, if you're loading charts, reports, etc, and the DB queries might take a long time;
+- [use view composers](https://laravel.com/docs/5.7/views#view-composers) to push variables inside this view when it's loaded, Like. ```View::composer('backpack::widgets.well, 'App\Http\View\Composers\WellComposer');```
+
+Inside the widget blade files, you include custom CSS and JS, by pushing to the stacks in the layout:
+```php
+@includeWhen(!empty($widget['wrapper']), 'backpack::widgets.inc.wrapper_start')
+    <div class="{{ $widget['class'] ?? 'well mb-2' }}">
+        {!! $widget['content'] !!}
+    </div>
+@includeWhen(!empty($widget['wrapper']), 'backpack::widgets.inc.wrapper_end')
+
+@push('after_styles')
+    <link href="{{ asset('packages/select2/dist/css/select2.min.css') }}" rel="stylesheet" type="text/css" />
+    <style>
+        .some_class {
+            color: red;
+        }
+    </style>
+@endpush
+
+
+@push('after_scripts')
+    <script src="{{ asset('packages/select2/dist/js/select2.min.js') }}"></script>
+    <script>
+        jQuery(document).ready(function($) {
+            // trigger select2 for each untriggered select2 box
+            $('.select2_field').each(function (i, obj) {
+                if (!$(obj).hasClass("select2-hidden-accessible"))
+                {
+                    $(obj).select2({
+                        theme: "bootstrap"
+                    });
+                }
+            });
+        });
+    </script>
+@endpush
+```
+
+
+<a name="using-widget-types-from-packages"></a>
+## Using a Widget Type from a Package
+
+You can choose the view namespace when loading a widget:
+
+```php
+
+// using the fluent syntax, use the 'from' alias
+Widget::add($widget_definition_array)->from('package::widgets');
+
+// using the widget definition array, specify its 'viewNamespace'
+Widget::add([
+    'type'          => 'card',
+    'viewNamespace' => 'package::widgets',
+    'wrapper'       => ['class' => 'col-sm-6 col-md-4'],
+    'class'         => 'card text-white bg-primary text-center',
+    'content'       => [
+        // 'header' => 'Another card title',
+        'body'      => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis non mi nec orci euismod venenatis. Integer quis sapien et diam facilisis facilisis ultricies quis justo. Phasellus sem <b>turpis</b>, ornare quis aliquet ut, volutpat et lectus. Aliquam a egestas elit.',
+    ],
+]);
+
+```
+
+Similarly, if you want to create widgets somewhere else than in ```resources/views/vendor/backpack/base/widgets```, you can pass that directory as the namespace of your widget. For example, ```resources/views/admin/widgets``` would have ```admin.widgets``` as the namespace.

--- a/5.x-dev/crud-api.md
+++ b/5.x-dev/crud-api.md
@@ -1,0 +1,530 @@
+# CRUD API
+
+---
+
+Here are all the features you will be using **inside your EntityCrudController**, grouped by the operation you will most likely use them for.
+
+## Operations
+
+- **operation()** - allows you to add a set of instructions inside ```setup()```, that only gets called when a certain operation is being performed; 
+```php
+public function setup() {
+	// ...
+	$this->crud->operation('list', function() {
+		$this->crud->addColumn('name');
+	});
+}
+```
+
+<a name="list-entries-api"></a>
+### List Operation
+
+<a name="columns-api"></a>
+#### Columns
+
+Manipulate what columns are shown in the table view.
+
+- **addColumn()** - add a column, at the end of the stack
+```php
+$this->crud->addColumn($column_definition_array); 
+```
+
+- **addColumns()** - add multiple columns, at the end of the stack
+```php
+$this->crud->addColumns([$column_definition_array, $another_column_definition_array]); 
+```
+
+- **modifyColumn()** - change column attributes
+```php
+$this->crud->modifyColumn($name, $modifs_array);
+```
+
+- **removeColumn()** - remove one column from all operations
+```php
+$this->crud->removeColumn('column_name');
+```
+
+- **removeColumns()** - remove multiple columns from all operations
+```php
+$this->crud->removeColumns(['column_name_1', 'column_name_2']); // remove an array of columns from the stack
+```
+
+- **setColumnDetails()** - change the attributes of one column; alias of ```modifyColumn()```;
+```php
+$this->crud->setColumnDetails('column_name', ['attribute' => 'value']);
+```
+
+- **setColumnsDetails()** - change the attributes of multiple columns; alias of ```modifyColumn()```;
+```php
+$this->crud->setColumnsDetails(['column_1', 'column_2'], ['attribute' => 'value']);
+```
+
+- **setColumns()** - remove previously set columns and only use the ones give now;
+```php
+$this->crud->setColumns();
+// sets the columns you want in the table view, either as array of column names, or multidimensional array with all columns detailed with their types
+```
+
+- **Chained - beforeColumn()** - insert current column _before_ the given column
+```php
+// ------ REORDER COLUMNS
+$this->crud->addColumn()->beforeColumn('name');
+```
+
+- **Chained - afterColumn()** - insert current column _after_ the given column
+```php
+$this->crud->addColumn()->afterColumn('name');
+```
+
+- **Chained - makeFirstColumn()** - make this column the first one in the list
+```php
+$this->crud->addColumn()->makeFirstColumn();
+// Please note: you need to also specify priority 1 in your addColumn statement for details_row or responsive expand buttons to show
+```
+
+<a name="buttons-api"></a>
+#### Buttons
+
+- **addButton()** - add a button in the given stack
+```php
+$this->crud->addButton($stack, $name, $type, $content, $position); 
+// stacks: top, line, bottom
+// types: view, model_function
+// positions: beginning, end (defaults to 'beginning' for the 'line' stack, 'end' for the others);
+```
+
+- **addButtonFromModelFunction()** - add a button whose HTML is returned by a method in the CRUD model
+```php
+$this->crud->addButtonFromModelFunction($stack, $name, $model_function_name, $position);
+```
+
+- **addButtonFromView()** - add a button whose HTML is in a view placed at ```resources\views\vendor\backpack\crud\buttons```
+```php
+$this->crud->addButtonFromView($stack, $name, $view, $position);
+```
+
+- **modifyButton()** - modify the attributes of a button
+```php
+$this->crud->modifyButton($name, $modifications);
+```
+
+- **removeButton()** - remove a button from whatever stack it's in
+```php
+$this->crud->removeButton($name); // remove a single button
+$this->crud->removeButtons($names); // or multiple
+```
+
+- **removeButtonFromStack()** - remove a button from a particular stack
+```php
+$this->crud->removeButtonFromStack($name, $stack);
+```
+
+- **removeAllButtons()** - remove all buttons from any stack
+```php
+$this->crud->removeAllButtons();
+```
+
+- **removeAllButtonsFromStack()** - remove all buttons from a particular stack
+```php
+$this->crud->removeAllButtonsFromStack($stack);
+```
+
+<a name="filters-api"></a>
+#### Filters
+
+Manipulate what filters are shown in the table view. Check out [CRUD > Operations > ListEntries > Filters](/docs/{{version}}/crud-filters) to see examples of ```$filter_definition_array```
+
+- **addFilter()** - add a filter to the list view
+```php
+$this->crud->addFilter($filter_definition_array, $values, $filter_logic);
+```
+
+- **modifyFilter()** - change the attributes of a filter
+```php
+$this->crud->modifyFilter($name, $modifs_array);
+```
+
+- **removeFilter()** - remove a certain filter from the list view
+```php
+$this->crud->removeFilter($name);
+```
+
+- **removeAllFilters()** - remove all filters from the list view
+```php
+$this->crud->removeAllFilters();
+```
+
+- **filters()** - get all the registered filters for the list view
+```php
+$this->crud->filters();
+```
+
+<a name="details-row-api"></a>
+#### Details Row
+
+Shows a ```+``` (plus sign) next to each table row, so that the user can expand that row and reveal details. You are responsible for creating the view with those details.
+
+- **enableDetailsRow()** - show the + sign in the table view
+```php
+$this->crud->enableDetailsRow();
+// NOTE: you also need to do allow access to the right users:
+$this->crud->allowAccess('details_row');
+// NOTE: you also need to do overwrite the showDetailsRow($id) method in your EntityCrudController to show whatever you'd like in the details row OR overwrite the views/backpack/crud/details_row.blade.php
+$this->crud->setDetailsRowView('your-view');
+```
+
+- **disableDetailsRow()** - hide the + sign in the table view
+```php
+$this->crud->disableDetailsRow();
+```
+
+<a name="export-buttons-api"></a>
+#### Export Buttons
+
+Please note it will only export the current _page_ of results. So in order to export all entries the user needs to make the current page show "All" entries from the top-left picker.
+
+- **enableExportButtons()** - Show export to PDF, CSV, XLS and Print buttons on the table view
+```php
+$this->crud->enableExportButtons();
+```
+
+<a name="responsive-table-api"></a>
+#### Responsive Table
+
+- **disableResponsiveTable()** - stop the listEntries view from showing/hiding columns depending on viewport width
+```php
+$this->crud->disableResponsiveTable();
+```
+
+- **enableResponsiveTable()** - make the listEntries view show/hide columns depending on viewport width
+```php
+$this->crud->enableResponsiveTable();
+```
+
+<a name="persistent-table-api"></a>
+#### Persistent Table
+
+- **enablePersistentTable()** - make the listEntries remember the filters, search and pagination for a user, even if he leaves the page, for 2 hours
+```php
+$this->crud->enablePersistentTable();
+```
+
+- **disablePersistentTable()** - stop the listEntries from remembering the filters, search and pagination for a user, even if he leaves the page
+```php
+$this->crud->disablePersistentTable();
+```
+
+<a name="page-length"></a>
+#### Page Length
+
+- **setDefaultPageLength()** - change the number of items per page in the list view
+```php
+$this->crud->setDefaultPageLength(10);
+```
+
+- **setPageLengthMenu()** - change the entire page length menu in the list view
+```php
+$this->crud->setPageLengthMenu([100, 200, 300]);
+```
+
+<a name="action-column-api"></a>
+#### Actions Column
+
+- **setActionsColumnPriority()** - make the actions column (in the table view) hide when not enough space is available, by giving it an unreasonable priority
+```php
+$this->crud->setActionsColumnPriority(10000);
+```
+
+<a name="custom-queries-api"></a>
+#### Custom / Advanced Queries
+
+- **addClause()** - change what entries are shown in the table view; this allows _developers_ to forcibly change the query used by the table view, as opposed to filters, that allow _users_ to change the query with new inputs;
+```php
+$this->crud->addClause('active'); // apply local scope
+$this->crud->addClause('type', 'car'); // apply local dynamic scope
+$this->crud->addClause('where', 'name', '=', 'car');
+$this->crud->addClause('whereName', 'car');
+$this->crud->addClause('whereHas', 'posts', function($query) {
+     $query->activePosts();
+ });
+```
+
+- **groupBy()** - shorthand to add a **groupBy** clause to the query
+```php
+$this->crud->groupBy();
+```
+
+- **limit()** - shorthand to add a **limit** clause to the query
+```php
+$this->crud->limit();
+```
+
+- **orderBy()** - shorthand to add an **orderBy** clause to the query
+```php
+$this->crud->orderBy();
+```
+
+<a name="show-api"></a>
+### Show Operation
+
+Use [the same Columns API as for the ListEntries operation](#columns-api), but inside your ```show()``` method.
+
+<a name="create-and-update-api"></a>
+### Create & Update Operations
+
+Manipulate what fields are shown in the create / update forms. Check out [CRUD > Operations > Create & Update > Fields](/docs/{{version}}/crud-fields) in the docs to see examples of ```$field_definition_array```.
+
+**Note:** The call is being performed for the current operation. So it's important to pay attention _where_ you're calling fields. Most likely, you'll want to do this inside ```setupCreateOperation()``` or ```setupUpdateOperation()```.
+
+- **addField()** - add one field
+```php
+$this->crud->addField($field_definition_array);
+$this->crud->addField('db_column_name'); // a lazy way to add fields: let the CRUD decide what field type it is and set it automatically, along with the field label
+```
+
+- **addFields()** - add multiple fields
+```php
+$this->crud->addFields($array_of_fields_definition_arrays);
+```
+
+- **modifyField()** - change the attributes of an existing field
+```php
+$this->crud->modifyField($name, $modifs_array);
+```
+
+- **removeField()** - remove a given field from the current operation
+```php
+$this->crud->removeField('name');
+```
+
+- **removeFields()** - remove multiple fields from the current operation
+```php
+$this->crud->removeFields($array_of_names);
+```
+
+- **removeAllFields()** - remove all registered fields
+```php
+$this->crud->removeAllFields();
+```
+- **Chained - beforeField()** - add a field _before_ a given field
+```php
+$this->crud->addField()->beforeField('name');
+```
+
+- **Chained - afterField()** - add a field _after_ a given field
+```php
+$this->crud->addField()->afterField('name');
+```
+
+- **setRequiredFields()** - check the FormRequests used in this EntityCrudController for required fields, and add an asterisk to them in the create or edit forms
+```php
+$this->crud->setRequiredFields(StoreRequest::class);
+```
+
+- **setValidation()** - makes sure validation and authorization in the FormRequest you've passed is being performed; also uses that file to figure out asterisk to show in the forms (calls ```setRequiredFields()``` above):
+```php
+$this->crud->setValidation(ArticleRequest::class);
+```
+
+<a name="reorder-api"></a>
+### Reorder Operation
+
+Show a reorder button in the table view, next to Add. Provides an interface to reorder & nest elements, provided the ```parent_id```, ```lft```, ```rgt```, ```depth``` columns are in the database, and ```$fillable``` on the model.
+
+```php
+$this->crud->set('reorder.label', 'name'); // which model attribute to use for labels
+$this->crud->set('reorder.max_level', 3); // maximum nesting depth; this example will prevent the user from creating trees deeper than 3 levels;
+```
+
+- **disableReorder()** - disable the Reorder functionality
+```php
+$this->crud->disableReorder();
+```
+
+- **isReorderEnabled()** - returns ```true```/```false``` if the Reorder operation is enabled or not
+```php
+$this->crud->isReorderEnabled();
+```
+
+<a name="revisions-api"></a>
+### Revise Operation
+
+A.k.a. Audit Trail. Tracks all changes to an entry and provides an interface to revert to a previous state. This operation is not installed by default - please check out [Revise Operation](/docs/{{version}}/crud-operation-revisions) for the installation & usage steps.
+
+<a name="all-operations-api"></a>
+## All Operations
+
+### Access
+
+Prevent or allow users from accessing different CRUD operations.
+
+- **allowAccess()** - give users access to one or multiple operations
+```php
+$this->crud->allowAccess('list');
+$this->crud->allowAccess(['list', 'create', 'delete']);
+```
+
+- **denyAccess()** - prevent users from accessing one or multiple operations
+```php
+$this->crud->denyAccess('list');
+$this->crud->denyAccess(['list', 'create', 'delete']);
+```
+
+- **hasAccess()** - check if the current user has access to one or multiple operations
+```php
+$this->crud->hasAccess('something'); // returns true/false
+$this->crud->hasAccessOrFail('something'); // throws 403 error
+$this->crud->hasAccessToAll(['create', 'update']); // returns true/false
+$this->crud->hasAccessToAny(['create', 'update']); // returns true/false
+```
+
+### Eager Loading Relationships
+
+- **with()** - when the current entry is loaded (in any operation) also get its relationships, so that only one query is made to the database per entry
+```php
+$this->crud->with('relationship_name');
+```
+
+### Custom Views
+
+- **setShowView()**, **setEditView()**, **setCreateView()**, **setListView()**, **setReorderView()**, **setRevisionsView()**, **setRevisionsTimelineView()**, **setDetailsRowView()** - set the view for a certain CRUD operation or feature
+
+```php
+// use a custom view for a CRUD operation
+$this->crud->setShowView('path.to.your.view');
+$this->crud->setEditView('path.to.your.view');
+$this->crud->setCreateView('path.to.your.view');
+$this->crud->setListView('path.to.your.view');
+$this->crud->setReorderView('path.to.your.view');
+$this->crud->setRevisionsView('path.to.your.view');
+$this->crud->setRevisionsTimelineView('path.to.your.view');
+$this->crud->setDetailsRowView('path.to.your.view');
+
+// more generally, you can use the Settings API:
+$this->crud->set('create.view', 'path.to.your.view');
+
+// if you want to load something from the /resources/vendor/backpack/crud directory, you can do
+$this->crud->set('create.view', 'crud::yourfolder.yourview');
+// or
+$this->crud->set('create.view', 'resources.vendor.backpack.crud.yourfolder.yourview');
+```
+
+### Content Class
+
+- **setShowContentClass()**, **setEditContentClass()**, **setCreateContentClass()**, **setListContentClass()**, **setReorderContentClass()**, **setRevisionsContentClass()**, **setRevisionsTimelineContentClass()** - set the CSS class for an operation view, to make the main area bigger or smaller:
+
+```php
+// use a custom view for a CRUD operation
+$this->crud->setShowContentClass('col-md-8');
+$this->crud->setEditContentClass('col-md-8');
+$this->crud->setCreateContentClass('col-md-8');
+$this->crud->setListContentClass('col-md-8');
+$this->crud->setReorderContentClass('col-md-8');
+$this->crud->setRevisionsContentClass('col-md-8');
+$this->crud->setRevisionsTimelineContentClass('col-md-8');
+
+// more generally, you can use the Settings API:
+$this->crud->set('create.contentClass', 'col-md-12');
+```
+
+### Getters
+
+- **getEntry()** - get a certain entry of the current model type
+```php
+$this->crud->getEntry($entry_id);
+```
+- **getEntries()** - get all entries using the current CRUD query
+```php
+$this->crud->getEntries();
+```
+
+- **getFields()** - get all fields for a certain operation, or for both
+```php
+$this->crud->getFields('create/update/both');
+```
+
+- **getCurrentEntry()** - get the current entry, for operations that work on a single entry
+```php
+$this->crud->getCurrentEntry();
+// ex: in your update() method, after calling parent::updateCrud()
+```
+
+### Operations
+
+- **getOperation()** - get the name of the operation that is currently being performed
+```php
+$this->crud->getOperation();
+```
+
+- **setOperation()** - set the name of the operation that is currently being performed
+```php
+$this->crud->setOperation('ListEntries');
+```
+
+### Actions
+
+An action is the controller method that is currently being run.
+
+- **getActionMethod()** - returns the method on the controller that was called by the route; ex: ```create()```, ```update()```, ```edit()``` etc;
+```php
+$this->crud->getActionMethod();
+```
+
+- **actionIs()** - checks if the given controller method is the one called by the route
+```php
+$this->crud->actionIs('create');
+```
+
+### Title, Heading, Subheading
+
+Legend:
+- _operation_ - a collection of functions in a CrudController, that together allow the admin to perform something on the current model;
+- _action_ - a method (aka function) of an operation; it is the actual PHP function's name;
+
+- **getTitle()** -  get the Title for the create action
+```php
+$this->crud->getTitle('create');
+```
+
+- **getHeading()** - get the Heading for the create action
+```php
+$this->crud->getHeading('create');
+```
+
+- **getSubheading()** - get the Subheading for the create action
+```php
+$this->crud->getSubheading('create');
+```
+
+- **setTitle()** -  set the Title for the create action
+```php
+$this->crud->setTitle('some string', 'create');
+```
+
+- **setHeading()** -  set the Heading for the create action
+```php
+$this->crud->setHeading('some string', 'create');
+```
+
+- **setSubheading()** -  set the Subheading for the create action
+```php
+$this->crud->setSubheading('some string', 'create');
+```
+
+### CrudPanel Basic Info
+
+- **setModel()** - set the Eloquent object that should be used for all operations
+```php
+$this->crud->setModel("App\Models\Example");
+```
+
+- **setRoute()** - set the main route to this CRUD
+```php
+$this->crud->setRoute("admin/example");
+// OR $this->crud->setRouteName("admin.example");
+```
+
+- **setEntityNameStrings()** - set how the entity name should be shown to the user, in singular and in plural
+```php
+$this->crud->setEntityNameStrings("example", "examples");
+```

--- a/5.x-dev/crud-basics.md
+++ b/5.x-dev/crud-basics.md
@@ -1,0 +1,46 @@
+# Basics
+
+---
+
+Backpack\CRUD provides a fast way to build administration panels - places where your administrators can Create, Read, Update, Delete entries for a specific Eloquent model. **One CRUD Panel provides functionality for one Eloquent Model.** 
+
+<a name="requirements"></a>
+## Requirements
+
+In order to create a CRUD Panel, you'll need:
+- **a table in the database** (and maybe connection tables for relationships);
+- **an Eloquent Model** that points to that db table;
+
+If you don't already have the models, don't worry, Backpack also includes a faster way to generate database migrations and models.
+
+<a name="architecture"></a>
+## Architecture
+
+A Backpack CRUD Panel uses _the same elements_ you would have created for an administration panel, if you were doing it from scratch:
+- a **controller** - holds the logic for the all operations an admin can perform on that Eloquent model; will be generated in ```app/Http/Controllers/Admin```;
+- a **request** file - used to validate Create and Update forms; will be generated in ```app/Http/Requests```;
+- a resource **route** - points to the controller above; will be generated in ```routes/backpack/custom.php```;
+
+**The only difference** between building it from scratch and using Backpack\CRUD** is that:
+- your controller will be extending ```Backpack\CRUD\app\Http\Controllers\CrudController```**, which allow you to easily add traits that handle the most common operations: Create, Update, Delete, List, Show,  Reorder, Revisions. 
+- your model will ```use \Backpack\CRUD\CrudTrait```;
+
+This simple architecture (```ProductCrudController extends CrudController```) means:
+- **your CRUD Panel will not be a _black box_**; you can easily see the logic for each operation, by checking the methods on this controller, or the traits you'll be using;
+- **you can _easily_ overwrite what happens inside each operation**; 
+- **you can _easily_ add custom operations**;
+
+For example:
+- want to change how a single ```Product``` is shown to the admin? just create a method called ```show()``` in your ```ProductCrudController```; simple OOP dictates that your method will be picked up, instead of the one in CrudController; some goes for ```create()```, ```store()```, etc - you have complete control;
+- want to create a new "Publish" operation on a ```Product```? your ```ProductCrudController``` is a great place for that logic; just create a custom ```publish()``` method and a route that points to it;
+
+<a name="files"></a>
+## Files
+
+For a ```Tag``` entity, your CRUD Panel would consist of:
+- a controller (```app/Http/Controllers/Admin/TagCrudController.php```);
+- a request (```app/Http/Requests/TagCrudRequest.php```);
+- a route inside ```routes/backpack/custom.php```;
+- your existing model (```app/Models/Tag.php```);
+
+To further your understanding  of how a CRUD Panel works, [read more about this example in the tutorial](/docs/{{version}}/crud-tutorial).

--- a/5.x-dev/crud-buttons.md
+++ b/5.x-dev/crud-buttons.md
@@ -1,0 +1,202 @@
+# Buttons
+
+---
+
+<a name="about"></a>
+## About
+
+Buttons are used inside the ListEdit operation, to allow the admin to trigger other operations. Some point to entirely new routes (```create```, ```update```, ```show```), others perform the operation on the current page using AJAX (```delete```).
+
+<a name="button-stacks"></a>
+### Button Stacks
+
+The ShowList operation has 3 places where buttons can be placed:
+  - ```top``` (where the Add button is)
+  - ```line``` (where the Edit and Delete buttons are)
+  - ```bottom``` (after the table)
+
+When adding a button to the stack, you can choose whether to insert it at the ```beginning``` or ```end``` of the stack by specifying that as a last parameter.
+
+<a name="default-buttons"></a>
+### Default Buttons
+
+Backpack adds a few buttons by default: 
+- ```create``` to the ```top``` stack;
+- ```update``` and ```delete``` to the ```line``` stack;
+
+Default buttons are invisible if an operation has been disabled. For example, you can: 
+- hide the "delete" button using ```$this->crud->denyAccess('delete')```;
+- show a "preview" button by using ```$this->crud->allowAccess('show')```;
+
+<a name="buttons-api"></a>
+### Buttons API
+
+Here are a few things you can call in your EntityCrudController's ```setupListOperation()``` method, to manipulate buttons:
+
+```php
+// possible positions: 'beginning' and 'end'; defaults to 'beginning' for the 'line' stack, 'end' for the others;
+
+// add a button; possible types are: view, model_function
+$this->crud->addButton($stack, $name, $type, $content, $position);
+
+// add a button whose HTML is returned by a method in the CRUD model
+$this->crud->addButtonFromModelFunction($stack, $name, $model_function_name, $position);
+
+// add a button whose HTML is in a view placed at resources\views\vendor\backpack\crud\buttons
+$this->crud->addButtonFromView($stack, $name, $view, $position);
+
+// remove a button
+$this->crud->removeButton($name);
+
+// remove a button for a certain stack (top, line, bottom)
+$this->crud->removeButtonFromStack($name, $stack);
+```
+<a name="overwriting-a-default-button"></a>
+### Overwriting a Default Button
+
+Before showing any buttons, Backpack will check your ```resources\views\vendor\backpack\crud\buttons``` directory, to see if you've overwritten any default buttons. If it finds a blade file with the same name there as the default buttons, it will use your blade file, instead of the default.
+
+That means **you can overwrite an existing button simply by creating a blade file with the same name inside this directory**.
+
+<a name="creating-a-custom-button"></a>
+### Creating a Custom Button
+
+To create a custom button:
+- create a new blade file in ```resources\views\vendor\backpack\crud\buttons```;
+- add that button using the ```addButton()``` syntax above, in the EntityCrudControllers you want, inside the ```setupListOperation()``` method;
+
+In this blade file, you can use:
+- ```$entry``` - the database entry you're showing (only inside the ```line``` stack);
+- ```$crud``` - the entire CrudPanel object;
+- ```$button``` - the button you're currently showing;
+
+Note: If you've opted to add a button from a model function (not a blade file), inside your model function you can use `$this` to get the current entry (so for example, you can do `$this->id`.
+
+<a name="examples"></a>
+## Examples
+
+<a name="adding-a-custom-button-with-a-blade-file"></a>
+### Adding a Custom Button with a Blade File
+
+Let's say we want to create a simple ```moderate.blade.php``` button. This button would just open a ```user/{id}/moderate/``` route, which would point to ```UserCrudController::moderate()```. The steps would be:
+
+- Create the ```resources\views\vendor\backpack\crud\buttons\moderate.blade.php``` file:
+```php
+@if ($crud->hasAccess('update'))
+  <a href="{{ url($crud->route.'/'.$entry->getKey().'/moderate') }} " class="btn btn-xs btn-default"><i class="fa fa-ban"></i> Moderate</a>
+@endif
+```
+- Add the new route, next to ```UserCrudController```'s route (most likely inside ```routes/backpack/custom.php```):
+```php
+Route::get('user/{id}/moderate', 'UserCrudController@moderate');
+```
+
+- We can now add a ```moderate()``` method to our ```UserCrudController```, which would moderate the user, and redirect back.
+```php
+public function moderate() 
+{
+    // show a form that does something
+}
+```
+
+- Now we can actually add this button to any of ```UserCrudController::setupListOperation()```:
+```php
+$this->crud->addButtonFromView('line', 'moderate', 'moderate', 'beginning');
+```
+
+<a name="adding-a-custom-button-without-a-blade-file"></a>
+### Adding a Custom Button without a Blade File
+
+Instead of creating a blade file for your button, you can use a function on your model to output the button's HTML.
+
+In your ```ArticleCrudController::setupListOperation()```:
+```php
+// add a button whose HTML is returned by a method in the CRUD model
+$this->crud->addButtonFromModelFunction('line', 'open_google', 'openGoogle', 'beginning');
+```
+
+In your ```Article``` model:
+
+```php
+public function openGoogle($crud = false)
+{
+    return '<a class="btn btn-sm btn-link" target="_blank" href="http://google.com?q='.urlencode($this->text).'" data-toggle="tooltip" title="Just a demo custom button."><i class="fa fa-search"></i> Google it</a>';
+}
+```
+
+
+<a name="adding-a-custom-button-with-a-blade-file"></a>
+### Adding a Custom Button with Javascript to the "top" stack
+
+Let's say we want to create an ```import.blade.php``` button. For simplicity, this button would just run an AJAX call which handles everything, and shows a status report to the user through notification bubbles. 
+
+The "top" buttons are not bound to any certain entry, like buttons from the "list" stack. They can only do general things. And if they do general things, it's _generally_ recommended that you move their javascript to the bottom of the page. You can easily do that with ```@push('after_scripts')```, because the Backpack default layout has an ```after_scripts``` stack. This way, you can make sure your Javascript is moved at the bottom of the page, after all other Javascript has been loaded (jQuery, DataTables, etc). Check out the example below.
+
+The steps would be:
+
+- Create the ```resources\views\vendor\backpack\crud\buttons\import.blade.php``` file:
+
+```php
+@if ($crud->hasAccess('create'))
+    <a href="javascript:void(0)" onclick="importTransaction(this)" data-route="{{ url($crud->route.'/import') }}" class="btn btn-sm btn-link" data-button-type="import">
+<span class="ladda-label"><i class="fa fa-plus"></i> Import {{ $crud->entity_name }}</span>
+</a>
+@endif
+
+@push('after_scripts')
+<script>
+    if (typeof importTransaction != 'function') {
+      $("[data-button-type=import]").unbind('click');
+
+      function importTransaction(button) {
+          // ask for confirmation before deleting an item
+          // e.preventDefault();
+          var button = $(button);
+          var route = button.attr('data-route');
+
+          $.ajax({
+              url: route,
+              type: 'POST',
+              success: function(result) {
+                  // Show an alert with the result
+                  console.log(result,route);
+                  new Noty({
+                      text: "Some Tx had been imported",
+                      type: "success"
+                  }).show();
+
+                  // Hide the modal, if any
+                  $('.modal').modal('hide');
+
+                  crud.table.ajax.reload();
+              },
+              error: function(result) {
+                  // Show an alert with the result
+                  new Noty({
+                      text: "The new entry could not be created. Please try again.",
+                      type: "warning"
+                  }).show();
+              }
+          });
+      }
+    }
+</script>
+@endpush
+```
+- Add the new route, next to ```UserCrudController```'s route (most likely inside ```routes/backpack/custom.php```):
+```php
+Route::get('user/import', 'UserCrudController@import');
+```
+
+- We can now add a ```import()``` method to our ```UserCrudController```, which would import the users.
+```php
+public function import() 
+{
+    // whatever you decide to do
+}
+```
+
+- Now we can actually add this button to any of ```UserCrudController::setupListOperation()```:
+```php
+$this->crud->addButtonFromView('top', 'import', 'import', 'end');
+```

--- a/5.x-dev/crud-cheat-sheet.md
+++ b/5.x-dev/crud-cheat-sheet.md
@@ -1,0 +1,336 @@
+# CRUD API Cheat Sheet
+
+---
+
+Here are all the functions you will be using **inside your EntityCrudController's ```setup()``` method**, grouped by the operation you will most likely use them for.
+
+## Operations
+
+<a name="list-entries-api"></a>
+### ListEntries
+
+<a name="columns-api"></a>
+#### Columns
+
+<small>Methods: addColumn(), addColumns(), modifyColumn(), removeColumn(), removeColumns(), setColumnDetails(), setColumnsDetails(), setColumns(), beforeColumn(), afterColumn(), makeFirstColumn()</small>
+
+```php
+// Manipulate what columns are shown in the table view.
+$this->crud->addColumn($column_definition_array); // add a column, at the end of the stack
+$this->crud->addColumns([$column_definition_array, $another_column_definition_array]); // add multiple columns, at the end of the stack
+$this->crud->modifyColumn($name, $modifs_array);
+$this->crud->removeColumn('column_name'); // remove a column from the stack
+$this->crud->removeColumns(['column_name_1', 'column_name_2']); // remove an array of columns from the stack
+$this->crud->setColumnDetails('column_name', ['attribute' => 'value']);
+$this->crud->setColumnsDetails(['column_1', 'column_2'], ['attribute' => 'value']);
+
+$this->crud->setColumns(); // set the columns you want in the table view, either as array of column names, or multidimensional array with all columns detailed with their types
+
+// ------ REORDER COLUMNS
+$this->crud->addColumn()->beforeColumn('name'); // will show this before the given column
+$this->crud->addColumn()->afterColumn('name'); // will show this after the given column
+
+$this->crud->addColumn()->makeFirstColumn(); 
+  // will make this column the first one in the list
+  // you need to also specify priority 1 in your addColumn statement for details_row or responsive expand buttons to show
+```
+
+<a name="buttons-api"></a>
+#### Buttons
+
+<small>Methods: addButton(), addButtonFromModelFunction(), addButtonFromView(), removeButton(), removeButtonFromStack()</small>
+
+```php
+// possible positions: 'beginning' and 'end'; defaults to 'beginning' for the 'line' stack, 'end' for the others;
+$this->crud->addButton($stack, $name, $type, $content, $position); // add a button; possible types are: view, model_function
+$this->crud->addButtonFromModelFunction($stack, $name, $model_function_name, $position); // add a button whose HTML is returned by a method in the CRUD model
+$this->crud->addButtonFromView($stack, $name, $view, $position); // add a button whose HTML is in a view placed at resources\views\vendor\backpack\crud\buttons
+$this->crud->removeButton($name);
+$this->crud->removeButtonFromStack($name, $stack);
+```
+
+<a name="filters-api"></a>
+#### Filters
+
+<small>Methods: addFilter(), modifyFilter(), removeFilter(), removeAllFilters(), filters()</small>
+
+```php
+// Manipulate what filters are shown in the table view.
+// 
+// Note: check out CRUD > Features > Filters in the docs to see examples of $filter_definition_array
+$this->crud->addFilter($filter_definition_array, $values, $filter_logic);
+$this->crud->modifyFilter($name, $modifs_array);
+$this->crud->removeFilter($name);
+$this->crud->removeAllFilters();
+$this->crud->filters(); // gets all the filters
+```
+
+<a name="details-row-api"></a>
+#### Details Row
+
+<small>Methods: enableDetailsRow(), disableDetailsRow()</small>
+
+```php
+// Shows a + sign next to each table row, so that the user can expand that row and reveal details. You are responsible for creating the view with those details.
+$this->crud->enableDetailsRow();
+// NOTE: you also need to do allow access to the right users: $this->crud->allowAccess('details_row');
+// NOTE: you also need to do overwrite the showDetailsRow($id) method in your EntityCrudController to show whatever you'd like in the details row OR overwrite the views/backpack/crud/details_row.blade.php
+
+$this->crud->disableDetailsRow();
+```
+
+<a name="export-buttons-api"></a>
+#### Export Buttons
+
+<small>Methods: enableExportButtons()</small>
+
+```php
+// Show export to PDF, CSV, XLS and Print buttons on the table view. Please note it will only export the current _page_ of results. So in order to export all entries the user needs to make the current page show "All" entries from the top-left picker.
+$this->crud->enableExportButtons();
+```
+
+<a name="responsive-table-api"></a>
+#### Responsive Table
+
+<small>Methods: enableResponsiveTable(), disableResponsiveTable()</small>
+
+```php
+$this->crud->disableResponsiveTable();
+$this->crud->enableResponsiveTable();
+```
+
+<a name="persistent-table-api"></a>
+#### Persistent Table
+
+<small>Methods: enablePersistenTable(), disablePersistenTable()</small>
+
+```php
+$this->crud->disablePersistentTable();
+$this->crud->enablePersistentTable();
+```
+
+<a name="page-length"></a>
+#### Page Length
+
+<small>Methods: setDetaultPageLength(), setPageLengthMenu()</small>
+
+```php
+// you can define the default page length. If it does not exist we will add it to the pagination array.
+$this->crud->setDefaultPageLength(10);
+
+// you can configure the paginator shown to the user in various ways
+
+// values and labels, 1st array the values, 2nd array the labels:
+$this->crud->setPageLengthMenu([[100, 200, 300], ['one hundred', 'two hundred', 'three hundred']]); 
+
+// values and labels in one array:
+$this->crud->setPageLengthMenu([100 => 'one hundred', 200 => 'two hundred', 300 => 'three hundred']); 
+
+// only values, we will use the values as labels:
+$this->crud->setPageLengthMenu([100, 200, 300]); // OR
+$this->crud->setPageLengthMenu([[100, 200, 300]]); 
+
+// only one option available:
+$this->crud->setPageLengthMenu(10); 
+```
+
+<small>NOTE: Do not use 0 as a key, if you want to represent "ALL" use -1 instead.</small>
+
+<a name="action-column-api"></a>
+#### Actions Column
+
+<small>Methods: setActionColumnPriority()</small>
+
+```php
+// make the actions column (in the table view) hide when not enough space is available, by giving it an unreasonable priority
+$this->crud->setActionsColumnPriority(10000);
+```
+
+<a name="custom-queries-api"></a>
+#### Custom / Advanced Queries
+
+<small>Methods: addClause(), groupBy(), limit(), orderBy()</small>
+
+```php
+// Change what entries are shown in the table view.
+// This changes all queries on the table view,
+// as opposed to filters, who only change it when that filter is applied. 
+$this->crud->addClause('active'); // apply local scope
+$this->crud->addClause('type', 'car'); // apply local dynamic scope
+$this->crud->addClause('where', 'name', '=', 'car');
+$this->crud->addClause('whereName', 'car');
+$this->crud->addClause('whereHas', 'posts', function($query) {
+     $query->activePosts();
+ });
+$this->crud->groupBy();
+$this->crud->limit();
+
+$this->crud->orderBy();
+// please note it's generally a good idea to use crud->orderBy() inside "if (!$this->crud->getRequest()->has('order')) {}"; that way, your custom order is applied ONLY IF the user hasn't forced another order (by clicking a column heading)
+```
+
+<a name="show-api"></a>
+### Show
+
+Use the same Columns API as for the ListEntries operation, but inside your ```show()``` method.
+
+<a name="create-and-update-api"></a>
+### Create & Update Operations
+
+<small>Methods: addField(), addFields(), modifyField(), modifyFields(), removeField(), removeFields(), removeAllFields(), beforeField(), afterField() </small>
+
+```php
+// ------
+// FIELDS
+// ------
+// Manipulate what fields are shown in the create / update forms.
+// 
+// Note: check out CRUD > Features > Field Types in the docs to see examples of $field_definition_array
+
+$this->crud->addField($field_definition_array);
+$this->crud->addField('db_column_name'); // a lazy way to add fields: let the CRUD decide what field type it is and set it automatically, along with the field label
+$this->crud->addFields($array_of_fields_definition_arrays);
+$this->crud->modifyField($name, $modifs_array);
+$this->crud->removeField('name');
+$this->crud->removeFields($array_of_names);
+$this->crud->removeAllFields();
+
+// ------ REORDER FIELDS
+$this->crud->addField()->beforeField('name'); // will show this before the given field
+$this->crud->addField()->afterField('name'); // will show this after the given field
+```
+
+<a name="reorder-api"></a>
+### Reorder
+
+<small>Methods: enableReorder(), disableReorder(), isReorderEnabled()</small>
+
+```php
+    protected function setupReorderOperation()
+    {
+    	// model attribute to be shown on draggable items
+        $this->crud->set('reorder.label', 'name'); 
+        // maximum number of nesting allowed
+        $this->crud->set('reorder.max_level', 2);
+
+        // extras:
+		// $this->crud->disableReorder();
+		// $this->crud->isReorderEnabled();
+    }
+```
+
+<a name="revisions-api"></a>
+### Revisions
+
+```php
+// -------------------------
+// REVISIONS aka Audit Trail
+// -------------------------
+// Tracks all changes to an entry and provides an interface to revert to a previous state.
+//
+// IMPORTANT: You also need to use \Venturecraft\Revisionable\RevisionableTrait;
+// Please check out: https://backpackforlaravel.com/docs/crud-operation-revisions
+$this->crud->allowAccess('revisions');
+```
+
+<a name="all-operations-api"></a>
+## All Operations
+
+<small>Methods: allowAccess(), denyAccess(), hasAccess(), hasAccessOrFail(), hasAccessToAll(), hasAccessToAny(), setShowView(), setEditView(), setCreateView(), setListView(), setReorderView(), setRevisionsView, setRevisionsTimelineView(), setDetailsRowView(), getEntry(), getFields(), getColumns(), getCurrentEntry(), getTitle(), setTitle(), getHeading(), setHeading(), getSubheading(), setSubheading(), </small>
+
+```php
+// ------ 
+// ACCESS
+// ------
+// Prevent or allow users from accessing different CRUD operations.
+
+$this->crud->allowAccess('list');
+$this->crud->allowAccess(['list', 'create', 'delete']);
+$this->crud->denyAccess('list');
+$this->crud->denyAccess(['list', 'create', 'delete']);
+
+$this->crud->hasAccess('add'); // returns true/false
+$this->crud->hasAccessOrFail('add'); // throws 403 error
+$this->crud->hasAccessToAll(['create', 'update']); // returns true/false
+$this->crud->hasAccessToAny(['create', 'update']); // returns true/false
+
+// -------------
+// EAGER LOADING
+// -------------
+
+// eager load a relationship
+$this->crud->with('relationship_name');
+
+// ------------
+// CUSTOM VIEWS
+// ------------
+
+// use a custom view for a CRUD operation
+$this->crud->setShowView('your-view');
+$this->crud->setEditView('your-view');
+$this->crud->setCreateView('your-view');
+$this->crud->setListView('your-view');
+$this->crud->setReorderView('your-view');
+$this->crud->setRevisionsView('your-view');
+$this->crud->setRevisionsTimelineView('your-view');
+$this->crud->setDetailsRowView('your-view');
+
+// -------------
+// CONTENT CLASS
+// -------------
+
+// use a custom CSS class for the content of a CRUD operation
+$this->crud->setShowContentClass('col-md-12');
+$this->crud->setEditContentClass('col-md-12');
+$this->crud->setCreateContentClass('col-md-12');
+$this->crud->setListContentClass('col-md-12');
+$this->crud->setReorderContentClass('col-md-12');
+$this->crud->setRevisionsContentClass('col-md-12');
+$this->crud->setRevisionsTimelineContentClass('col-md-12');
+
+// -------
+// GETTERS
+// -------
+
+$this->crud->getEntry($entry_id);
+$this->crud->getEntries();
+
+$this->crud->getFields('create/update/both');
+
+// in your update() method, after calling parent::updateCrud()
+$this->crud->getCurrentEntry();
+
+// -------
+// OPERATIONS
+// -------
+
+$this->crud->setOperation('list');
+$this->crud->getOperation();
+
+// -------
+// ACTIONS
+// -------
+
+$this->crud->getActionMethod(); // returns the method on the controller that was called by the route; ex: create(), update(), edit() etc;
+$this->crud->actionIs('create'); // checks if the controller method given is the one called by the route
+
+$this->crud->getTitle('create'); // get the Title for the create action
+$this->crud->getHeading('create'); // get the Heading for the create action
+$this->crud->getSubheading('create'); // get the Subheading for the create action
+
+$this->crud->setTitle('some string', 'create'); // set the Title for the create action
+$this->crud->setHeading('some string', 'create'); // set the Heading for the create action
+$this->crud->setSubheading('some string', 'create'); // set the Subheading for the create action
+
+// ---------------------------
+// CrudPanel Basic Information
+// ---------------------------
+$this->crud->setModel("App\Models\Example");
+$this->crud->setRoute("admin/example");
+// OR $this->crud->setRouteName("admin.example");
+$this->crud->setEntityNameStrings("example", "examples");
+
+// check the FormRequests used in that EntityCrudController for required fields, and add an asterisk to them in the create/edit form
+$this->crud->setRequiredFields(StoreRequest::class, 'create');
+$this->crud->setRequiredFields(UpdateRequest::class, 'edit');
+```

--- a/5.x-dev/crud-columns.md
+++ b/5.x-dev/crud-columns.md
@@ -94,7 +94,7 @@ $this->crud->addColumn()->makeFirstColumn();
 ## Default Column Types
 
 <a name="array"></a>
-### array
+### array <span class="badge badge-pill badge-info">PRO</span>
 
 Enumerate an array stored in the db column as JSON.
 ```php
@@ -108,7 +108,7 @@ Enumerate an array stored in the db column as JSON.
 <hr>
 
 <a name="array_count"></a>
-### array_count
+### array_count <span class="badge badge-pill badge-info">PRO</span>
 
 Count the items in an array stored in the db column as JSON.
 
@@ -315,7 +315,7 @@ Display database stored JSON in a prettier way to your users.
 <hr>
 
 <a name="markdown"></a>
-### markdown
+### markdown <span class="badge badge-pill badge-info">PRO</span>
 
 
 Convert a markdown string to HTML, using ```Illuminate\Mail\Markdown```. Since Markdown is usually used for long texts, this column is most helpful in the "Show" operation - not so much in the "ListEntries" operation, where only short snippets make sense.
@@ -458,7 +458,7 @@ This example will show:
 <hr>
 
 <a name="relationship"></a>
-### relationship
+### relationship <span class="badge badge-pill badge-info">PRO</span>
 
 Output the related entries, no matter the relationship:
 - 1-n relationships - outputs the name of its one connected entity;
@@ -588,7 +588,7 @@ The select_multiple column will output a comma separated list of its connected e
 <hr>
 
 <a name="table"></a>
-### table
+### table <span class="badge badge-pill badge-info">PRO</span>
 
 
 The ```table``` column will output a condensed table, when used on an attribute that stores a JSON array or object. It is meant to be used inside the show functionality (not list, though it also works there).
@@ -670,7 +670,7 @@ Its definition is very similar to the [upload_multiple *field type*](/docs/{{ver
 <hr>
 
 <a name="video"></a>
-### video
+### video <span class="badge badge-pill badge-info">PRO</span>
 
 
 Display a small screenshot for a Youtube or Vimeo video, stored in the database as JSON using the "video" field type.

--- a/5.x-dev/crud-columns.md
+++ b/5.x-dev/crud-columns.md
@@ -1,0 +1,953 @@
+# Columns
+
+---
+
+<a name="about"></a>
+## About
+
+A column shows the information of an Eloquent attribute, in a user-friendly format. 
+
+It's used inside default operations to:
+- show a table cell in **ListEntries**;
+- show an attribute value in **Show**;
+
+A column consists of only one file - a blade file with the same name as the column type (ex: ```text.blade.php```). Backpack provides you with [default column types](#default-column-types) for the common use cases, but you can easily [change how a default field type works](#overwriting-default-column-types), or [create an entirely new field type](#creating-a-custom-column-type).
+
+<a name="mandatory-attributes"></a>
+### Mandatory Attributes
+
+When passing a column array, you need to specify at least these attributes:
+```php
+[
+   'name' => 'options', // the db column name (attribute name)
+   'label' => "Options", // the human-readable label for it
+   'type' => 'text' // the kind of column to show
+],
+```
+
+<a name="optional-attributes"></a>
+### Optional Attributes
+
+- [```searchLogic```](#custom-search-logic)
+- [```orderLogic```](#custom-order-logic)
+- [```orderable```](#custom-order-logic)
+- [```wrapper```](#custom-wrapper-for-columns)
+- [```visibleInTable```](#choose-where-columns-are-visible)
+- [```visibleInModal```](#choose-where-columns-are-visible)
+- [```visibleInExport```](#choose-where-columns-are-visible)
+- [```visibleInShow```](#choose-where-columns-are-visible)
+- [```priority```](#define-which-columns-to-hide-in-responsive-table)
+- [```escaped```](#escape-column-output)
+
+<a name="columns-api"></a>
+### Columns API
+
+Inside your ```setupListOperation()``` or ```setupShowOperation()``` method, there are a few calls you can make to configure or manipulate columns:
+
+```php
+// add a column, at the end of the stack
+$this->crud->addColumn($column_definition_array);
+
+// add multiple columns, at the end of the stack
+$this->crud->addColumns([$column_definition_array, $another_column_definition_array]);
+
+// remove a column from the stack
+$this->crud->removeColumn('column_name');
+
+// remove an array of columns from the stack
+$this->crud->removeColumns(['column_name_1', 'column_name_2']);
+
+// change the attributes of a column
+$this->crud->modifyColumn($name, $modifs_array);
+$this->crud->setColumnDetails('column_name', ['attribute' => 'value']);
+
+// change the attributes of multiple columns
+$this->crud->setColumnsDetails(['column_1', 'column_2'], ['attribute' => 'value']);
+
+// forget what columns have been previously defined, only use these columns
+$this->crud->setColumns([$column_definition_array, $another_column_definition_array]);
+
+// -------------------
+// New in Backpack 4.1
+// -------------------
+// add a column with this name
+$this->crud->column('price');
+
+// change the type and prefix attributes on the 'price' column
+$this->crud->column('price')->type('number')->prefix('$');
+```
+
+In addition, to manipulate the order columns are shown in, you can:
+
+```php
+// add this column before a given column
+$this->crud->addColumn('text')->beforeColumn('name');
+
+// add this column after a given column
+$this->crud->addColumn()->afterColumn('name');
+
+// make this column the first one in the list
+$this->crud->addColumn()->makeFirstColumn();
+```
+
+<a name="default-column-types"></a>
+## Default Column Types
+
+<a name="array"></a>
+### array
+
+Enumerate an array stored in the db column as JSON.
+```php
+[
+   'name'  => 'options', // The db column name
+   'label' => 'Options', // Table column heading
+   'type'  => 'array'
+],
+```
+
+<hr>
+
+<a name="array_count"></a>
+### array_count
+
+Count the items in an array stored in the db column as JSON.
+
+```php
+[
+   'name'  => 'options', // The db column name
+   'label' => 'Options', // Table column heading
+   'type'  => 'array_count',
+   // 'suffix' => 'options', // if you want it to show "2 options" instead of "2 items"
+],
+```
+
+<hr>
+
+<a name="boolean"></a>
+### boolean
+
+Show Yes/No (or custom text) instead of 1/0.
+
+```php
+[
+    'name'  => 'name',
+    'label' => 'Status',
+    'type'  => 'boolean',
+    // optionally override the Yes/No texts
+    // 'options' => [0 => 'Active', 1 => 'Inactive']
+],
+```
+
+<hr>
+
+<a name="check"></a>
+### check
+
+Show a favicon with a checked or unchecked box, depending on the given boolean.
+```php
+[
+   'name'  => 'featured', // The db column name
+   'label' => 'Featured', // Table column heading
+   'type'  => 'check'
+],
+```
+
+<hr>
+
+<a name="checkbox"></a>
+### checkbox
+
+Shows a checkbox (the form element), and inserts the js logic needed to select/deselect multiple entries. It is mostly used for [the Bulk Delete action](/docs/{{version}}/crud-operation-delete#delete-multiple-items-bulk-delete), and [custom bulk actions](/docs/{{version}}/crud-operations#creating-a-new-operation-with-a-bulk-action-no-interface).
+
+Shorthand:
+```php
+$this->crud->enableBulkActions();
+```
+(will also add an empty custom_html column)
+
+Verbose:
+```php
+$this->crud->addColumn([
+    'type'           => 'checkbox',
+    'name'           => 'bulk_actions',
+    'label'          => ' <input type="checkbox" class="crud_bulk_actions_main_checkbox" style="width: 16px; height: 16px;" />',
+    'priority'       => 1,
+    'searchLogic'    => false,
+    'orderable'      => false,
+    'visibleInModal' => false,
+])->makeFirstColumn();
+```
+
+<hr>
+
+<a name="closure"></a>
+### closure
+
+Show custom HTML based on a closure you specify in your EntityCrudController.
+
+```php
+[
+    'name'     => 'created_at',
+    'label'    => 'Created At',
+    'type'     => 'closure',
+    'function' => function($entry) {
+        return 'Created on '.$entry->created_at;
+    }
+],
+```
+
+> **DEPRECATED**: closure column will be removed in a future version of Backpack, since the same thing can now be achieved using any column (including the `text` column) and the `value` attribute - just pass the same closure to the `value` attribute of any column type.
+
+<hr>
+
+<a name="custom_html"></a>
+### custom_html
+
+Show the HTML that you provide in the page. You can optionaly escape the text when displaying it on page, if you don't trust the value.
+
+```php
+[
+    'name'     => 'my_custom_html',
+    'label'    => 'Custom HTML',
+    'type'     => 'custom_html',
+    'value'    => '<span class="text-danger">Something</span>',
+
+    // OPTIONALS
+    // 'escaped' => true // echo using {{ }} instead of {!! !!}
+],
+```
+
+> <span class="badge badge-danger text-white" style="text-decoration: none;">IMPORTANT</span> As opposed to most other Backpack columns, the output of `custom_html` is **NOT escaped by default**. That means if the database value contains malicious JS, that JS might be run when the admin previews it. Make sure to purify the value of this column in an accessor on your Model. At a minimum, you can use `strip_tags()` (here's [an example](https://github.com/Laravel-Backpack/demo/commit/509c0bf0d8b9ee6a52c50f0d2caed65f1f986385)), but a lot better would be to use an [HTML Purifier package](https://github.com/mewebstudio/Purifier) (do that [manually](https://github.com/Laravel-Backpack/demo/commit/7342cffb418bb568b9e4ee279859685ddc0456c1) or by casting the attribute to `CleanHtmlOutput::class`).
+
+<hr>
+
+<a name="date"></a>
+### date
+
+
+The date column will show a localized date in the default date format (as specified in the ```config/backpack/base.php``` file), whether the attribute is casted as date in the model or not.
+
+Note that the ```format``` attribute uses ISO date formatting parameters and not PHP ```date()``` formatters.  See <https://carbon.nesbot.com/docs/#iso-format-available-replacements> for more information.
+
+```php
+[
+    'name'  => 'name', // The db column name
+    'label' => 'Tag Name', // Table column heading
+    'type'  => 'date',
+    // 'format' => 'l j F Y', // use something else than the base.default_date_format config value
+],
+```
+
+<hr>
+
+<a name="datetime"></a>
+### datetime
+
+
+The date column will show a localized datetime in the default datetime format (as specified in the ```config/backpack/base.php``` file), whether the attribute is casted as datetime in the model or not.
+
+Note that the ```format``` attribute uses ISO date formatting parameters and not PHP ```date()``` formatters.  See <https://carbon.nesbot.com/docs/#iso-format-available-replacements> for more information.
+
+
+```php
+[
+    'name'  => 'name', // The db column name
+    'label' => 'Tag Name', // Table column heading
+    'type'  => 'datetime',
+    // 'format' => 'l j F Y H:i:s', // use something else than the base.default_datetime_format config value
+],
+```
+
+<hr>
+
+<a name="email"></a>
+### email
+
+The email column will output the email address in the database (truncated to 254 characters if needed), with a ```mailto:``` link towards the full email. Its definition is:
+```php
+[
+   'name'  => 'email', // The db column name
+   'label' => 'Email Address', // Table column heading
+   'type'  => 'email',
+   // 'limit' => 500, // if you want to truncate the text to a different number of characters
+],
+```
+
+<hr>
+
+<a name="image"></a>
+### image
+
+
+Show a thumbnail image.
+
+```php
+[
+    'name'      => 'profile_image', // The db column name
+    'label'     => 'Profile image', // Table column heading
+    'type'      => 'image',
+    // 'prefix' => 'folder/subfolder/',
+    // image from a different disk (like s3 bucket)
+    // 'disk'   => 'disk-name', 
+    // optional width/height if 25px is not ok with you
+    // 'height' => '30px',
+    // 'width'  => '30px',
+],
+```
+
+<hr>
+
+<a name="json"></a>
+### json
+
+
+Display database stored JSON in a prettier way to your users.
+
+```php
+[
+    'name'     => 'my_json_column_name',
+    'label'    => 'JSON',
+    'type'     => 'json',
+    // 'escaped' => false, // echo using {!! !!} instead of {{ }}, in order to render HTML
+],
+```
+
+<hr>
+
+<a name="markdown"></a>
+### markdown
+
+
+Convert a markdown string to HTML, using ```Illuminate\Mail\Markdown```. Since Markdown is usually used for long texts, this column is most helpful in the "Show" operation - not so much in the "ListEntries" operation, where only short snippets make sense.
+
+```php
+[
+   'name'  => 'text', // The db column name
+   'label' => 'Text', // Table column heading
+   'type'  => 'markdown',
+],
+```
+
+> <span class="badge badge-danger text-white" style="text-decoration: none;">IMPORTANT</span> As opposed to most other Backpack columns, the output of `markdown` is **NOT escaped by default**. That means if the database value contains malicious JS, that JS might be run when the admin previews it. Make sure to purify the value of this column in an accessor on your Model. At a minimum, you can use `strip_tags()` (here's [an example](https://github.com/Laravel-Backpack/demo/commit/509c0bf0d8b9ee6a52c50f0d2caed65f1f986385)), but a lot better would be to use an [HTML Purifier package](https://github.com/mewebstudio/Purifier) (do that [manually](https://github.com/Laravel-Backpack/demo/commit/7342cffb418bb568b9e4ee279859685ddc0456c1) or by casting the attribute to `CleanHtmlOutput::class`).
+
+<hr>
+
+<a name="model_function"></a>
+### model_function
+
+
+The model_function column will output a function on your main model. Its definition is:
+```php
+[
+   // run a function on the CRUD model and show its return value
+   'name'  => 'url',
+   'label' => 'URL', // Table column heading
+   'type'  => 'model_function',
+   'function_name' => 'getSlugWithLink', // the method in your Model
+   // 'function_parameters' => [$one, $two], // pass one/more parameters to that method
+   // 'limit' => 100, // Limit the number of characters shown
+   // 'escaped' => false, // echo using {!! !!} instead of {{ }}, in order to render HTML
+],
+```
+For this example, if your model would feature this method, it would return the link to that entity:
+```php
+public function getSlugWithLink() {
+    return '<a href="'.url($this->slug).'" target="_blank">'.$this->slug.'</a>';
+}
+```
+
+<hr>
+
+<a name="model_function_attribute"></a>
+### model_function_attribute
+
+
+If the function you're trying to use returns an object, not a string, you can use the model_function_attribute column, which will output the attribute on the function result. Its definition is:
+```php
+[
+   'name'  => 'url',
+   'label' => 'URL', // Table column heading
+   'type'  => 'model_function_attribute',
+   'function_name' => 'getSlugWithLink', // the method in your Model
+   // 'function_parameters' => [$one, $two], // pass one/more parameters to that method
+   'attribute' => 'route',
+   // 'limit' => 100, // Limit the number of characters shown
+   // 'escaped' => false, // echo using {!! !!} instead of {{ }}, in order to render HTML
+],
+```
+
+<hr>
+
+<a name="multidimensional_array"></a>
+### multidimensional_array
+
+
+Enumerate the values in a multidimensional array, stored in the db as JSON.
+
+```php
+[
+   'name'        => 'options', // The db column name
+   'label'       => 'Options', // Table column heading
+   'type'        => 'multidimensional_array',
+   'visible_key' => 'name' // The key to the attribute you would like shown in the enumeration
+],
+```
+
+<hr>
+
+<a name="number"></a>
+### number
+
+
+The text column will just output the number value of a db column (or model attribute). Its definition is:
+```php
+[
+   'name'  => 'name', // The db column name
+   'label' => 'Tag Name', // Table column heading
+   'type'  => 'number',
+   // 'prefix'        => '$',
+   // 'suffix'        => ' EUR',
+   // 'decimals'      => 2,
+   // 'dec_point'     => ',',
+   // 'thousands_sep' => '.',
+   // decimals, dec_point and thousands_sep are used to format the number;
+   // for details on how they work check out PHP's number_format() method, they're passed directly to it;
+   // https://www.php.net/manual/en/function.number-format.php
+],
+```
+
+<hr>
+
+<a name="phone"></a>
+### phone
+
+The phone column will output the phone number from the database (truncated to 254 characters if needed), with a ```tel:``` link so that users on mobile can click them to call (or with Skype or similar browser extensions). Its definition is:
+```php
+[
+   'name'     => 'phone', // The db column name
+   'label'    => 'Phone number', // Table column heading
+   'type'     => 'phone',
+   // 'limit' => 10, // if you want to truncate the phone number to a different number of characters
+],
+```
+
+<hr>
+
+<a name="radio"></a>
+### radio
+
+
+Show a pretty text instead of the database value, according to an associative array. Usually used as a column for the "radio" field type.
+
+```php
+[
+    'name'        => 'status',
+    'label'       => 'Status',
+    'type'        => 'radio',
+    'options'     => [
+        0 => 'Draft',
+        1 => 'Published'
+    ]
+],
+```
+
+This example will show: 
+- "Draft" when the value stored in the db is 0;
+- "Published" when the value stored in the db is 1;  
+
+<hr>
+
+<a name="relationship"></a>
+### relationship
+
+Output the related entries, no matter the relationship:
+- 1-n relationships - outputs the name of its one connected entity;
+- n-n relationships - enumerates the names of all its connected entities;
+
+Its name and definition is the same as for the relationship *field type*:
+```php
+[  
+   // any type of relationship
+   'name'         => 'tags', // name of relationship method in the model
+   'type'         => 'relationship',
+   'label'        => 'Tags', // Table column heading
+   // OPTIONAL
+   // 'entity'    => 'tags', // the method that defines the relationship in your Model
+   // 'attribute' => 'name', // foreign key attribute that is shown to user
+   // 'model'     => App\Models\Category::class, // foreign key model
+],
+```
+
+Backpack tries to guess which attribute to show for the related item. Something that the end-user will recognize as unique. If it's something common like "name" or "title" it will guess it. If not, you can manually specify the ```attribute``` inside the column definition, or you can add ```public $identifiableAttribute = 'column_name';``` to your model, and Backpack will use that column as the one the user finds identifiable. It will use it here, and it will use it everywhere you haven't explicitly asked for a different attribute.
+
+<hr>
+
+<a name="relationship_count"></a>
+### relationship_count
+
+Shows the number of items that are related to the current entry, for a particular relationship.
+
+```php
+[
+   // relationship count
+   'name'      => 'tags', // name of relationship method in the model
+   'type'      => 'relationship_count', 
+   'label'     => 'Tags', // Table column heading
+   // OPTIONAL
+   // 'suffix' => ' tags', // to show "123 tags" instead of "123 items"
+],
+```
+
+**Important Note:** This column will load ALL related items onto the page. Which is not a problem normally, for small tables. But if your related table has thousands or millions of entries, it will considerably slow down the page. For a much more performant option, with the same result, you can add a fake column to the results using Laravel's `withCount()` method, then use the `text` column to show that number. That will be a lot faster, and the end-result is identical from the user's perspective. For the same example above (number of tags) this is how it will look:
+```
+$this->crud->query->withCount('tags'); // this will add a tags_count column to the results
+$this->crud->addColumn([
+   'name'      => 'tags_count', // name of relationship method in the model
+   'type'      => 'text', 
+   'label'     => 'Tags', // Table column heading
+   'suffix'    => ' tags', // to show "123 tags" instead of "123"
+]);
+```
+
+<hr>
+
+<a name="row_number"></a>
+### row_number
+
+
+Show the row number (index). The number depends strictly on the result set (x records per page, pagination, search, filters, etc). It does not get any information from the database. It is not searchable. It is only useful to show the current row number.
+
+```php
+$this->crud->addColumn([
+    'name'      => 'row_number',
+    'type'      => 'row_number',
+    'label'     => '#',
+    'orderable' => false,
+])->makeFirstColumn();
+```
+
+Notes:
+- you can have a different ```name```; just make sure your model doesn't have that attribute;
+- you can have a different label;
+- you can place the column as second / third / etc if you remove ```makeFirstColumn()```;
+- this column type allows the use of suffix/prefix just like the text column type;
+- if upon placement you notice it always shows ```false``` then please note there have been changes in the ```search()``` method - you need to add another parameter to your ```getEntriesAsJsonForDatatables()``` call;
+
+<hr>
+
+<a name="select"></a>
+### select
+
+The select column will output its connected entity. Used for relationships like hasOne() and belongsTo(). Its name and definition is the same as for the select *field type*:
+```php
+[
+   // 1-n relationship
+   'label'     => 'Parent', // Table column heading
+   'type'      => 'select',
+   'name'      => 'parent_id', // the column that contains the ID of that connected entity;
+   'entity'    => 'parent', // the method that defines the relationship in your Model
+   'attribute' => 'name', // foreign key attribute that is shown to user
+   'model'     => "App\Models\Category", // foreign key model
+],
+```
+
+<hr>
+<a name="select_from_array"></a>
+### select_from_array
+
+Show a particular text depending on the value of the attribute.
+
+```php
+[
+    // select_from_array
+    'name'    => 'status',
+    'label'   => 'Status',
+    'type'    => 'select_from_array',
+    'options' => ['draft' => 'Draft (invisible)', 'published' => 'Published (visible)'],
+],
+```
+
+<hr>
+
+<a name="select_multiple"></a>
+### select_multiple
+
+The select_multiple column will output a comma separated list of its connected entities. Used for relationships like hasMany() and belongsToMany(). Its name and definition is the same as the select_multiple field:
+```php
+[
+   // n-n relationship (with pivot table)
+   'label'     => 'Tags', // Table column heading
+   'type'      => 'select_multiple',
+   'name'      => 'tags', // the method that defines the relationship in your Model
+   'entity'    => 'tags', // the method that defines the relationship in your Model
+   'attribute' => 'name', // foreign key attribute that is shown to user
+   'model'     => 'App\Models\Tag', // foreign key model
+],
+```
+
+<hr>
+
+<a name="table"></a>
+### table
+
+
+The ```table``` column will output a condensed table, when used on an attribute that stores a JSON array or object. It is meant to be used inside the show functionality (not list, though it also works there).
+
+Its definition is very similar to the [table *field type*](/docs/{{version}}/crud-fields#table).
+
+```php
+[
+    'name'  => 'features', 
+    'label' => 'Features', 
+    'type'  => 'table', 
+    'columns' => [
+        'name'        => 'Name',
+        'description' => 'Description',
+        'price'       => 'Price',
+        'obs'         => 'Observations'
+    ]
+],
+```
+
+<hr>
+
+<a name="text"></a>
+### text
+
+The text column will just output the text value of a db column (or model attribute). Its definition is:
+```php
+[
+   'name'      => 'name', // The db column name
+   'label'     => 'Tag Name', // Table column heading
+   // 'prefix' => 'Name: ',
+   // 'suffix' => '(user)',
+   // 'limit'  => 120, // character limit; default is 50,
+],
+```
+
+**Advanced use case:** The ```text``` column type can also show the attribute of a 1-1 relationship. If you have a relationship (like ```parent()```) set up in your Model, you can use relationship and attribute in the ```name```, using dot notation:
+```php
+[
+    'name'  => 'parent.title',
+    'label' => 'Title',
+    'type'  => 'text'
+],
+```
+
+<hr>
+
+<a name="textarea"></a>
+### textarea
+The text column will just output the text value of a db column (or model attribute) in a textarea field. Its definition is:
+```php
+[
+   'name'      => 'name', // The db column name
+   'label'     => 'Tag Name', // Table column heading
+   // 'prefix' => 'Name: ',
+   // 'suffix' => '(user)',
+   // 'limit'  => 120, // character limit; default is 50
+   // 'escaped' => false, // echo using {!! !!} instead of {{ }}, in order to render HTML
+],
+```
+
+<a name="upload_multiple"></a>
+### upload_multiple
+
+
+The ```table``` column will output a list of files and links, when used on an attribute that stores a JSON array of file paths. It is meant to be used inside the show functionality (not list, though it also works there), to preview files uploaded with the ```upload_multiple``` field type.
+
+Its definition is very similar to the [upload_multiple *field type*](/docs/{{version}}/crud-fields#upload_multiple).
+
+```php
+[
+    'name'    => 'photos',
+    'label'   => 'Photos',
+    'type'    => 'upload_multiple',
+    // 'disk' => 'public', // filesystem disk if you're using S3 or something custom
+],
+```
+
+<hr>
+
+<a name="video"></a>
+### video
+
+
+Display a small screenshot for a Youtube or Vimeo video, stored in the database as JSON using the "video" field type.
+
+```php
+[
+   'name'  => 'name', // The db column name
+   'label' => 'Tag Name', // Table column heading
+   'type'  => 'video',
+],
+```
+
+<hr>
+
+<a name="view"></a>
+### view
+
+Display any custom column type you want. Usually used by Backpack package developers, to use views from within their packages, instead of having to publish the views. 
+
+```php
+[
+   'name'  => 'name', // The db column name
+   'label' => 'Tag Name', // Table column heading
+   'type'  => 'view',
+   'view'  => 'package::columns.column_type_name', // or path to blade file
+],
+```
+
+<hr>
+
+<a name="overwriting-default-column-types"></a>
+## Overwriting Default Column Types
+
+You can overwrite a column type by placing a file with the same name in your ```resources\views\vendor\backpack\crud\columns``` directory. When a file is there, Backpack will pick that one up, instead of the one in the package. You can do that from command line using ```php artisan backpack:publish crud/columns/column-file-name```
+
+Examples:
+- creating a ```resources\views\vendor\backpack\crud\columns\number.blade.php``` file would overwrite the ```number``` column functionality;
+- ```php artisan backpack:publish crud/columns/text``` will take the view from the package and copy it to the directory above, so you can edit it;
+
+>Keep in mind that when you're overwriting a default column type, you're forfeiting any future updates for that column. We can't push updates to a file that you're no longer using.
+
+<hr>
+
+<a name="creating-a-custom-column-type"></a>
+## Creating a Custom Column Type
+
+Columns consist of only one file - a blade file with the same name as the column type (ex: ```text.blade.php```). You can create one by placing a new blad file inside ```resources\views\vendor\backpack\crud\columns```. Be careful to choose a distinctive name, otherwise you might be overwriting a default column type (see above).
+
+For example, you can create a ```markdown.blade.php```:
+```php
+<span>{!! \Markdown::convertToHtml($entry->{$column['name']}) !!}</span>
+```
+
+The most useful variables you'll have in this file here are:
+- ```$entry``` - the database entry you're showing (Eloquent object);
+- ```$crud``` - the entire CrudPanel object, with settings, options and variables;
+
+By default, custom columns are not searchable. In order to make your column searchable you need to [specify a custom ```searchLogic``` in your declaration](#custom-search-logic).
+
+
+<hr>
+
+<a name="advanced-columns-use"></a>
+## Advanced Columns Use
+
+<a name="custom-search-logic"></a>
+### Custom Search Logic for Columns
+
+If your column points to something atypical (not a value that is stored as plain text in the database column, maybe a model function, or a JSON, or something else), you might find that the search doesn't work for that column. You can choose which columns are searchable, and what those columns actually search, by using the column's ```searchLogic``` attribute:
+
+```php
+// column with custom search logic
+$this->crud->addColumn([
+    'name'        => 'slug_or_title',
+    'label'       => 'Title',
+    'searchLogic' => function ($query, $column, $searchTerm) {
+        $query->orWhere('title', 'like', '%'.$searchTerm.'%');
+    }
+]);
+
+
+// 1-n relationship column with custom search logic
+$this->crud->addColumn([
+    'label'       => 'Cruise Ship',
+    'type'        => 'select',
+    'name'        => 'cruise_ship_id',
+    'entity'      => 'cruise_ship',
+    'attribute'   => 'cruise_ship_name_date', // combined name & date column
+    'model'       => 'App\Models\CruiseShip',
+    'searchLogic' => function ($query, $column, $searchTerm) {
+        $query->orWhereHas('cruise_ship', function ($q) use ($column, $searchTerm) {
+            $q->where('name', 'like', '%'.$searchTerm.'%')
+              ->orWhereDate('depart_at', '=', date($searchTerm));
+        });
+    }
+]);
+
+
+// column that doesn't need to be searchable
+$this->crud->addColumn([
+    'name'        => 'slug_or_title',
+    'label'       => 'Title',
+    'searchLogic' => false
+]);
+
+// column whose search logic should behave like it were a 'text' column type
+$this->crud->addColumn([
+    'name'        => 'slug_or_title',
+    'label'       => 'Title',
+    'searchLogic' => 'text'
+]);
+```
+
+<a name="custom-order-logic"></a>
+### Custom Order Logic for Columns
+
+If your column points to something atypical (not a value that is stored as plain text in the database column, maybe a model function, or a JSON, or something else), you might find that the ordering doesn't work for that column. You can choose which columns are orderable, and how those columns actually get ordered, by using the column's ```orderLogic``` attribute.
+
+For example, to order Articles not by its Category ID (as default, but by the Category Name), you can do:
+
+```php
+$this->crud->addColumn([
+    // Select
+   'label'      => 'Category',
+   'type'       => 'select',
+   'name'       => 'category_id', // the db column for the foreign key
+   'entity'     => 'category', // the method that defines the relationship in your Model
+   'attribute'  => 'name', // foreign key attribute that is shown to user
+   'orderable'  => true,
+   'orderLogic' => function ($query, $column, $columnDirection) {
+        return $query->leftJoin('categories', 'categories.id', '=', 'articles.select')
+            ->orderBy('categories.name', $columnDirection)->select('articles.*');
+    }
+]);
+```
+
+
+<a name="custom-wrapper-for-columns"></a>
+### Wrap Column Text in an HTML Element 
+
+Sometimes the text that the column echoes is not enough. You want to add interactivity to it, by adding a link to that column. Or you want to show the value in a green/yellow/red badge so it stands out. You can do both of that - with the ```wrapper``` attribute, which most columns support.
+
+For example, you can wrap the text in an anchor element, to point to that Article's Show operation:
+
+```php
+$this->crud->addColumn([
+  // Select
+  'label'     => 'Category',
+  'type'      => 'select',
+  'name'      => 'category_id', // the db column for the foreign key
+  'entity'    => 'category', // the method that defines the relationship in your Model
+  'attribute' => 'name', // foreign key attribute that is shown to user
+  'wrapper'   => [
+      // 'element' => 'a', // the element will default to "a" so you can skip it here
+      'href' => function ($crud, $column, $entry, $related_key) {
+          return backpack_url('article/'.$related_key.'/show');
+      },
+      // 'target' => '_blank',
+      // 'class' => 'some-class',
+  ],
+]);
+```
+
+If you specify ```wrapper``` to a column, the entries in that column will be wrapped in the element you specify. Note that: 
+- To get an HTML anchor (a link), you can specify ```a``` for the element (but that's also the default); to get a paragraph you'd specify ```p``` for the element; to get an inline element you'd specify ```span``` for the element; etc;
+- Anything you declare in the ```wrapper``` array (other than ```element```) will be used as HTML attributes for that element (ex: ```class```, ```style```, ```target``` etc);
+- Each wrapper attribute, including the element itself, can be declared as a string OR as a callback;
+
+Let's take another example, and wrap a boolean column into a green/red span:
+
+```php
+$this->crud->addColumn([
+    'name'    => 'published',
+    'label'   => 'Published',
+    'type'    => 'boolean',
+    'options' => [0 => 'No', 1 => 'Yes'], // optional
+    'wrapper' => [
+        'element' => 'span',
+        'class' => function ($crud, $column, $entry, $related_key) {
+            if ($column['text'] == 'Yes') {
+                return 'badge badge-success';
+            }
+
+            return 'badge badge-default';
+        },
+    ],
+]);
+```
+
+
+<a name="choose-where-columns-are-visible"></a>
+### Choose Where Columns are Visible
+
+Starting with Backpack\CRUD 3.5.0, you can choose to show/hide columns in different contexts. You can pass ```true``` / ```false``` to the column attributes below, and Backpack will know to show the column or not, in different contexts:
+
+```php
+$this->crud->addColumn([
+   'name'            => 'description',
+   'visibleInTable'  => false, // no point, since it's a large text
+   'visibleInModal'  => false, // would make the modal too big
+   'visibleInExport' => false, // not important enough
+   'visibleInShow'   => true, // boolean or closure - function($entry) { return $entry->isAdmin(); } 
+]);
+```
+
+This also allows you to do tricky things like:
+- add a column that's hidden from the table view, but WILL get exported;
+- adding a column that's hidden everywhere, but searchable (even with a custom ```searchLogic```);
+
+<a name="multiple-columns-with-the-same-name"></a>
+### Multiple Columns With the Same Name
+
+Starting with Backpack\CRUD 3.3 (Nov 2017), you can have multiple columns with the same name, by specifying a unique ```key``` property. So if you want to use the same column name twice, you can do that. Notice below we have the same name for both columns, but one of them has a ```key```. This additional key will be used as an array key, if provided.
+
+```php
+// column that shows the parent's first name
+$this->crud->addColumn([
+   'label'     => 'Parent First Name', // Table column heading
+   'type'      => 'select',
+   'name'      => 'parent_id', // the column that contains the ID of that connected entity;
+   'entity'    => 'parent', // the method that defines the relationship in your Model
+   'attribute' => 'first_name', // foreign key attribute that is shown to user
+   'model'     => 'App\Models\User', // foreign key model
+]);
+
+// column that shows the parent's last name
+$this->crud->addColumn([
+   'label'     => 'Parent Last Name', // Table column heading
+   'type'      => 'select',
+   'name'      => 'parent_id', // the column that contains the ID of that connected entity;
+   'key'       => 'parent_last_name', // the column that contains the ID of that connected entity;
+   'entity'    => 'parent', // the method that defines the relationship in your Model
+   'attribute' => 'last_name', // foreign key attribute that is shown to user
+   'model'     => 'App\Models\User', // foreign key model
+]);
+```
+
+<a name="escape-column-output"></a>
+### Escape column output
+
+For security purposes, Backpack escapes the output of all column types except for `markdown` and `custom_html` (those columns would be useless escaped). That means it uses `{{ }}` to echo the output, not `{!! !!}`. If you have any HTML inside a db column, it will be shown as HTML instead of interpreted. It does that because, if the value was added by a malicious user (not admin), it could contain malicious JS code.
+
+However, if you trust that a certain column contains _safe_ HTML, you can disable this behaviour by setting the `escaped` attribute to `false`.
+
+Our recommendation, in order to trust the output of a column, is to either:
+- (a) only allow the admin to add/edit that column;
+- (b) purify the value in an accessor on the Model, so that every time you get it, it's cleaned; you can use an [HTML Purifier package](https://github.com/mewebstudio/Purifier) for that (do it [manually](https://github.com/Laravel-Backpack/demo/commit/7342cffb418bb568b9e4ee279859685ddc0456c1) or by casting the attribute to `CleanHtmlOutput::class`);
+
+<a name="define-which-columns-to-hide-in-responsive-table"></a>
+### Define which columns to show or hide in the responsive table
+
+By default, DataTables-responsive will try his best to show:
+- **the first column** (since that usually is the most important for the user, plus it holds the modal button and the details_row button so it's crucial for usability);
+- **the last column** (the actions column, where the action buttons reside);
+
+When giving priorities, lower is better. So a column with priority 4 will be hidden BEFORE a column with priority 2. The first and last columns have a priority of 1. You can define a different priority for a column using the ```priority``` attribute. For example:
+
+```php
+$this->crud->addColumn([
+    'name'     => 'details',
+    'type'     => 'text',
+    'label'    => 'Details',
+    'priority' => 2,
+]);
+$this->crud->addColumn([
+    'name'     => 'obs',
+    'type'     => 'text',
+    'label'    => 'Observations',
+    'priority' => 3,
+]);
+```
+In the example above, depending on how much space it's got in the viewport, DataTables will first hide the ```obs``` column, then ```details```, then the last column, then the first column.
+
+You can make the last column be less important (and hide) by giving it an unreasonable priority:
+
+```php
+$this->crud->setActionsColumnPriority(10000);
+```
+
+>Note that responsive tables adopt special behavior if the table is not able to show all columns. This includes displaying a vertical ellipsis to the left of the row, and making the row clickable to reveal more detail. This behavior is automatic and is not manually controllable via a field property.

--- a/5.x-dev/crud-fields.md
+++ b/5.x-dev/crud-fields.md
@@ -265,140 +265,10 @@ class Category
 
 
 <a name="default-field-types"></a>
-## Default Field Types
-
-<a name="address_algolia"></a>
-### address_algolia
-
-Use [Algolia Places autocomplete](https://community.algolia.com/places/) to help users type their address faster. With the ```store_as_json``` option, it will store the address, postcode, city, country, latitude and longitude in a JSON in the database. Without it, it will just store the address string. For information stored as JSON in the database, it's recommended that you use [attribute casting](https://mattstauffer.co/blog/laravel-5.0-eloquent-attribute-casting) to ```array``` or ```object```. That way, every time you get the info from the database you'd get it in a usable format.
-
-```php
-[   // Address algolia
-    'name'          => 'address',
-    'label'         => 'Address',
-    'type'          => 'address_algolia',
-    // optional
-    'store_as_json' => true
-],
-```
-
-> **Algolia is killing Places.** Please note that Algolia Places **will stop working in May 2022**, as reported in [this announcement](https://www.algolia.com/blog/product/sunseting-our-places-feature/). For that reason, it's probably a good idea to use the `address_google` field instead (it's right after this one).
-
-
-Input preview: 
-
-![CRUD Field - address](https://backpackforlaravel.com/uploads/docs-4-2/fields/address.png)
-
-<hr>
-
-<a name="address_google"></a>
-### address_google
-
-Use [Google Places Search](https://developers.google.com/places/web-service/search) to help users type their address faster. With the ```store_as_json``` option, it will store the address, postcode, city, country, latitude and longitude in a JSON in the database. Without it, it will just store the complete address string.
-
-```php
-[   // Address google
-    'name'          => 'address',
-    'label'         => 'Address',
-    'type'          => 'address_google',
-    // optional
-    'store_as_json' => true
-],
-```
-
-Using Google Places API is dependent on using an API Key. Please [get an API key](https://console.cloud.google.com/apis/credentials) - you do have to configure billing, but you qualify for $200/mo free usage, which covers most use cases. Then copy-paste that key as your ```services.google_places.key``` value. So inside your ```config/services.php``` please add the items below:
-
-```php
-'google_places' => [
-    'key' => 'the-key-you-got-from-google-places'
-],
-```
-
-> **Use attribute casting.** For information stored as JSON in the database, it's recommended that you use [attribute casting](https://mattstauffer.co/blog/laravel-5.0-eloquent-attribute-casting) to ```array``` or ```object```. That way, every time you get the info from the database you'd get it in a usable format. Also, it is heavily recommended that your database column can hold a large JSON - so use `text` rather than `string` in your migration (in MySQL this translates to `text` instead of `varchar`).
-
-Input preview: 
-
-![CRUD Field - address](https://backpackforlaravel.com/uploads/docs-4-2/fields/address_google.png)
-
-<hr>
-
-<a name="browse"></a>
-### browse
-
-This button allows the admin to open [elFinder](http://elfinder.org/) and select a file from there. Run ```composer require backpack/filemanager && php artisan backpack:filemanager:install``` to install [FileManager](https://github.com/laravel-backpack/filemanager), then you can use the field:
-
-```php
-[   // Browse
-    'name'  => 'image',
-    'label' => 'Image',
-    'type'  => 'browse'
-],
-```
-
-
-Input preview: 
-
-![CRUD Field - browse](https://backpackforlaravel.com/uploads/docs-4-2/fields/browse.png)
-
-Onclick preview:
-
-![CRUD Field - browse popup](https://backpackforlaravel.com/uploads/docs-4-2/fields/browse_popup.png)
-
-<hr>
-
-<a name="browse-multiple"></a>
-### browse_multiple
-
-Open elFinder and select multiple files from there. Run ```composer require backpack/filemanager && php artisan backpack:filemanager:install``` to install [FileManager](https://github.com/laravel-backpack/filemanager), then you can use the field:
-
-```php
-[   // Browse multiple
-    'name'          => 'files',
-    'label'         => 'Files',
-    'type'          => 'browse_multiple',
-    // 'multiple'   => true, // enable/disable the multiple selection functionality
-    // 'sortable'   => false, // enable/disable the reordering with drag&drop
-    // 'mime_types' => null, // visible mime prefixes; ex. ['image'] or ['application/pdf']
-],
-```
-
-The field assumes you've cast your attribute as ```array``` on your model.  That way, when you do ```$entry->files``` you get a nice array.
-**NOTE:** If you use `multiple => false` you should NOT cast your attribute as ```array```
-
-Input preview: 
-
-![CRUD Field - browse_multiple](https://backpackforlaravel.com/uploads/docs-4-2/fields/browse_multiple.png)
-
-<hr>
-
-<a name="base64-image"></a>
-### base64_image
-
-Upload an image and store it in the database as Base64. Notes:
-- make sure the column type is LONGBLOB;
-- detailed [instructions and customizations here](https://github.com/Laravel-Backpack/CRUD/pull/56#issue-164712261); 
-
-```php
-// base64_image
-$this->crud->addField([
-    'label'        => "Profile Image",
-    'name'         => "image",
-    'filename'     => "image_filename", // set to null if not needed
-    'type'         => 'base64_image',
-    'aspect_ratio' => 1, // set to 0 to allow any aspect ratio
-    'crop'         => true, // set to true to allow cropping, false to disable
-    'src'          => NULL, // null to read straight from DB, otherwise set to model accessor function
-]);
-```
-
-Input preview: 
-
-![CRUD Field - base64_image](https://backpackforlaravel.com/uploads/docs-4-2/fields/base64_image.png)
-
-<hr>
+## FREE Field Types
 
 <a name="checkbox"></a>
-### checkbox
+### checkbox <span class="badge badge-pill badge-success">FREE</span>
 
 Checkbox for true/false.
 
@@ -417,7 +287,7 @@ Input preview:
 <hr>
 
 <a name="checklist"></a>
-### checklist
+### checklist <span class="badge badge-pill badge-success">FREE</span>
 
 Show a list of checkboxes, for the user to check one or more of them.
 
@@ -443,7 +313,7 @@ Input preview:
 <hr>
 
 <a name="checklist-dependency"></a>
-### checklist_dependency
+### checklist_dependency <span class="badge badge-pill badge-success">FREE</span>
 
 ```php
 [   // two interconnected entities
@@ -482,37 +352,8 @@ Input preview:
 
 <hr>
 
-<a name="ckeditor"></a>
-### ckeditor
-
-Show a wysiwyg CKEditor to the user.
-
-```php
-[   // CKEditor
-    'name'          => 'description',
-    'label'         => 'Description',
-    'type'          => 'ckeditor',
-
-    // optional:
-    'extra_plugins' => ['oembed', 'widget'],
-    'options'       => [
-        'autoGrow_minHeight'   => 200,
-        'autoGrow_bottomSpace' => 50,
-        'removePlugins'        => 'resize,maximize',
-    ]
-],
-```
-
-If you'd like to be able to select files from elFinder, you need to also run ```composer require backpack/filemanager``` to install elFinder.
-
-Input preview: 
-
-![CRUD Field - ckeditor](https://backpackforlaravel.com/uploads/docs-4-2/fields/ckeditor.png)
-
-<hr>
-
 <a name="color"></a>
-### color
+### color <span class="badge badge-pill badge-success">FREE</span>
 
 ```php
 [   // Color
@@ -529,53 +370,8 @@ Input preview:
 
 <hr>
 
-<a name="color-picker"></a>
-### color_picker
-
-Show a pretty colour picker using [Bootstrap Colorpicker](https://itsjavi.com/bootstrap-colorpicker/).
-
-```php
-[   // color_picker
-    'label'                => 'Background Color',
-    'name'                 => 'background_color',
-    'type'                 => 'color_picker',
-    'default'              => '#000000',
-
-    // optional
-    // Anything your define inside `color_picker_options` will be passed as JS
-    // to the JavaScript plugin. For more information about the options available
-    // please see the plugin docs at:
-    //  ### https://itsjavi.com/bootstrap-colorpicker/module-options.html
-    'color_picker_options' => [
-        'customClass' => 'custom-class',
-        'horizontal' => true,
-        'extensions' => [
-            [
-                'name' => 'swatches', // extension name to load
-                'options' => [ // extension options
-                    'colors' => [
-                        'primary' => '#337ab7',
-                        'success' => '#5cb85c',
-                        'info' => '#5bc0de',
-                        'warning' => '#f0ad4e',
-                        'danger' => '#d9534f'
-                    ],
-                    'namesAsValues' => false
-                ]
-            ]
-        ]
-    ]
-],
-```
-
-Input preview: 
-
-![CRUD Field - color_picker](https://backpackforlaravel.com/uploads/docs-4-2/fields/color_picker.png)
-
-<hr>
-
 <a name="custom-html"></a>
-### custom_html
+### custom_html <span class="badge badge-pill badge-success">FREE</span>
 
 Allows you to insert custom HTML in the create/update forms. Usually used in forms with a lot of fields, to separate them using h1-h5, hr, etc, but can be used for any HTML.
 
@@ -588,7 +384,7 @@ Allows you to insert custom HTML in the create/update forms. Usually used in for
 ```
 
 <a name="date"></a>
-### date
+### date <span class="badge badge-pill badge-success">FREE</span>
 
 ```php
 [   // Date
@@ -604,72 +400,8 @@ Input preview:
 
 <hr>
 
-<a name="date-picker"></a>
-### date_picker
-
-Show a pretty [Bootstrap Datepicker](http://bootstrap-datepicker.readthedocs.io/en/latest/).
-
-```php
-[   // date_picker
-   'name'  => 'date',
-   'type'  => 'date_picker',
-   'label' => 'Date',
-
-   // optional:
-   'date_picker_options' => [
-      'todayBtn' => 'linked',
-      'format'   => 'dd-mm-yyyy',
-      'language' => 'fr'
-   ],
-],
-```
-
-Please note it is recommended that you use [attribute casting](https://laravel.com/docs/5.3/eloquent-mutators#attribute-casting) on your model (cast to date).
-
-
-Input preview: 
-
-![CRUD Field - date_picker](https://backpackforlaravel.com/uploads/docs-4-2/fields/date_picker.png)
-
-<hr>
-
-<a name="date-range"></a>
-### date_range
-
-Starting with Backpack\CRUD 3.1.59
-
-Show a DateRangePicker and let the user choose a start date and end date.
-
-```php
-[   // date_range
-    'name'  => ['start_date', 'end_date'], // db columns for start_date & end_date
-    'label' => 'Event Date Range',
-    'type'  => 'date_range',
-
-    // OPTIONALS
-    // default values for start_date & end_date
-    'default'            => ['2019-03-28 01:01', '2019-04-05 02:00'], 
-    // options sent to daterangepicker.js
-    'date_range_options' => [
-        'drops' => 'down', // can be one of [down/up/auto]
-        'timePicker' => true,
-        'locale' => ['format' => 'DD/MM/YYYY HH:mm']
-    ]
-],
-```
-
-Please note it is recommended that you use [attribute casting](https://laravel.com/docs/5.3/eloquent-mutators#attribute-casting) on your model (cast to date).
-
-Your end result will look like this:
-
-Input preview: 
-
-![CRUD Field - date_range](https://backpackforlaravel.com/uploads/docs-4-2/fields/date_range.png)
-
-<hr>
-
 <a name="datetime"></a>
-### datetime
+### datetime <span class="badge badge-pill badge-success">FREE</span>
 
 ```php
 [   // DateTime
@@ -693,48 +425,8 @@ Input preview:
 
 <hr>
 
-<a name="datetime-picker"></a>
-### datetime_picker
-
-Show a [Bootstrap Datetime Picker](https://eonasdan.github.io/bootstrap-datetimepicker/).
-
-```php
-[   // DateTime
-    'name'  => 'start',
-    'label' => 'Event start',
-    'type'  => 'datetime_picker',
-
-    // optional:
-    'datetime_picker_options' => [
-        'format' => 'DD/MM/YYYY HH:mm',
-        'language' => 'pt',
-        'tooltips' => [ //use this to translate the tooltips in the field
-                'today' => 'Hoje',
-                'selectDate' => 'Selecione a data',
-                // available tooltips: today, clear, close, selectMonth, prevMonth, nextMonth, selectYear, prevYear, nextYear, selectDecade, prevDecade, nextDecade, prevCentury, nextCentury, pickHour, incrementHour, decrementHour, pickMinute, incrementMinute, decrementMinute, pickSecond, incrementSecond, decrementSecond, togglePeriod, selectTime, selectDate
-        ]
-    ],
-    'allows_null' => true,
-    // 'default' => '2017-05-12 11:59:59',
-],
-```
-
-**Please note:** if you're using date [attribute casting](https://laravel.com/docs/5.3/eloquent-mutators#attribute-casting) on your model, you may also need to place this mutator inside your model:
-```php
-	public function setDatetimeAttribute($value) {
-		$this->attributes['datetime'] = \Carbon\Carbon::parse($value);
-	}
-```
-Otherwise the input's datetime-local format will cause some errors. Remember to change "datetime" with the name of your attribute (column name).
-
-Input preview: 
-
-![CRUD Field - datetime_picker](https://backpackforlaravel.com/uploads/docs-4-2/fields/datetime_picker.png)
-
-<hr>
-
 <a name="easymde"></a>
-### easymde
+### easymde <span class="badge badge-pill badge-success">FREE</span>
 
 Show an [EasyMDE - Markdown Editor](https://easy-markdown-editor.tk/) to the user. EasyMDE is a well-maintained fork of SimpleMDE.
 
@@ -763,7 +455,7 @@ Input preview:
 <hr>
 
 <a name="email"></a>
-### email
+### email <span class="badge badge-pill badge-success">FREE</span>
 
 ```php
 [   // Email
@@ -781,7 +473,7 @@ Input preview:
 <hr>
 
 <a name="enum"></a>
-### enum
+### enum <span class="badge badge-pill badge-success">FREE</span>
 
 Show a select with the values in the database for that ENUM field. Requires that the db column type is "enum". If the db column allows null, the " - " value will also show up in the select.
 
@@ -802,7 +494,7 @@ Input preview:
 <hr>
 
 <a name="hidden"></a>
-### hidden
+### hidden <span class="badge badge-pill badge-success">FREE</span>
 
 Include an `<input type="hidden">` in the form.
 
@@ -816,139 +508,8 @@ Include an `<input type="hidden">` in the form.
 
 <hr>
 
-<a name="icon-picker"></a>
-### icon_picker
-
-Show an icon picker. Supported icon sets are fontawesome, lineawesome, glyphicon, ionicon, weathericon, mapicon, octicon, typicon, elusiveicon, materialdesign as per the jQuery plugin, [bootstrap-iconpicker](http://victor-valencia.github.io/bootstrap-iconpicker/).
-
-The stored value will be the class name (ex: fa-home).
-
-```php
-[   // icon_picker
-    'label'   => "Icon",
-    'name'    => 'icon',
-    'type'    => 'icon_picker',
-    'iconset' => 'fontawesome' // options: fontawesome, lineawesome, glyphicon, ionicon, weathericon, mapicon, octicon, typicon, elusiveicon, materialdesign
-],
-```
-
-Your input will look like button, with a dropdown where the user can search or pick an icon:
-
-Input preview: 
-
-![CRUD Field - icon_picker](https://backpackforlaravel.com/uploads/docs-4-2/fields/icon_picker.png)
-
-<hr>
-
-<a name="image"></a>
-### image
-
-Upload an image and store it on the disk. 
-
-**Step 1.** Show the field. 
-```php
-// image
-$this->crud->addField([
-    'label' => "Profile Image",
-    'name' => "image",
-    'type' => 'image',
-    'crop' => true, // set to true to allow cropping, false to disable
-    'aspect_ratio' => 1, // omit or set to 0 to allow any aspect ratio
-    // 'disk'      => 's3_bucket', // in case you need to show images from a different disk
-    // 'prefix'    => 'uploads/images/profile_pictures/' // in case your db value is only the file name (no path), you can use this to prepend your path to the image src (in HTML), before it's shown to the user;
-]);
-```
-
-**Step 2.** Add a [mutator](https://laravel.com/docs/7.x/eloquent-mutators#defining-a-mutator) to your Model, where you pick up the uploaded file and store it wherever you want. You can use this boilerplate code and modify it to match your use case. 
-
-**NOTE: The code below requires that you have ```intervention/image``` installed. If you don't, please do ```composer require intervention/image``` first.**
-
-```php
-// ..
-
-use Illuminate\Support\Str;
-use Intervention\Image\ImageManagerStatic as Image;
-
-// ..
-
-Class Product extends Model
-{
-    // ..
-
-    public function setImageAttribute($value)
-    {
-        $attribute_name = "image";
-        // or use your own disk, defined in config/filesystems.php
-        $disk = config('backpack.base.root_disk_name'); 
-        // destination path relative to the disk above
-        $destination_path = "public/uploads/folder_1/folder_2"; 
-
-        // if the image was erased
-        if ($value==null) {
-            // delete the image from disk
-            \Storage::disk($disk)->delete($this->{$attribute_name});
-
-            // set null in the database column
-            $this->attributes[$attribute_name] = null;
-        }
-
-        // if a base64 was sent, store it in the db
-        if (Str::startsWith($value, 'data:image'))
-        {
-            // 0. Make the image
-            $image = \Image::make($value)->encode('jpg', 90);
-            
-	        // 1. Generate a filename.
-            $filename = md5($value.time()).'.jpg';
-            
-	        // 2. Store the image on disk.
-            \Storage::disk($disk)->put($destination_path.'/'.$filename, $image->stream());
-	    
-	        // 3. Delete the previous image, if there was one.
-            \Storage::disk($disk)->delete($this->{$attribute_name});
-		
-            // 4. Save the public path to the database
-	        // but first, remove "public/" from the path, since we're pointing to it 
-            // from the root folder; that way, what gets saved in the db
-	        // is the public URL (everything that comes after the domain name)
-            $public_destination_path = Str::replaceFirst('public/', '', $destination_path);
-            $this->attributes[$attribute_name] = $public_destination_path.'/'.$filename;
-        }
-    }
-    
-// ..
-```
-> **The uploaded images are not deleted for you.** If you delete an entry (using the CRUD or anywhere inside your app), the image file won't be deleted from the disk.
-> If you're NOT using soft deletes on that Model and want the image to be deleted at the same time the entry is, just specify that in your Model's ```deleting``` event:
-> ```php
->	public static function boot()
->	{
->		parent::boot();
->		static::deleted(function($obj) {
->			\Storage::disk('public_folder')->delete($obj->image);
->		});
->	}
-> ```
-
-**A note about aspect_ratio**
-The value for aspect ratio is a float that represents the ratio of the cropping rectangle height and width. By way of example,
-
-- Square = 1
-- Landscape = 2
-- Portrait = 0.5
-
-And you can, of course, use any value for more extreme rectangles.
-
-Input preview: 
-
-![CRUD Field - image](https://backpackforlaravel.com/uploads/docs-4-2/fields/image.png)
-
-> NOTE: if you are having trouble uploading big images, please check your php extensions **apcu** and/or **opcache**, users have reported some issues with these extensions when trying to upload very big images. REFS: https://github.com/Laravel-Backpack/CRUD/issues/3457
-
-<hr>
-
 <a name="month"></a>
-### month
+### month <span class="badge badge-pill badge-success">FREE</span>
 
 ```php
 [   // Month
@@ -965,7 +526,7 @@ Input preview:
 <hr>
 
 <a name="number"></a>
-### number
+### number <span class="badge badge-pill badge-success">FREE</span>
 
 Shows an input type=number to the user, with optional prefix and suffix:
 
@@ -982,14 +543,14 @@ Shows an input type=number to the user, with optional prefix and suffix:
 ],
 ```
 
-Input preview: 
+Input preview:
 
 ![CRUD Field - number](https://backpackforlaravel.com/uploads/docs-4-2/fields/number.png)
 
 <hr>
 
 <a name="password"></a>
-### password
+### password <span class="badge badge-pill badge-success">FREE</span>
 
 ```php
 [   // Password
@@ -999,7 +560,7 @@ Input preview:
 ],
 ```
 
-Input preview: 
+Input preview:
 
 ![CRUD Field - password](https://backpackforlaravel.com/uploads/docs-4-2/fields/password.png)
 
@@ -1044,7 +605,7 @@ public function setPasswordAttribute($value) {
 <hr>
 
 <a name="radio"></a>
-### radio
+### radio <span class="badge badge-pill badge-success">FREE</span>
 
 Show radios according to an associative array you give the input and let the user pick from them. You can choose for the radio options to be displayed inline or one-per-line.
 
@@ -1070,7 +631,7 @@ Input preview:
 <hr>
 
 <a name="range"></a>
-### range
+### range <span class="badge badge-pill badge-success">FREE</span>
 
 Shows an HTML5 range element, allowing the user to drag a cursor left-right, to pick a number from a defined range.
 
@@ -1093,8 +654,847 @@ Input preview:
 
 <hr>
 
+<a name="select"></a>
+### select (1-n relationship) <span class="badge badge-pill badge-success">FREE</span>
+
+Show a Select with the names of the connected entity and let the user select one of them.
+Your relationships should already be defined on your models as hasOne() or belongsTo().
+
+```php
+[  // Select
+   'label'     => "Category",
+   'type'      => 'select',
+   'name'      => 'category_id', // the db column for the foreign key
+
+   // optional
+   // 'entity' should point to the method that defines the relationship in your Model
+   // defining entity will make Backpack guess 'model' and 'attribute'
+   'entity'    => 'category',
+
+   // optional - manually specify the related model and attribute
+   'model'     => "App\Models\Category", // related model
+   'attribute' => 'name', // foreign key attribute that is shown to user
+
+   // optional - force the related options to be a custom query, instead of all();
+   'options'   => (function ($query) {
+        return $query->orderBy('name', 'ASC')->where('depth', 1)->get();
+    }), //  you can use this to filter the results show in the select
+],
+```
+
+For more information about the optional attributes that fields use when they interact with related entries - [look here](#optional-attributes-for-fields-containing-related-entries).
+
+Input preview:
+
+![CRUD Field - select](https://backpackforlaravel.com/uploads/docs-4-2/fields/select.png)
+
+
+<hr>
+
+
+<a name="select-grouped"></a>
+### select_grouped <span class="badge badge-pill badge-success">FREE</span>
+
+Display a select where the options are grouped by a second entity (like Categories).
+
+```php
+[   // select_grouped
+    'label'     => 'Articles grouped by categories',
+    'type'      => 'select_grouped', //https://github.com/Laravel-Backpack/CRUD/issues/502
+    'name'      => 'article_id',
+    'entity'    => 'article',
+    'attribute' => 'title',
+    'group_by'  => 'category', // the relationship to entity you want to use for grouping
+    'group_by_attribute' => 'name', // the attribute on related model, that you want shown
+    'group_by_relationship_back' => 'articles', // relationship from related model back to this model
+],
+```
+
+For more information about the optional attributes that fields use when they interact with related entries - [look here](#optional-attributes-for-fields-containing-related-entries).
+
+Input preview:
+
+![CRUD Field - select_grouped](https://backpackforlaravel.com/uploads/docs-4-2/fields/select_grouped.png)
+
+<hr>
+
+<a name="select-multiple"></a>
+### select_multiple (n-n relationship) <span class="badge badge-pill badge-success">FREE</span>
+
+Show a Select with the names of the connected entity and let the user select any number of them.
+Your relationship should already be defined on your models as belongsToMany().
+
+```php
+[   // SelectMultiple = n-n relationship (with pivot table)
+    'label'     => "Tags",
+    'type'      => 'select_multiple',
+    'name'      => 'tags', // the method that defines the relationship in your Model
+
+    // optional
+    'entity'    => 'tags', // the method that defines the relationship in your Model
+    'model'     => "App\Models\Tag", // foreign key model
+    'attribute' => 'name', // foreign key attribute that is shown to user
+    'pivot'     => true, // on create&update, do you need to add/delete pivot table entries?
+
+    // also optional
+    'options'   => (function ($query) {
+        return $query->orderBy('name', 'ASC')->where('depth', 1)->get();
+    }), // force the related options to be a custom query, instead of all(); you can use this to filter the results show in the select
+],
+```
+
+For more information about the optional attributes that fields use when they interact with related entries - [look here](#optional-attributes-for-fields-containing-related-entries).
+
+Input preview:
+
+![CRUD Field - select_multiple](https://backpackforlaravel.com/uploads/docs-4-2/fields/select_multiple.png)
+
+
+<hr>
+
+<a name="select-from-array"></a>
+### select_from_array <span class="badge badge-pill badge-success">FREE</span>
+
+Display a select with the values you want:
+
+```php
+[   // select_from_array
+    'name'        => 'template',
+    'label'       => "Template",
+    'type'        => 'select_from_array',
+    'options'     => ['one' => 'One', 'two' => 'Two'],
+    'allows_null' => false,
+    'default'     => 'one',
+    // 'allows_multiple' => true, // OPTIONAL; needs you to cast this to array in your model;
+],
+```
+
+Input preview:
+
+![CRUD Field - select_from_array](https://backpackforlaravel.com/uploads/docs-4-2/fields/select_from_array.png)
+
+<hr>
+
+<a name="text"></a>
+### text <span class="badge badge-pill badge-success">FREE</span>
+
+The basic field type, all it needs is the two mandatory parameters: name and label.
+
+```php
+[   // Text
+    'name'  => 'title',
+    'label' => "Title",
+    'type'  => 'text',
+
+    // optional
+    //'prefix'     => '',
+    //'suffix'     => '',
+    //'default'    => 'some value', // default value
+    //'hint'       => 'Some hint text', // helpful text, show up after input
+    //'attributes' => [
+       //'placeholder' => 'Some text when empty',
+       //'class' => 'form-control some-class',
+       //'readonly'  => 'readonly',
+       //'disabled'  => 'disabled',
+     //], // extra HTML attributes and values your input might need
+     //'wrapper'   => [
+       //'class' => 'form-group col-md-12'
+     //], // extra HTML attributes for the field wrapper - mostly for resizing fields
+
+],
+```
+
+You can use the optional 'prefix' and 'suffix' attributes to display something before and after the input, like icons, path prefix, etc:
+
+Input preview:
+
+![CRUD Field - text](https://backpackforlaravel.com/uploads/docs-4-2/fields/text.png)
+
+<hr>
+
+<a name="textarea"></a>
+### textarea <span class="badge badge-pill badge-success">FREE</span>
+
+Show a textarea to the user.
+
+```php
+[   // Textarea
+    'name'  => 'description',
+    'label' => 'Description',
+    'type'  => 'textarea'
+],
+```
+
+Input preview:
+
+![CRUD Field - textarea](https://backpackforlaravel.com/uploads/docs-4-2/fields/textarea.png)
+
+<hr>
+
+<a name="time"></a>
+### time <span class="badge badge-pill badge-success">FREE</span>
+
+```php
+[   // Time
+    'name'  => 'start',
+    'label' => 'Start time',
+    'type'  => 'time'
+],
+```
+
+<hr>
+
+<a name="upload"></a>
+### upload <span class="badge badge-pill badge-success">FREE</span>
+
+**Step 1.** Show a file input to the user:
+```php
+[   // Upload
+    'name'      => 'image',
+    'label'     => 'Image',
+    'type'      => 'upload',
+    'upload'    => true,
+    'disk'      => 'uploads', // if you store files in the /public folder, please omit this; if you store them in /storage or S3, please specify it;
+    // optional:
+    'temporary' => 10 // if using a service, such as S3, that requires you to make temporary URLs this will make a URL that is valid for the number of minutes specified
+],
+```
+
+**Step 2.** In order to save/update/delete the file from disk&db, we need to create [a mutator](https://laravel.com/docs/5.3/eloquent-mutators#defining-a-mutator) on your model:
+```php
+public function setImageAttribute($value)
+    {
+    	$attribute_name = "image";
+    	$disk = "public";
+    	$destination_path = "folder_1/subfolder_1";
+
+    	$this->uploadFileToDisk($value, $attribute_name, $disk, $destination_path);
+
+	// return $this->attributes[{$attribute_name}]; // uncomment if this is a translatable field
+    }
+```
+
+**How it works:**
+
+The field sends the file, through a Request, to the Controller. The Controller then tries to create/update the Model. That's when the mutator on your model will run. That also means we can do any [file validation](https://laravel.com/docs/5.3/validation#rule-file) (```file```, ```image```, ```mimetypes```, ```mimes```) in the Request, before the file is stored on the disk.
+
+>NOTE: If this field is mandatory (required in validation) please use the [sometimes laravel validation rule](https://laravel.com/docs/5.8/validation#conditionally-adding-rules) together with **required** in your validation. (sometimes|required|file etc... )
+
+[The ```uploadFileToDisk()``` method](https://github.com/Laravel-Backpack/CRUD/blob/master/src/app/Models/Traits/HasUploadFields.php#L31-L59) will take care of everything for most use cases:
+
+```php
+/**
+     * Handle file upload and DB storage for a file:
+     * - on CREATE
+     *     - stores the file at the destination path
+     *     - generates a name
+     *     - stores the full path in the DB;
+     * - on UPDATE
+     *     - if the value is null, deletes the file and sets null in the DB
+     *     - if the value is different, stores the different file and updates DB value
+     * /
+public function uploadFileToDisk($value, $attribute_name, $disk, $destination_path) {}
+```
+
+If you wish to have a different functionality, you can delete the method call from your mutator and do your own thing.
+
+>**The uploaded files are not deleted for you.** When you delete an entry (whether through CRUD or the application), the uploaded files will not be deleted.
+
+If you're NOT using soft deletes on that Model and want the file to be deleted at the same time the entry is, just specify that in your Model's ```deleting``` event:
+```php
+	public static function boot()
+	{
+		parent::boot();
+		static::deleting(function($obj) {
+			\Storage::disk('public_folder')->delete($obj->image);
+		});
+	}
+```
+
+Input preview:
+
+![CRUD Field - upload](https://backpackforlaravel.com/uploads/docs-4-2/fields/upload.png)
+
+<hr>
+
+<a name="upload-multiple"></a>
+### upload_multiple <span class="badge badge-pill badge-success">FREE</span>
+
+Shows a multiple file input to the user and stores the values as a JSON array in the database.
+
+**Step 0.** Make sure the db column can hold the amount of text this field will have. For example, for MySQL, VARCHAR(255) might not be enough all the time (for 3+ files), so it's better to go with TEXT. Make sure you're using a big column type in your migration or db.
+
+**Step 1.** Show a multiple file input to the user:
+```php
+[   // Upload
+    'name'      => 'photos',
+    'label'     => 'Photos',
+    'type'      => 'upload_multiple',
+    'upload'    => true,
+    'disk'      => 'uploads', // if you store files in the /public folder, please omit this; if you store them in /storage or S3, please specify it;
+    // optional:
+    'temporary' => 10 // if using a service, such as S3, that requires you to make temporary URLs this will make a URL that is valid for the number of minutes specified
+],
+```
+
+**Step 2.** In order to save/update/delete the files from disk&db, we need to create [a mutator](https://laravel.com/docs/5.3/eloquent-mutators#defining-a-mutator) on your model:
+```php
+public function setPhotosAttribute($value)
+    {
+    	$attribute_name = "photos";
+    	$disk = "public";
+    	$destination_path = "folder_1/subfolder_1";
+
+    	$this->uploadMultipleFilesToDisk($value, $attribute_name, $disk, $destination_path);
+    }
+```
+
+**Step 3.** Since the filenames are stored in the database as a JSON array, we're going to use [attribute casting](https://laravel.com/docs/5.3/eloquent-mutators#attribute-casting) on your model, so every time we get the filenames array from the database it's converted from a JSON array to a PHP array:
+```php
+    protected $casts = [
+    	'photos' => 'array'
+    ];
+```
+
+**How it works:**
+
+The field sends the files, through a Request, to the Controller. The Controller then tries to create/update the Model. That's when the mutator on your model will run. That also means we can do any [file validation](https://laravel.com/docs/5.3/validation#rule-file) (```file```, ```image```, ```mimetypes```, ```mimes```) in the Request, before the files are stored on the disk.
+
+[The ```uploadMultipleFilesToDisk()``` method](https://github.com/Laravel-Backpack/CRUD/blob/master/src/app/Models/Traits/HasUploadFields.php#L76-L113) will take care of everything for most use cases:
+
+```
+/**
+     * Handle multiple file upload and DB storage:
+     * - if files are sent
+     *     - stores the files at the destination path
+     *     - generates random names
+     *     - stores the full path in the DB, as JSON array;
+     * - if a hidden input is sent to clear one or more files
+     *     - deletes the file
+     *     - removes that file from the DB.
+     * /
+public function uploadMultipleFilesToDisk($value, $attribute_name, $disk, $destination_path) {}
+```
+
+If you wish to have a different functionality, you can delete the method call from your mutator and do your own thing.
+
+>**The uploaded files are not deleted for you.** When you delete an entry (whether through CRUD or the application), the uploaded files will not be deleted.
+
+If you're NOT using soft deletes on that Model and want the files to be deleted at the same time the entry is, just specify that in your Model's ```deleting``` event:
+```php
+	public static function boot()
+	{
+		parent::boot();
+		static::deleting(function($obj) {
+			if (count((array)$obj->photos)) {
+				foreach ($obj->photos as $file_path) {
+					\Storage::disk('public_folder')->delete($file_path);
+				}
+			}
+		});
+	}
+```
+
+You might notice the field is using a ```clear_photos``` variable. Don't worry, you don't need it in your db table. That's just used to delete photos upon "update". If you use ```$fillable``` on your model, just don't include it. If you use ```$guarded``` on your model, place it in guarded.
+
+Input preview:
+
+![CRUD Field - upload_multiple](https://backpackforlaravel.com/uploads/docs-4-2/fields/upload_multiple.png)
+
+<a name="url"></a>
+### url <span class="badge badge-pill badge-success">FREE</span>
+
+```php
+[   // URL
+    'name'  => 'link',
+    'label' => 'Link to video file',
+    'type'  => 'url'
+],
+```
+
+<hr>
+
+<a name="view"></a>
+### view <span class="badge badge-pill badge-success">FREE</span>
+
+Load a custom view in the form.
+
+```php
+[   // view
+    'name' => 'custom-ajax-button',
+    'type' => 'view',
+    'view' => 'partials/custom-ajax-button'
+],
+```
+
+**Note:** the same functionality can be achieved using a [custom field type](/docs/{{version}}/crud-fields#creating-a-custom-field-type), or using the [custom_html field type](/docs/{{version}}/crud-fields#custom-html) (if the content is really simple).
+
+<hr>
+
+<a name="week"></a>
+### week <span class="badge badge-pill badge-success">FREE</span>
+
+```php
+[   // Week
+    'name'  => 'first_week',
+    'label' => 'First week',
+    'type'  => 'week'
+],
+```
+
+Input preview:
+
+![CRUD Field - week](https://backpackforlaravel.com/uploads/docs-4-2/fields/week.png)
+
+
+
+<a name="pro-field-types"></a>
+## PRO Field Types
+
+
+<a name="address_algolia"></a>
+### address_algolia <span class="badge badge-pill badge-info">PRO</span>
+
+Use [Algolia Places autocomplete](https://community.algolia.com/places/) to help users type their address faster. With the ```store_as_json``` option, it will store the address, postcode, city, country, latitude and longitude in a JSON in the database. Without it, it will just store the address string. For information stored as JSON in the database, it's recommended that you use [attribute casting](https://mattstauffer.co/blog/laravel-5.0-eloquent-attribute-casting) to ```array``` or ```object```. That way, every time you get the info from the database you'd get it in a usable format.
+
+```php
+[   // Address algolia
+    'name'          => 'address',
+    'label'         => 'Address',
+    'type'          => 'address_algolia',
+    // optional
+    'store_as_json' => true
+],
+```
+
+> **Algolia is killing Places.** Please note that Algolia Places **will stop working in May 2022**, as reported in [this announcement](https://www.algolia.com/blog/product/sunseting-our-places-feature/). For that reason, it's probably a good idea to use the `address_google` field instead (it's right after this one).
+
+
+Input preview:
+
+![CRUD Field - address](https://backpackforlaravel.com/uploads/docs-4-2/fields/address.png)
+
+<hr>
+
+<a name="address_google"></a>
+### address_google <span class="badge badge-pill badge-info">PRO</span>
+
+Use [Google Places Search](https://developers.google.com/places/web-service/search) to help users type their address faster. With the ```store_as_json``` option, it will store the address, postcode, city, country, latitude and longitude in a JSON in the database. Without it, it will just store the complete address string.
+
+```php
+[   // Address google
+    'name'          => 'address',
+    'label'         => 'Address',
+    'type'          => 'address_google',
+    // optional
+    'store_as_json' => true
+],
+```
+
+Using Google Places API is dependent on using an API Key. Please [get an API key](https://console.cloud.google.com/apis/credentials) - you do have to configure billing, but you qualify for $200/mo free usage, which covers most use cases. Then copy-paste that key as your ```services.google_places.key``` value. So inside your ```config/services.php``` please add the items below:
+
+```php
+'google_places' => [
+    'key' => 'the-key-you-got-from-google-places'
+],
+```
+
+> **Use attribute casting.** For information stored as JSON in the database, it's recommended that you use [attribute casting](https://mattstauffer.co/blog/laravel-5.0-eloquent-attribute-casting) to ```array``` or ```object```. That way, every time you get the info from the database you'd get it in a usable format. Also, it is heavily recommended that your database column can hold a large JSON - so use `text` rather than `string` in your migration (in MySQL this translates to `text` instead of `varchar`).
+
+Input preview:
+
+![CRUD Field - address](https://backpackforlaravel.com/uploads/docs-4-2/fields/address_google.png)
+
+<hr>
+
+<a name="browse"></a>
+### browse <span class="badge badge-pill badge-info">PRO</span>
+
+This button allows the admin to open [elFinder](http://elfinder.org/) and select a file from there. Run ```composer require backpack/filemanager && php artisan backpack:filemanager:install``` to install [FileManager](https://github.com/laravel-backpack/filemanager), then you can use the field:
+
+```php
+[   // Browse
+    'name'  => 'image',
+    'label' => 'Image',
+    'type'  => 'browse'
+],
+```
+
+
+Input preview:
+
+![CRUD Field - browse](https://backpackforlaravel.com/uploads/docs-4-2/fields/browse.png)
+
+Onclick preview:
+
+![CRUD Field - browse popup](https://backpackforlaravel.com/uploads/docs-4-2/fields/browse_popup.png)
+
+<hr>
+
+<a name="browse-multiple"></a>
+### browse_multiple <span class="badge badge-pill badge-info">PRO</span>
+
+Open elFinder and select multiple files from there. Run ```composer require backpack/filemanager && php artisan backpack:filemanager:install``` to install [FileManager](https://github.com/laravel-backpack/filemanager), then you can use the field:
+
+```php
+[   // Browse multiple
+    'name'          => 'files',
+    'label'         => 'Files',
+    'type'          => 'browse_multiple',
+    // 'multiple'   => true, // enable/disable the multiple selection functionality
+    // 'sortable'   => false, // enable/disable the reordering with drag&drop
+    // 'mime_types' => null, // visible mime prefixes; ex. ['image'] or ['application/pdf']
+],
+```
+
+The field assumes you've cast your attribute as ```array``` on your model.  That way, when you do ```$entry->files``` you get a nice array.
+**NOTE:** If you use `multiple => false` you should NOT cast your attribute as ```array```
+
+Input preview:
+
+![CRUD Field - browse_multiple](https://backpackforlaravel.com/uploads/docs-4-2/fields/browse_multiple.png)
+
+<hr>
+
+<a name="base64-image"></a>
+### base64_image <span class="badge badge-pill badge-info">PRO</span>
+
+Upload an image and store it in the database as Base64. Notes:
+- make sure the column type is LONGBLOB;
+- detailed [instructions and customizations here](https://github.com/Laravel-Backpack/CRUD/pull/56#issue-164712261);
+
+```php
+// base64_image
+$this->crud->addField([
+    'label'        => "Profile Image",
+    'name'         => "image",
+    'filename'     => "image_filename", // set to null if not needed
+    'type'         => 'base64_image',
+    'aspect_ratio' => 1, // set to 0 to allow any aspect ratio
+    'crop'         => true, // set to true to allow cropping, false to disable
+    'src'          => NULL, // null to read straight from DB, otherwise set to model accessor function
+]);
+```
+
+Input preview:
+
+![CRUD Field - base64_image](https://backpackforlaravel.com/uploads/docs-4-2/fields/base64_image.png)
+
+<hr>
+
+<a name="ckeditor"></a>
+### ckeditor <span class="badge badge-pill badge-info">PRO</span>
+
+Show a wysiwyg CKEditor to the user.
+
+```php
+[   // CKEditor
+    'name'          => 'description',
+    'label'         => 'Description',
+    'type'          => 'ckeditor',
+
+    // optional:
+    'extra_plugins' => ['oembed', 'widget'],
+    'options'       => [
+        'autoGrow_minHeight'   => 200,
+        'autoGrow_bottomSpace' => 50,
+        'removePlugins'        => 'resize,maximize',
+    ]
+],
+```
+
+If you'd like to be able to select files from elFinder, you need to also run ```composer require backpack/filemanager``` to install elFinder.
+
+Input preview:
+
+![CRUD Field - ckeditor](https://backpackforlaravel.com/uploads/docs-4-2/fields/ckeditor.png)
+
+<hr>
+
+<a name="color-picker"></a>
+### color_picker <span class="badge badge-pill badge-info">PRO</span>
+
+Show a pretty colour picker using [Bootstrap Colorpicker](https://itsjavi.com/bootstrap-colorpicker/).
+
+```php
+[   // color_picker
+    'label'                => 'Background Color',
+    'name'                 => 'background_color',
+    'type'                 => 'color_picker',
+    'default'              => '#000000',
+
+    // optional
+    // Anything your define inside `color_picker_options` will be passed as JS
+    // to the JavaScript plugin. For more information about the options available
+    // please see the plugin docs at:
+    //  ### https://itsjavi.com/bootstrap-colorpicker/module-options.html
+    'color_picker_options' => [
+        'customClass' => 'custom-class',
+        'horizontal' => true,
+        'extensions' => [
+            [
+                'name' => 'swatches', // extension name to load
+                'options' => [ // extension options
+                    'colors' => [
+                        'primary' => '#337ab7',
+                        'success' => '#5cb85c',
+                        'info' => '#5bc0de',
+                        'warning' => '#f0ad4e',
+                        'danger' => '#d9534f'
+                    ],
+                    'namesAsValues' => false
+                ]
+            ]
+        ]
+    ]
+],
+```
+
+Input preview:
+
+![CRUD Field - color_picker](https://backpackforlaravel.com/uploads/docs-4-2/fields/color_picker.png)
+
+<hr>
+
+<a name="date-range"></a>
+### date_range <span class="badge badge-pill badge-info">PRO</span>
+
+Show a DateRangePicker and let the user choose a start date and end date.
+
+```php
+[   // date_range
+    'name'  => ['start_date', 'end_date'], // db columns for start_date & end_date
+    'label' => 'Event Date Range',
+    'type'  => 'date_range',
+
+    // OPTIONALS
+    // default values for start_date & end_date
+    'default'            => ['2019-03-28 01:01', '2019-04-05 02:00'],
+    // options sent to daterangepicker.js
+    'date_range_options' => [
+        'drops' => 'down', // can be one of [down/up/auto]
+        'timePicker' => true,
+        'locale' => ['format' => 'DD/MM/YYYY HH:mm']
+    ]
+],
+```
+
+Please note it is recommended that you use [attribute casting](https://laravel.com/docs/5.3/eloquent-mutators#attribute-casting) on your model (cast to date).
+
+Your end result will look like this:
+
+Input preview:
+
+![CRUD Field - date_range](https://backpackforlaravel.com/uploads/docs-4-2/fields/date_range.png)
+
+
+
+<hr>
+
+<a name="date-picker"></a>
+### date_picker <span class="badge badge-pill badge-info">PRO</span>
+
+Show a pretty [Bootstrap Datepicker](http://bootstrap-datepicker.readthedocs.io/en/latest/).
+
+```php
+[   // date_picker
+   'name'  => 'date',
+   'type'  => 'date_picker',
+   'label' => 'Date',
+
+   // optional:
+   'date_picker_options' => [
+      'todayBtn' => 'linked',
+      'format'   => 'dd-mm-yyyy',
+      'language' => 'fr'
+   ],
+],
+```
+
+Please note it is recommended that you use [attribute casting](https://laravel.com/docs/5.3/eloquent-mutators#attribute-casting) on your model (cast to date).
+
+
+Input preview:
+
+![CRUD Field - date_picker](https://backpackforlaravel.com/uploads/docs-4-2/fields/date_picker.png)
+
+<hr>
+
+<a name="datetime-picker"></a>
+### datetime_picker <span class="badge badge-pill badge-info">PRO</span>
+
+Show a [Bootstrap Datetime Picker](https://eonasdan.github.io/bootstrap-datetimepicker/).
+
+```php
+[   // DateTime
+    'name'  => 'start',
+    'label' => 'Event start',
+    'type'  => 'datetime_picker',
+
+    // optional:
+    'datetime_picker_options' => [
+        'format' => 'DD/MM/YYYY HH:mm',
+        'language' => 'pt',
+        'tooltips' => [ //use this to translate the tooltips in the field
+                'today' => 'Hoje',
+                'selectDate' => 'Selecione a data',
+                // available tooltips: today, clear, close, selectMonth, prevMonth, nextMonth, selectYear, prevYear, nextYear, selectDecade, prevDecade, nextDecade, prevCentury, nextCentury, pickHour, incrementHour, decrementHour, pickMinute, incrementMinute, decrementMinute, pickSecond, incrementSecond, decrementSecond, togglePeriod, selectTime, selectDate
+        ]
+    ],
+    'allows_null' => true,
+    // 'default' => '2017-05-12 11:59:59',
+],
+```
+
+**Please note:** if you're using date [attribute casting](https://laravel.com/docs/5.3/eloquent-mutators#attribute-casting) on your model, you may also need to place this mutator inside your model:
+```php
+    public function setDatetimeAttribute($value) {
+        $this->attributes['datetime'] = \Carbon\Carbon::parse($value);
+    }
+```
+Otherwise the input's datetime-local format will cause some errors. Remember to change "datetime" with the name of your attribute (column name).
+
+Input preview:
+
+![CRUD Field - datetime_picker](https://backpackforlaravel.com/uploads/docs-4-2/fields/datetime_picker.png)
+
+
+<hr>
+
+<a name="icon-picker"></a>
+### icon_picker <span class="badge badge-pill badge-info">PRO</span>
+
+Show an icon picker. Supported icon sets are fontawesome, lineawesome, glyphicon, ionicon, weathericon, mapicon, octicon, typicon, elusiveicon, materialdesign as per the jQuery plugin, [bootstrap-iconpicker](http://victor-valencia.github.io/bootstrap-iconpicker/).
+
+The stored value will be the class name (ex: fa-home).
+
+```php
+[   // icon_picker
+    'label'   => "Icon",
+    'name'    => 'icon',
+    'type'    => 'icon_picker',
+    'iconset' => 'fontawesome' // options: fontawesome, lineawesome, glyphicon, ionicon, weathericon, mapicon, octicon, typicon, elusiveicon, materialdesign
+],
+```
+
+Your input will look like button, with a dropdown where the user can search or pick an icon:
+
+Input preview:
+
+![CRUD Field - icon_picker](https://backpackforlaravel.com/uploads/docs-4-2/fields/icon_picker.png)
+
+<hr>
+
+<a name="image"></a>
+### image <span class="badge badge-pill badge-info">PRO</span>
+
+Upload an image and store it on the disk.
+
+**Step 1.** Show the field.
+```php
+// image
+$this->crud->addField([
+    'label' => "Profile Image",
+    'name' => "image",
+    'type' => 'image',
+    'crop' => true, // set to true to allow cropping, false to disable
+    'aspect_ratio' => 1, // omit or set to 0 to allow any aspect ratio
+    // 'disk'      => 's3_bucket', // in case you need to show images from a different disk
+    // 'prefix'    => 'uploads/images/profile_pictures/' // in case your db value is only the file name (no path), you can use this to prepend your path to the image src (in HTML), before it's shown to the user;
+]);
+```
+
+**Step 2.** Add a [mutator](https://laravel.com/docs/7.x/eloquent-mutators#defining-a-mutator) to your Model, where you pick up the uploaded file and store it wherever you want. You can use this boilerplate code and modify it to match your use case.
+
+**NOTE: The code below requires that you have ```intervention/image``` installed. If you don't, please do ```composer require intervention/image``` first.**
+
+```php
+// ..
+
+use Illuminate\Support\Str;
+use Intervention\Image\ImageManagerStatic as Image;
+
+// ..
+
+Class Product extends Model
+{
+    // ..
+
+    public function setImageAttribute($value)
+    {
+        $attribute_name = "image";
+        // or use your own disk, defined in config/filesystems.php
+        $disk = config('backpack.base.root_disk_name');
+        // destination path relative to the disk above
+        $destination_path = "public/uploads/folder_1/folder_2";
+
+        // if the image was erased
+        if ($value==null) {
+            // delete the image from disk
+            \Storage::disk($disk)->delete($this->{$attribute_name});
+
+            // set null in the database column
+            $this->attributes[$attribute_name] = null;
+        }
+
+        // if a base64 was sent, store it in the db
+        if (Str::startsWith($value, 'data:image'))
+        {
+            // 0. Make the image
+            $image = \Image::make($value)->encode('jpg', 90);
+
+            // 1. Generate a filename.
+            $filename = md5($value.time()).'.jpg';
+
+            // 2. Store the image on disk.
+            \Storage::disk($disk)->put($destination_path.'/'.$filename, $image->stream());
+
+            // 3. Delete the previous image, if there was one.
+            \Storage::disk($disk)->delete($this->{$attribute_name});
+
+            // 4. Save the public path to the database
+            // but first, remove "public/" from the path, since we're pointing to it
+            // from the root folder; that way, what gets saved in the db
+            // is the public URL (everything that comes after the domain name)
+            $public_destination_path = Str::replaceFirst('public/', '', $destination_path);
+            $this->attributes[$attribute_name] = $public_destination_path.'/'.$filename;
+        }
+    }
+
+// ..
+```
+> **The uploaded images are not deleted for you.** If you delete an entry (using the CRUD or anywhere inside your app), the image file won't be deleted from the disk.
+> If you're NOT using soft deletes on that Model and want the image to be deleted at the same time the entry is, just specify that in your Model's ```deleting``` event:
+> ```php
+>   public static function boot()
+>   {
+>       parent::boot();
+>       static::deleted(function($obj) {
+>           \Storage::disk('public_folder')->delete($obj->image);
+>       });
+>   }
+> ```
+
+**A note about aspect_ratio**
+The value for aspect ratio is a float that represents the ratio of the cropping rectangle height and width. By way of example,
+
+- Square = 1
+- Landscape = 2
+- Portrait = 0.5
+
+And you can, of course, use any value for more extreme rectangles.
+
+Input preview:
+
+![CRUD Field - image](https://backpackforlaravel.com/uploads/docs-4-2/fields/image.png)
+
+> NOTE: if you are having trouble uploading big images, please check your php extensions **apcu** and/or **opcache**, users have reported some issues with these extensions when trying to upload very big images. REFS: https://github.com/Laravel-Backpack/CRUD/issues/3457
+
+
+<hr>
+
 <a name="relationship"></a>
-### relationship
+### relationship <span class="badge badge-pill badge-info">PRO</span>
 
 Shows the user a `select2` input, allowing them to choose one/more entries of a related Eloquent Model. In order to work, the relationships need to be properly defined on the Model.
 
@@ -1398,13 +1798,13 @@ Normally, when the admin removes a relationship from the "select", only the rela
 <hr>
 
 <a name="repeatable"></a>
-### repeatable
+### repeatable <span class="badge badge-pill badge-info">PRO</span>
 
 Shows a group of inputs to the user, and allows the user to add or remove groups of that kind:
 
 ![CRUD Field - repeatable](https://backpackforlaravel.com/uploads/docs-4-2/fields/repeatable.png)
 
-**Since 4.2**: repeatable returns an array when the form is submitted instead of the already parsed json. **You must cast** the repeatable field to **ARRAY** or **JSON** in your model.
+**Since v5**: repeatable returns an array when the form is submitted instead of the already parsed json. **You must cast** the repeatable field to **ARRAY** or **JSON** in your model.
 
 Clicking on the "New Item" button will add another group with the same subfields (in the example, another Testimonial).
 
@@ -1444,7 +1844,7 @@ You can use most field types inside the field groups, add as many subfields you 
             'label' => 'Quote',
         ],
     ],
-    
+
     // optional
     'new_item_label'  => 'Add Group', // customize the text of the button
     'init_rows' => 2, // number of empty rows to be initialized, by default 1
@@ -1458,77 +1858,12 @@ You can use most field types inside the field groups, add as many subfields you 
 ],
 ```
 
-
-<hr>
-
-<a name="select"></a>
-### select (1-n relationship)
-
-Show a Select with the names of the connected entity and let the user select one of them.
-Your relationships should already be defined on your models as hasOne() or belongsTo().
-
-```php
-[  // Select
-   'label'     => "Category",
-   'type'      => 'select',
-   'name'      => 'category_id', // the db column for the foreign key
-
-   // optional 
-   // 'entity' should point to the method that defines the relationship in your Model
-   // defining entity will make Backpack guess 'model' and 'attribute'
-   'entity'    => 'category', 
-
-   // optional - manually specify the related model and attribute
-   'model'     => "App\Models\Category", // related model
-   'attribute' => 'name', // foreign key attribute that is shown to user
-
-   // optional - force the related options to be a custom query, instead of all();
-   'options'   => (function ($query) {
-        return $query->orderBy('name', 'ASC')->where('depth', 1)->get();
-    }), //  you can use this to filter the results show in the select
-],
-```
-
-For more information about the optional attributes that fields use when they interact with related entries - [look here](#optional-attributes-for-fields-containing-related-entries).
-
-Input preview: 
-
-![CRUD Field - select](https://backpackforlaravel.com/uploads/docs-4-2/fields/select.png)
-
-
-<hr>
-
-
-<a name="select-grouped"></a>
-### select_grouped
-
-Display a select where the options are grouped by a second entity (like Categories).
-
-```php
-[   // select_grouped
-    'label'     => 'Articles grouped by categories',
-    'type'      => 'select_grouped', //https://github.com/Laravel-Backpack/CRUD/issues/502
-    'name'      => 'article_id',
-    'entity'    => 'article',
-    'attribute' => 'title',
-    'group_by'  => 'category', // the relationship to entity you want to use for grouping
-    'group_by_attribute' => 'name', // the attribute on related model, that you want shown
-    'group_by_relationship_back' => 'articles', // relationship from related model back to this model
-],
-```
-
-For more information about the optional attributes that fields use when they interact with related entries - [look here](#optional-attributes-for-fields-containing-related-entries).
-
-Input preview:
-
-![CRUD Field - select_grouped](https://backpackforlaravel.com/uploads/docs-4-2/fields/select_grouped.png)
-
 <hr>
 
 <a name="select2"></a>
-### select2 (1-n relationship)
+### select2 (1-n relationship) <span class="badge badge-pill badge-info">PRO</span>
 
-Works just like the SELECT field, but prettier. Shows a Select2 with the names of the connected entity and let the user select one of them. 
+Works just like the SELECT field, but prettier. Shows a Select2 with the names of the connected entity and let the user select one of them.
 Your relationships should already be defined on your models as hasOne() or belongsTo().
 
 ```php
@@ -1552,48 +1887,15 @@ Your relationships should already be defined on your models as hasOne() or belon
 
 For more information about the optional attributes that fields use when they interact with related entries - [look here](#optional-attributes-for-fields-containing-related-entries).
 
-Input preview: 
+Input preview:
 
 ![CRUD Field - select2](https://backpackforlaravel.com/uploads/docs-4-2/fields/select2_nested.png)
-
-<hr>
-
-<a name="select-multiple"></a>
-### select_multiple (n-n relationship)
-
-Show a Select with the names of the connected entity and let the user select any number of them.
-Your relationship should already be defined on your models as belongsToMany().
-
-```php
-[   // SelectMultiple = n-n relationship (with pivot table)
-    'label'     => "Tags",
-    'type'      => 'select_multiple',
-    'name'      => 'tags', // the method that defines the relationship in your Model
-
-    // optional
-    'entity'    => 'tags', // the method that defines the relationship in your Model
-    'model'     => "App\Models\Tag", // foreign key model
-    'attribute' => 'name', // foreign key attribute that is shown to user
-    'pivot'     => true, // on create&update, do you need to add/delete pivot table entries?
-
-    // also optional
-    'options'   => (function ($query) {
-        return $query->orderBy('name', 'ASC')->where('depth', 1)->get();
-    }), // force the related options to be a custom query, instead of all(); you can use this to filter the results show in the select
-],
-```
-
-For more information about the optional attributes that fields use when they interact with related entries - [look here](#optional-attributes-for-fields-containing-related-entries).
-
-Input preview: 
-
-![CRUD Field - select_multiple](https://backpackforlaravel.com/uploads/docs-4-2/fields/select_multiple.png)
 
 
 <hr>
 
 <a name="select2-multiple"></a>
-### select2_multiple (n-n relationship)
+### select2_multiple (n-n relationship) <span class="badge badge-pill badge-info">PRO</span>
 
 [Works just like the SELECT field, but prettier]
 
@@ -1622,14 +1924,14 @@ Your relationship should already be defined on your models as belongsToMany().
 
 For more information about the optional attributes that fields use when they interact with related entries - [look here](#optional-attributes-for-fields-containing-related-entries).
 
-Input preview: 
+Input preview:
 
 ![CRUD Field - select2_multiple](https://backpackforlaravel.com/uploads/docs-4-2/fields/select2_multiple.png)
 
 <hr>
 
 <a name="select2-nested"></a>
-### select2_nested
+### select2_nested <span class="badge badge-pill badge-info">PRO</span>
 
 Display a select2 with the values ordered hierarchically and indented, for an entity where you use Reorder. Please mind that the connected model needs:
 - a ```children()``` relationship pointing to itself;
@@ -1642,7 +1944,7 @@ Display a select2 with the values ordered hierarchically and indented, for an en
     'type'      => 'select2_nested',
     'entity'    => 'category', // the method that defines the relationship in your Model
     'attribute' => 'name', // foreign key attribute that is shown to user
-    
+
     // optional
     'model'     => "App\Models\Category", // force foreign key model
 ],
@@ -1657,7 +1959,7 @@ Input preview:
 <hr>
 
 <a name="select2-grouped"></a>
-### select2_grouped
+### select2_grouped <span class="badge badge-pill badge-info">PRO</span>
 
 Display a select2 where the options are grouped by a second entity (like Categories).
 
@@ -1684,7 +1986,7 @@ Input preview:
 <hr>
 
 <a name="select_and_order"></a>
-### select_and_order
+### select_and_order <span class="badge badge-pill badge-info">PRO</span>
 
 Display items on two columns and let the user drag&drop between them to choose which items are selected and which are not, and reorder the selected items with drag&drop.
 
@@ -1721,38 +2023,15 @@ Also possible:
 ],
 ```
 
-Input preview: 
+Input preview:
 
 ![CRUD Field - select_and_order](https://backpackforlaravel.com/uploads/docs-4-2/fields/select_and_order.png)
 
 
 <hr>
 
-<a name="select-from-array"></a>
-### select_from_array
-
-Display a select with the values you want:
-
-```php
-[   // select_from_array
-    'name'        => 'template',
-    'label'       => "Template",
-    'type'        => 'select_from_array',
-    'options'     => ['one' => 'One', 'two' => 'Two'],
-    'allows_null' => false,
-    'default'     => 'one',
-    // 'allows_multiple' => true, // OPTIONAL; needs you to cast this to array in your model;
-],
-```
-
-Input preview: 
-
-![CRUD Field - select_from_array](https://backpackforlaravel.com/uploads/docs-4-2/fields/select_from_array.png)
-
-<hr>
-
 <a name="select2-from-array"></a>
-### select2_from_array
+### select2_from_array <span class="badge badge-pill badge-info">PRO</span>
 
 Display a select2 with the values you want:
 
@@ -1768,14 +2047,14 @@ Display a select2 with the values you want:
 ],
 ```
 
-Input preview: 
+Input preview:
 
 ![CRUD Field - select2_from_array](https://backpackforlaravel.com/uploads/docs-4-2/fields/select2_from_array.png)
 
 <hr>
 
 <a name="select2-from-ajax"></a>
-### select2_from_ajax
+### select2_from_ajax <span class="badge badge-pill badge-info">PRO</span>
 
 Display a select2 that takes its values from an AJAX call.
 
@@ -1839,19 +2118,19 @@ class CategoryController extends Controller
 **Note:** If you want to also make this field work inside `repeatable` too, your API endpoint will also need to respond to the `keys` parameter, with the actual items that have those keys. For example:
 
 ```php
-        if ($request->has('keys')) { 
+        if ($request->has('keys')) {
             return Category::findMany($request->input('keys'));
         }
 ```
 
-Input preview: 
+Input preview:
 
 ![CRUD Field - select2_from_array](https://backpackforlaravel.com/uploads/docs-4-2/fields/select2_from_array.png)
 
 <hr>
 
 <a name="select2-from-ajax-multiple"></a>
-### select2_from_ajax_multiple
+### select2_from_ajax_multiple <span class="badge badge-pill badge-info">PRO</span>
 
 Display a select2 that takes its values from an AJAX call. Same as [select2_from_ajax](#section-select2_from_ajax) above, but allows for multiple items to be selected. The only difference in the field definition is the "pivot" attribute.
 
@@ -1859,12 +2138,12 @@ Display a select2 that takes its values from an AJAX call. Same as [select2_from
 [   // n-n relationship
     'label'       => "Cities", // Table column heading
     'type'        => "select2_from_ajax_multiple",
-    'name'        => 'cities', // a unique identifier (usually the method that defines the relationship in your Model) 
+    'name'        => 'cities', // a unique identifier (usually the method that defines the relationship in your Model)
     'entity'      => 'cities', // the method that defines the relationship in your Model
     'attribute'   => "name", // foreign key attribute that is shown to user
     'data_source' => url("api/city"), // url to controller search function (with /{id} should return model)
     'pivot'       => true, // on create&update, do you need to add/delete pivot table entries?
-    
+
     // OPTIONAL
     'delay' => 500, // the minimum amount of time between ajax requests when searching in the field
     'model'                => "App\Models\City", // foreign key model
@@ -1918,14 +2197,14 @@ class CityController extends Controller
 }
 ```
 
-Input preview: 
+Input preview:
 
 ![CRUD Field - select2_from_ajax_multiple](https://backpackforlaravel.com/uploads/docs-4-2/fields/select2_from_ajax_multiple.png)
 
 **Note:** If you want to also make this field work inside `repeatable` too, your API endpoint will also need to respond to the `keys` parameter, with the actual items that have those keys. For example:
 
 ```php
-        if ($request->has('keys')) { 
+        if ($request->has('keys')) {
             return City::findMany($request->input('keys'));
         }
 ```
@@ -1934,7 +2213,7 @@ Input preview:
 <hr>
 
 <a name="summernote"></a>
-### summernote
+### summernote <span class="badge badge-pill badge-info">PRO</span>
 
 Show a [Summernote wysiwyg editor](http://summernote.org/) to the user.
 
@@ -1948,11 +2227,11 @@ Show a [Summernote wysiwyg editor](http://summernote.org/) to the user.
 
 // the summernote field works with the default configuration options but allow developer to configure to his needs
 // optional configuration check https://summernote.org/deep-dive/ for a list of available configs
-[   
+[
     'name'  => 'description',
     'label' => 'Description',
     'type'  => 'summernote',
-    'options' => [ 
+    'options' => [
         'toolbar' => [
             ['font', ['bold', 'underline', 'italic']]
         ]
@@ -1963,14 +2242,14 @@ Show a [Summernote wysiwyg editor](http://summernote.org/) to the user.
 
 > NOTE: Summernote does NOT sanitize the input. If you do not trust the users of this field, you should sanitize the input or output using something like HTML Purifier. Personally we like to use install [mewebstudio/Purifier](https://github.com/mewebstudio/Purifier) and add an [accessor or mutator](https://laravel.com/docs/8.x/eloquent-mutators#accessors-and-mutators) on the Model, so that wherever the model is created from (admin panel or app), the output will always be clean. [Example here](https://github.com/Laravel-Backpack/demo/commit/7342cffb418bb568b9e4ee279859685ddc0456c1).
 
-Input preview: 
+Input preview:
 
 ![CRUD Field - summernote](https://backpackforlaravel.com/uploads/docs-4-2/fields/summernote.png)
 
 <hr>
 
 <a name="table"></a>
-### table
+### table <span class="badge badge-pill badge-info">PRO</span>
 
 Show a table with multiple inputs per row and store the values as JSON array of objects in the database. The user can add more rows and reorder the rows as they please.
 
@@ -1992,83 +2271,15 @@ Show a table with multiple inputs per row and store the values as JSON array of 
 
 >It's highly recommended that you use [attribute casting](https://mattstauffer.co/blog/laravel-5.0-eloquent-attribute-casting) on your model when working with JSON arrays stored in database columns, and cast this attribute to either ```object``` or ```array``` in your Model.
 
-Input preview: 
+Input preview:
 
 ![CRUD Field - table](https://backpackforlaravel.com/uploads/docs-4-2/fields/table.png)
 
-<hr>
-
-<a name="text"></a>
-### text
-
-The basic field type, all it needs is the two mandatory parameters: name and label.
-
-```php
-[   // Text
-    'name'  => 'title',
-    'label' => "Title",
-    'type'  => 'text',
-
-    // optional
-    //'prefix'     => '',
-    //'suffix'     => '',
-    //'default'    => 'some value', // default value
-    //'hint'       => 'Some hint text', // helpful text, show up after input
-    //'attributes' => [
-       //'placeholder' => 'Some text when empty',
-       //'class' => 'form-control some-class',
-       //'readonly'  => 'readonly',
-       //'disabled'  => 'disabled',
-     //], // extra HTML attributes and values your input might need
-     //'wrapper'   => [
-       //'class' => 'form-group col-md-12'
-     //], // extra HTML attributes for the field wrapper - mostly for resizing fields 
-    
-],
-```
-
-You can use the optional 'prefix' and 'suffix' attributes to display something before and after the input, like icons, path prefix, etc:
-
-Input preview: 
-
-![CRUD Field - text](https://backpackforlaravel.com/uploads/docs-4-2/fields/text.png)
-
-<hr>
-
-<a name="textarea"></a>
-### textarea
-
-Show a textarea to the user.
-
-```php
-[   // Textarea
-    'name'  => 'description',
-    'label' => 'Description',
-    'type'  => 'textarea'
-],
-```
-
-Input preview: 
-
-![CRUD Field - textarea](https://backpackforlaravel.com/uploads/docs-4-2/fields/textarea.png)
-
-<hr>
-
-<a name="time"></a>
-### time
-
-```php
-[   // Time
-    'name'  => 'start',
-    'label' => 'Start time',
-    'type'  => 'time'
-],
-```
 
 <hr>
 
 <a name="tinymce"></a>
-### tinymce
+### tinymce <span class="badge badge-pill badge-info">PRO</span>
 
 Show a wysiwyg (TinyMCE) to the user.
 
@@ -2082,184 +2293,15 @@ Show a wysiwyg (TinyMCE) to the user.
 ],
 ```
 
-Input preview: 
+Input preview:
 
 ![CRUD Field - tinymce](https://backpackforlaravel.com/uploads/docs-4-2/fields/tinymce.png)
 
-<hr>
-
-<a name="upload"></a>
-### upload
-
-**Step 1.** Show a file input to the user:
-```php
-[   // Upload
-    'name'      => 'image',
-    'label'     => 'Image',
-    'type'      => 'upload',
-    'upload'    => true,
-    'disk'      => 'uploads', // if you store files in the /public folder, please omit this; if you store them in /storage or S3, please specify it;
-    // optional:
-    'temporary' => 10 // if using a service, such as S3, that requires you to make temporary URLs this will make a URL that is valid for the number of minutes specified
-],
-```
-
-**Step 2.** In order to save/update/delete the file from disk&db, we need to create [a mutator](https://laravel.com/docs/5.3/eloquent-mutators#defining-a-mutator) on your model:
-```php
-public function setImageAttribute($value)
-    {
-    	$attribute_name = "image";
-    	$disk = "public";
-    	$destination_path = "folder_1/subfolder_1";
-
-    	$this->uploadFileToDisk($value, $attribute_name, $disk, $destination_path);
-	
-	// return $this->attributes[{$attribute_name}]; // uncomment if this is a translatable field
-    }
-```
-
-**How it works:**
-
-The field sends the file, through a Request, to the Controller. The Controller then tries to create/update the Model. That's when the mutator on your model will run. That also means we can do any [file validation](https://laravel.com/docs/5.3/validation#rule-file) (```file```, ```image```, ```mimetypes```, ```mimes```) in the Request, before the file is stored on the disk.
-
->NOTE: If this field is mandatory (required in validation) please use the [sometimes laravel validation rule](https://laravel.com/docs/5.8/validation#conditionally-adding-rules) together with **required** in your validation. (sometimes|required|file etc... )
-
-[The ```uploadFileToDisk()``` method](https://github.com/Laravel-Backpack/CRUD/blob/master/src/app/Models/Traits/HasUploadFields.php#L31-L59) will take care of everything for most use cases:
-
-```php
-/**
-     * Handle file upload and DB storage for a file:
-     * - on CREATE
-     *     - stores the file at the destination path
-     *     - generates a name
-     *     - stores the full path in the DB;
-     * - on UPDATE
-     *     - if the value is null, deletes the file and sets null in the DB
-     *     - if the value is different, stores the different file and updates DB value
-     * /
-public function uploadFileToDisk($value, $attribute_name, $disk, $destination_path) {}
-```
-
-If you wish to have a different functionality, you can delete the method call from your mutator and do your own thing.
-
->**The uploaded files are not deleted for you.** When you delete an entry (whether through CRUD or the application), the uploaded files will not be deleted.
-
-If you're NOT using soft deletes on that Model and want the file to be deleted at the same time the entry is, just specify that in your Model's ```deleting``` event:
-```php
-	public static function boot()
-	{
-		parent::boot();
-		static::deleting(function($obj) {
-			\Storage::disk('public_folder')->delete($obj->image);
-		});
-	}
-```
-
-Input preview: 
-
-![CRUD Field - upload](https://backpackforlaravel.com/uploads/docs-4-2/fields/upload.png)
-
-<hr>
-
-<a name="upload-multiple"></a>
-### upload_multiple
-
-Shows a multiple file input to the user and stores the values as a JSON array in the database.
-
-**Step 0.** Make sure the db column can hold the amount of text this field will have. For example, for MySQL, VARCHAR(255) might not be enough all the time (for 3+ files), so it's better to go with TEXT. Make sure you're using a big column type in your migration or db.
-
-**Step 1.** Show a multiple file input to the user:
-```php
-[   // Upload
-    'name'      => 'photos',
-    'label'     => 'Photos',
-    'type'      => 'upload_multiple',
-    'upload'    => true,
-    'disk'      => 'uploads', // if you store files in the /public folder, please omit this; if you store them in /storage or S3, please specify it;
-    // optional:
-    'temporary' => 10 // if using a service, such as S3, that requires you to make temporary URLs this will make a URL that is valid for the number of minutes specified
-],
-```
-
-**Step 2.** In order to save/update/delete the files from disk&db, we need to create [a mutator](https://laravel.com/docs/5.3/eloquent-mutators#defining-a-mutator) on your model:
-```php
-public function setPhotosAttribute($value)
-    {
-    	$attribute_name = "photos";
-    	$disk = "public";
-    	$destination_path = "folder_1/subfolder_1";
-
-    	$this->uploadMultipleFilesToDisk($value, $attribute_name, $disk, $destination_path);
-    }
-```
-
-**Step 3.** Since the filenames are stored in the database as a JSON array, we're going to use [attribute casting](https://laravel.com/docs/5.3/eloquent-mutators#attribute-casting) on your model, so every time we get the filenames array from the database it's converted from a JSON array to a PHP array:
-```php
-    protected $casts = [
-    	'photos' => 'array'
-    ];
-```
-
-**How it works:**
-
-The field sends the files, through a Request, to the Controller. The Controller then tries to create/update the Model. That's when the mutator on your model will run. That also means we can do any [file validation](https://laravel.com/docs/5.3/validation#rule-file) (```file```, ```image```, ```mimetypes```, ```mimes```) in the Request, before the files are stored on the disk.
-
-[The ```uploadMultipleFilesToDisk()``` method](https://github.com/Laravel-Backpack/CRUD/blob/master/src/app/Models/Traits/HasUploadFields.php#L76-L113) will take care of everything for most use cases:
-
-```
-/**
-     * Handle multiple file upload and DB storage:
-     * - if files are sent
-     *     - stores the files at the destination path
-     *     - generates random names
-     *     - stores the full path in the DB, as JSON array;
-     * - if a hidden input is sent to clear one or more files
-     *     - deletes the file
-     *     - removes that file from the DB.
-     * /
-public function uploadMultipleFilesToDisk($value, $attribute_name, $disk, $destination_path) {}
-```
-
-If you wish to have a different functionality, you can delete the method call from your mutator and do your own thing.
-
->**The uploaded files are not deleted for you.** When you delete an entry (whether through CRUD or the application), the uploaded files will not be deleted.
-
-If you're NOT using soft deletes on that Model and want the files to be deleted at the same time the entry is, just specify that in your Model's ```deleting``` event:
-```php
-	public static function boot()
-	{
-		parent::boot();
-		static::deleting(function($obj) {
-			if (count((array)$obj->photos)) {
-				foreach ($obj->photos as $file_path) {
-					\Storage::disk('public_folder')->delete($file_path);
-				}
-			}
-		});
-	}
-```
-
-You might notice the field is using a ```clear_photos``` variable. Don't worry, you don't need it in your db table. That's just used to delete photos upon "update". If you use ```$fillable``` on your model, just don't include it. If you use ```$guarded``` on your model, place it in guarded.
-
-Input preview: 
-
-![CRUD Field - upload_multiple](https://backpackforlaravel.com/uploads/docs-4-2/fields/upload_multiple.png)
-
-
-### url
-
-```php
-[   // URL
-    'name'  => 'link',
-    'label' => 'Link to video file',
-    'type'  => 'url'
-],
-```
 
 <hr>
 
 <a name="video"></a>
-### video
+### video <span class="badge badge-pill badge-info">PRO</span>
 
 Allow the user to paste a YouTube/Vimeo link. That will get the video information with JavaScript and store it as a JSON in the database.
 
@@ -2291,42 +2333,8 @@ Vimeo does not require an API key in order to query their DB, but YouTube does, 
 
 <hr>
 
-<a name="view"></a>
-### view
-
-Load a custom view in the form.
-
-```php
-[   // view
-    'name' => 'custom-ajax-button',
-    'type' => 'view',
-    'view' => 'partials/custom-ajax-button'
-],
-```
-
-**Note:** the same functionality can be achieved using a [custom field type](/docs/{{version}}/crud-fields#creating-a-custom-field-type), or using the [custom_html field type](/docs/{{version}}/crud-fields#custom-html) (if the content is really simple).
-
-<hr>
-
-<a name="week"></a>
-### week
-
-```php
-[   // Week
-    'name'  => 'first_week',
-    'label' => 'First week',
-    'type'  => 'week'
-],
-```
-
-Input preview: 
-
-![CRUD Field - week](https://backpackforlaravel.com/uploads/docs-4-2/fields/week.png)
-
-<hr>
-
 <a name="wysiwyg"></a>
-### wysiwyg
+### wysiwyg <span class="badge badge-pill badge-info">PRO</span>
 
 Show a wysiwyg (CKEditor) to the user.
 
@@ -2337,6 +2345,7 @@ Show a wysiwyg (CKEditor) to the user.
     'type'  => 'wysiwyg'
 ],
 ```
+
 
 <a name="overwriting-default-field-types"></a>
 ## Overwriting Default Field Types

--- a/5.x-dev/crud-fields.md
+++ b/5.x-dev/crud-fields.md
@@ -1,0 +1,2412 @@
+# Fields
+
+---
+
+<a name="about"></a>
+## About
+
+Field types define how the admin can manipulate an entry's values. They're used by the Create and Update operations.
+
+Think of the field type as the type of input: ```<input type="text" />```. But for most entities, you won't just need text inputs - you'll need datepickers, upload buttons, 1-n relationship, n-n relationships, textareas, etc.
+
+We have a lot of default field types, detailed below. If you don't find what you're looking for, you can [create a custom field type](/docs/{{version}}/crud-fields#creating-a-custom-field-type). Or if you just want to tweak a default field type a little bit, you can [overwrite default field types](/docs/{{version}}/crud-fields#overwriting-default-field-types).
+
+> NOTE: Starting with Backpack 4.1, if the _field name_ is the exact same as a relation method in the model, Backpack will assume you're adding a field for that relationship and infer relation attributes from it. To disable this behaviour, you can use `'entity' => false` in your field definition. 
+
+<a name="fields-api"></a>
+### Fields API
+
+To manipulate fields, you can use the methods below. The action will be performed on the currently running operation. So make sure you run these methods inside ```setupCreateOperation()```, ```setupUpdateOperation()``` or in ```setup()``` inside operation blocks:
+
+```php
+// add a field 
+$this->crud->addField($field_definition_array);
+
+// shorthand: add a text field 
+$this->crud->addField('db_column_name');
+
+// add multiple fields
+$this->crud->addFields([$field_definition_array_1, $field_definition_array_2]);
+
+// change the attributes of a field
+$this->crud->modifyField($name, $modifs_array);
+
+// remove a field from both operations
+$this->crud->removeField('name');
+
+// remove multiple fields from both operations
+$this->crud->removeFields($array_of_names);
+
+// remove all fields from all operations
+$this->crud->removeAllFields();
+
+// FIELD ORDER
+
+// add a field before a given field
+$this->crud->addField($field_definition_array)->beforeField('name');
+
+// add a field after a given field
+$this->crud->addField($field_definition_array)->afterField('name');
+
+
+// -------------------
+// New in Backpack 4.1
+// -------------------
+// add a field with this name
+$this->crud->field('price');
+
+// change the type attribute on the 'price' field
+$this->crud->field('price')->type('number');
+```
+
+<a name="field-attributes"></a>
+### Field Attributes
+
+<a name="mandatory-field-attributes"></a>
+#### Mandatory Field Attributes
+
+**The only attribute that's mandatory when you define a field is its `name`**, which will be used:
+- inside the inputs, as `<input name='your_db_column' />`;
+- to store the information in the database, so your `name` should correspond to a database column (if the field type doesn't have different instructions); 
+
+Every other field attribute other than `name`, Backpack 4.1+ will try to guess.
+
+<a name="recommended-field-attributes"></a>
+#### Recommended Field Attributes
+
+Usually developers define the following attributes for all fields:
+- the ```name``` of the column in the database (ex: "title")
+- the human-readable ```label``` for the input (ex: "Title")
+- the ```type``` of the input (ex: "text")
+
+So at minimum, a field definition array usually looks like:
+```php
+[
+    'name'  => 'description',
+    'label' => 'Article Description',
+    'type'  => 'textarea',
+]
+```
+
+Please note that `label` and `type` are not _mandatory_, just _recommended_:
+- `label` can be omitted, and Backpack will try to construct it from the `name`;
+- `type` can be omitted, and Backpack will try to guess it from the column type, or if there's a relationship on the Model with the same `name`;
+
+<a name="optional-field-attributes-for-presentation-purposes"></a>
+#### Optional - Field Attributes for Presentation Purposes
+
+There are a few optional attributes on most default field types, that you can use to easily achieve a few common customizations:
+
+```php
+[
+    'prefix'     => '',
+    'suffix'     => '',
+    'default'    => 'some value', // set a default value
+    'hint'       => 'Some hint text', // helpful text, shows up after the input
+    'attributes' => [
+       'placeholder' => 'Some text when empty',
+       'class'       => 'form-control some-class',
+       'readonly'    => 'readonly',
+       'disabled'    => 'disabled',
+     ], // change the HTML attributes of your input
+     'wrapper'   => [ 
+        'class'      => 'form-group col-md-12'
+     ], // change the HTML attributes for the field wrapper - mostly for resizing fields 
+]
+```
+
+These will help you:
+
+- **prefix** - add a text or icon _before_ the actual input;
+- **suffix** - add a text or icon _after_ the actual input;
+- **default** - specify a default value for the input, on create;
+- **hint** - add descriptive text for this input;
+- **attributes** - change or add actual HTML attributes of the input (ex: readonly, disabled, class, placeholder, etc);
+- **wrapper** - change or add actual HTML attributes to the div that contains the input; 
+
+<a name="fake-fields"></a>
+#### Optional - Fake Field Attributes (stores fake attributes as JSON in the database)
+
+In case you want to store information for an entry that doesn't need a separate database column, you can add any number of Fake Fields, and their information will be stored inside a column in the db, as JSON. By default, an ```extras``` column is used and assumed on the database table, but you can change that.
+
+**Step 1.** Use the fake attribute on your field:
+```php
+[
+    'name'     => 'name', // JSON variable name
+    'label'    => "Tag Name", // human-readable label for the input
+    
+    'fake'     => true, // show the field, but don't store it in the database column above
+    'store_in' => 'extras' // [optional] the database column name where you want the fake fields to ACTUALLY be stored as a JSON array 
+],
+```
+
+**Step 2.** On your model, make sure the db columns where you store the JSONs (by default only ```extras```):
+- are in your ```$fillable``` property;
+- are on a new ```$fakeColumns``` property (create it now);
+- are casted as array in ```$casts```;
+
+>If you need your fakes to also be translatable, remember to also place ```extras``` in your model's ```$translatable``` property and remove it from ```$casts```.
+
+Example:
+```php
+[
+    'name'     => 'meta_title',
+    'label'    => "Meta Title", 
+    'fake'     => true, 
+    'store_in' => 'metas' // [optional]
+],
+[
+    'name'     => 'meta_description',
+    'label'    => "Meta Description", 
+    'fake'     => true, 
+    'store_in' => 'metas' // [optional]
+],
+[
+    'name'     => 'meta_keywords',
+    'label'    => "Meta Keywords", 
+    'fake'     => true, 
+    'store_in' => 'metas' // [optional]
+],
+```
+
+In this example, these 3 fields will show up in the create & update forms, the CRUD will process as usual, but in the database these values won't be stored in the ```meta_title```, ```meta_description``` and ```meta_keywords``` columns. They will be stored in the ```metas``` column as a JSON array:
+
+```php
+{"meta_title":"title","meta_description":"desc","meta_keywords":"keywords"}
+```
+
+If the ```store_in``` attribute wasn't used, they would have been stored in the ```extras``` column.
+
+<a name="split-fields-into-tabs"></a>
+#### Optional - Tab Attribute Splits Forms into Tabs
+
+You can now split your create/edit inputs into multiple tabs.
+
+![CRUD Fields Tabs](https://backpackforlaravel.com/uploads/docs-4-0/operations/create_tabs.png)
+
+In order to use this feature, you just need to specify the tab name for each of your fields. Example:
+
+```php
+// select_from_array
+$this->crud->addField([
+    'name'            => 'select_from_array',
+    'label'           => "Select from array",
+    'type'            => 'select_from_array',
+    'options'         => ['one' => 'One', 'two' => 'Two', 'three' => 'Three'],
+    'allows_null'     => false,
+    'allows_multiple' => true,
+    'tab'             => 'Tab name here',
+]);
+```
+
+If you forget to specify a tab name for a field, Backpack will place it above all tabs.
+
+
+<a name="entity-model-and-attribute"></a>
+#### Optional - Attributes for Fields Containing Related Entries
+
+When a field works with related entities (relationships like `BelongsTo`, `HasOne`, `HasMany`, `BelongsToMany`, etc), Backpack needs to know how the current model (being create/edited) and the other model (that shows up in the field) are related. And it stores that information in a few additional field attributes, right after you add the field.
+
+*Normally, Backpack 4.1+ will guess all this relationship information for you.* If you have your relationships properly defined in your Models, you can just use a relationship field the same way you would a normal field. Pretend that _the method in your Model that defines your relationship_ is a real column, and Backpack will do all the work for you.
+
+But if you want to overwrite any of the relationship attributes Backpack guesses, here they are:
+- `entity` - points to the method on the model that contains the relationship; having this defined, Backpack will try to guess from it all other field attributes; ex: `category` or `tags`;
+- `model` - the classname (including namespace) of the related model (ex: `App\Models\Category`); usually deducted from the relationship function in the model;
+- `attribute` - the attribute on the related model (aka foreign attribute) that will be show to the user; for example, you wouldn't want a dropdown of categories showing IDs - no, you'd want to show the category names; in this case, the `attribute` will be `name`; usually deducted using the [identifiable attribute functionality explained below](#identifiable-attribute);
+- `multiple` - boolean, allows the user to pick one or multiple items; usually deducted depending on whether it's a 1-to-n or n-n relationship;
+- `pivot` - boolean, instructs Backpack to store the information inside a pivot table; usually deducted depending on whether it's a 1-to-n or n-n relationship;
+- `relation_type` - text, deducted from `entity`; not a good idea to overwrite;
+
+If you do need a field that contains relationships to behave a certain way, it's usually enough to just specify a different `entity`. However, you _can_ specify any of the attributes above, and Backpack will take your value for it, instead of trying to guess one.
+
+
+<a name="identifiable-attribute"></a>
+** Identifiable Attribute for Relationship Fields**
+
+Fields that work with relationships will allow you to select which ```attribute``` on the related entry you want to show to the user. All relationship fields (relationship, select, select2, select_multiple, select2_multiple, select2_from_ajax, select2_from_ajax_multiple) let you define the ```attribute``` for this specific purpose.
+
+For example, when the admin creates an ```Article``` they'll have to select a ```Category``` from a dropdown. It's important to show an attribute for ```Category``` that will help the admin easily identify the category, even if it's not the ID. In this example, it would probably be the category name - that's what you'd like the dropdown to show.
+
+In Backpack, you can explicitly define this, by giving the field an ```attribute```. But you can also NOT explicitly define this - Backpack will try to guess it. If you don't like what Backpack guessed would be a good identifiable attribute, you can either:
+- (A) explicitly define an ```attribute``` for that field, or
+- (B) you can specify the identifiable attribute in your model, and all fields will pick this up:
+
+```php
+
+use Backpack\CRUD\app\Models\Traits\CrudTrait;
+
+class Category
+{
+    use CrudTrait;
+
+    // you can define this
+
+    /**
+     * Attribute shown on the element to identify this model.
+     *
+     * @var string
+     */
+    protected $identifiableAttribute = 'title';
+
+    // or for more complicated use cases you can do
+    
+    /**
+     * Get the attribute shown on the element to identify this model.
+     *
+     * @return string
+     */
+    public function identifiableAttribute()
+    {
+        // process stuff here
+        return 'whatever_you_want_even_an_accessor';
+    }
+}
+```
+
+
+<a name="default-field-types"></a>
+## Default Field Types
+
+<a name="address_algolia"></a>
+### address_algolia
+
+Use [Algolia Places autocomplete](https://community.algolia.com/places/) to help users type their address faster. With the ```store_as_json``` option, it will store the address, postcode, city, country, latitude and longitude in a JSON in the database. Without it, it will just store the address string. For information stored as JSON in the database, it's recommended that you use [attribute casting](https://mattstauffer.co/blog/laravel-5.0-eloquent-attribute-casting) to ```array``` or ```object```. That way, every time you get the info from the database you'd get it in a usable format.
+
+```php
+[   // Address algolia
+    'name'          => 'address',
+    'label'         => 'Address',
+    'type'          => 'address_algolia',
+    // optional
+    'store_as_json' => true
+],
+```
+
+> **Algolia is killing Places.** Please note that Algolia Places **will stop working in May 2022**, as reported in [this announcement](https://www.algolia.com/blog/product/sunseting-our-places-feature/). For that reason, it's probably a good idea to use the `address_google` field instead (it's right after this one).
+
+
+Input preview: 
+
+![CRUD Field - address](https://backpackforlaravel.com/uploads/docs-4-2/fields/address.png)
+
+<hr>
+
+<a name="address_google"></a>
+### address_google
+
+Use [Google Places Search](https://developers.google.com/places/web-service/search) to help users type their address faster. With the ```store_as_json``` option, it will store the address, postcode, city, country, latitude and longitude in a JSON in the database. Without it, it will just store the complete address string.
+
+```php
+[   // Address google
+    'name'          => 'address',
+    'label'         => 'Address',
+    'type'          => 'address_google',
+    // optional
+    'store_as_json' => true
+],
+```
+
+Using Google Places API is dependent on using an API Key. Please [get an API key](https://console.cloud.google.com/apis/credentials) - you do have to configure billing, but you qualify for $200/mo free usage, which covers most use cases. Then copy-paste that key as your ```services.google_places.key``` value. So inside your ```config/services.php``` please add the items below:
+
+```php
+'google_places' => [
+    'key' => 'the-key-you-got-from-google-places'
+],
+```
+
+> **Use attribute casting.** For information stored as JSON in the database, it's recommended that you use [attribute casting](https://mattstauffer.co/blog/laravel-5.0-eloquent-attribute-casting) to ```array``` or ```object```. That way, every time you get the info from the database you'd get it in a usable format. Also, it is heavily recommended that your database column can hold a large JSON - so use `text` rather than `string` in your migration (in MySQL this translates to `text` instead of `varchar`).
+
+Input preview: 
+
+![CRUD Field - address](https://backpackforlaravel.com/uploads/docs-4-2/fields/address_google.png)
+
+<hr>
+
+<a name="browse"></a>
+### browse
+
+This button allows the admin to open [elFinder](http://elfinder.org/) and select a file from there. Run ```composer require backpack/filemanager && php artisan backpack:filemanager:install``` to install [FileManager](https://github.com/laravel-backpack/filemanager), then you can use the field:
+
+```php
+[   // Browse
+    'name'  => 'image',
+    'label' => 'Image',
+    'type'  => 'browse'
+],
+```
+
+
+Input preview: 
+
+![CRUD Field - browse](https://backpackforlaravel.com/uploads/docs-4-2/fields/browse.png)
+
+Onclick preview:
+
+![CRUD Field - browse popup](https://backpackforlaravel.com/uploads/docs-4-2/fields/browse_popup.png)
+
+<hr>
+
+<a name="browse-multiple"></a>
+### browse_multiple
+
+Open elFinder and select multiple files from there. Run ```composer require backpack/filemanager && php artisan backpack:filemanager:install``` to install [FileManager](https://github.com/laravel-backpack/filemanager), then you can use the field:
+
+```php
+[   // Browse multiple
+    'name'          => 'files',
+    'label'         => 'Files',
+    'type'          => 'browse_multiple',
+    // 'multiple'   => true, // enable/disable the multiple selection functionality
+    // 'sortable'   => false, // enable/disable the reordering with drag&drop
+    // 'mime_types' => null, // visible mime prefixes; ex. ['image'] or ['application/pdf']
+],
+```
+
+The field assumes you've cast your attribute as ```array``` on your model.  That way, when you do ```$entry->files``` you get a nice array.
+**NOTE:** If you use `multiple => false` you should NOT cast your attribute as ```array```
+
+Input preview: 
+
+![CRUD Field - browse_multiple](https://backpackforlaravel.com/uploads/docs-4-2/fields/browse_multiple.png)
+
+<hr>
+
+<a name="base64-image"></a>
+### base64_image
+
+Upload an image and store it in the database as Base64. Notes:
+- make sure the column type is LONGBLOB;
+- detailed [instructions and customizations here](https://github.com/Laravel-Backpack/CRUD/pull/56#issue-164712261); 
+
+```php
+// base64_image
+$this->crud->addField([
+    'label'        => "Profile Image",
+    'name'         => "image",
+    'filename'     => "image_filename", // set to null if not needed
+    'type'         => 'base64_image',
+    'aspect_ratio' => 1, // set to 0 to allow any aspect ratio
+    'crop'         => true, // set to true to allow cropping, false to disable
+    'src'          => NULL, // null to read straight from DB, otherwise set to model accessor function
+]);
+```
+
+Input preview: 
+
+![CRUD Field - base64_image](https://backpackforlaravel.com/uploads/docs-4-2/fields/base64_image.png)
+
+<hr>
+
+<a name="checkbox"></a>
+### checkbox
+
+Checkbox for true/false.
+
+```php
+[   // Checkbox
+    'name'  => 'active',
+    'label' => 'Active',
+    'type'  => 'checkbox'
+],
+```
+
+Input preview: 
+
+![CRUD Field - checkbox](https://backpackforlaravel.com/uploads/docs-4-2/fields/checkbox.png)
+
+<hr>
+
+<a name="checklist"></a>
+### checklist
+
+Show a list of checkboxes, for the user to check one or more of them.
+
+```php
+[   // Checklist
+    'label'     => 'Roles',
+    'type'      => 'checklist',
+    'name'      => 'roles',
+    'entity'    => 'roles',
+    'attribute' => 'name',
+    'model'     => "Backpack\PermissionManager\app\Models\Role",
+    'pivot'     => true,
+    // 'number_of_columns' => 3,
+],
+```
+
+**Note: If you don't use a pivot table (pivot = false), you need to cast your db column as `array` in your model,by adding your column to your model's `$casts`. **
+
+Input preview: 
+
+![CRUD Field - checklist](https://backpackforlaravel.com/uploads/docs-4-2/fields/checklist.png)
+
+<hr>
+
+<a name="checklist-dependency"></a>
+### checklist_dependency
+
+```php
+[   // two interconnected entities
+    'label'             => 'User Role Permissions',
+    'field_unique_name' => 'user_role_permission',
+    'type'              => 'checklist_dependency',
+    'name'              => ['roles', 'permissions'], // the methods that define the relationship in your Models
+    'subfields'         => [
+        'primary' => [
+            'label'            => 'Roles',
+            'name'             => 'roles', // the method that defines the relationship in your Model
+            'entity'           => 'roles', // the method that defines the relationship in your Model
+            'entity_secondary' => 'permissions', // the method that defines the relationship in your Model
+            'attribute'        => 'name', // foreign key attribute that is shown to user
+            'model'            => "Backpack\PermissionManager\app\Models\Role", // foreign key model
+            'pivot'            => true, // on create&update, do you need to add/delete pivot table entries?]
+            'number_columns'   => 3, //can be 1,2,3,4,6
+        ],
+        'secondary' => [
+            'label'          => 'Permission',
+            'name'           => 'permissions', // the method that defines the relationship in your Model
+            'entity'         => 'permissions', // the method that defines the relationship in your Model
+            'entity_primary' => 'roles', // the method that defines the relationship in your Model
+            'attribute'      => 'name', // foreign key attribute that is shown to user
+            'model'          => "Backpack\PermissionManager\app\Models\Permission", // foreign key model
+            'pivot'          => true, // on create&update, do you need to add/delete pivot table entries?]
+            'number_columns' => 3, //can be 1,2,3,4,6
+        ],
+    ],
+],
+```
+
+Input preview: 
+
+![CRUD Field - checklist_dependency](https://backpackforlaravel.com/uploads/docs-4-2/fields/checklist_dependency.png)
+
+<hr>
+
+<a name="ckeditor"></a>
+### ckeditor
+
+Show a wysiwyg CKEditor to the user.
+
+```php
+[   // CKEditor
+    'name'          => 'description',
+    'label'         => 'Description',
+    'type'          => 'ckeditor',
+
+    // optional:
+    'extra_plugins' => ['oembed', 'widget'],
+    'options'       => [
+        'autoGrow_minHeight'   => 200,
+        'autoGrow_bottomSpace' => 50,
+        'removePlugins'        => 'resize,maximize',
+    ]
+],
+```
+
+If you'd like to be able to select files from elFinder, you need to also run ```composer require backpack/filemanager``` to install elFinder.
+
+Input preview: 
+
+![CRUD Field - ckeditor](https://backpackforlaravel.com/uploads/docs-4-2/fields/ckeditor.png)
+
+<hr>
+
+<a name="color"></a>
+### color
+
+```php
+[   // Color
+    'name'    => 'background_color',
+    'label'   => 'Background Color',
+    'type'    => 'color',
+    'default' => '#000000',
+],
+```
+
+Input preview: 
+
+![CRUD Field - color](https://backpackforlaravel.com/uploads/docs-4-2/fields/color.png)
+
+<hr>
+
+<a name="color-picker"></a>
+### color_picker
+
+Show a pretty colour picker using [Bootstrap Colorpicker](https://itsjavi.com/bootstrap-colorpicker/).
+
+```php
+[   // color_picker
+    'label'                => 'Background Color',
+    'name'                 => 'background_color',
+    'type'                 => 'color_picker',
+    'default'              => '#000000',
+
+    // optional
+    // Anything your define inside `color_picker_options` will be passed as JS
+    // to the JavaScript plugin. For more information about the options available
+    // please see the plugin docs at:
+    //  ### https://itsjavi.com/bootstrap-colorpicker/module-options.html
+    'color_picker_options' => [
+        'customClass' => 'custom-class',
+        'horizontal' => true,
+        'extensions' => [
+            [
+                'name' => 'swatches', // extension name to load
+                'options' => [ // extension options
+                    'colors' => [
+                        'primary' => '#337ab7',
+                        'success' => '#5cb85c',
+                        'info' => '#5bc0de',
+                        'warning' => '#f0ad4e',
+                        'danger' => '#d9534f'
+                    ],
+                    'namesAsValues' => false
+                ]
+            ]
+        ]
+    ]
+],
+```
+
+Input preview: 
+
+![CRUD Field - color_picker](https://backpackforlaravel.com/uploads/docs-4-2/fields/color_picker.png)
+
+<hr>
+
+<a name="custom-html"></a>
+### custom_html
+
+Allows you to insert custom HTML in the create/update forms. Usually used in forms with a lot of fields, to separate them using h1-h5, hr, etc, but can be used for any HTML.
+
+```php
+[   // CustomHTML
+    'name'  => 'separator',
+    'type'  => 'custom_html',
+    'value' => '<hr>'
+],
+```
+
+<a name="date"></a>
+### date
+
+```php
+[   // Date
+    'name'  => 'birthday',
+    'label' => 'Birthday',
+    'type'  => 'date'
+],
+```
+
+Input preview: 
+
+![CRUD Field - date](https://backpackforlaravel.com/uploads/docs-4-2/fields/date.png)
+
+<hr>
+
+<a name="date-picker"></a>
+### date_picker
+
+Show a pretty [Bootstrap Datepicker](http://bootstrap-datepicker.readthedocs.io/en/latest/).
+
+```php
+[   // date_picker
+   'name'  => 'date',
+   'type'  => 'date_picker',
+   'label' => 'Date',
+
+   // optional:
+   'date_picker_options' => [
+      'todayBtn' => 'linked',
+      'format'   => 'dd-mm-yyyy',
+      'language' => 'fr'
+   ],
+],
+```
+
+Please note it is recommended that you use [attribute casting](https://laravel.com/docs/5.3/eloquent-mutators#attribute-casting) on your model (cast to date).
+
+
+Input preview: 
+
+![CRUD Field - date_picker](https://backpackforlaravel.com/uploads/docs-4-2/fields/date_picker.png)
+
+<hr>
+
+<a name="date-range"></a>
+### date_range
+
+Starting with Backpack\CRUD 3.1.59
+
+Show a DateRangePicker and let the user choose a start date and end date.
+
+```php
+[   // date_range
+    'name'  => ['start_date', 'end_date'], // db columns for start_date & end_date
+    'label' => 'Event Date Range',
+    'type'  => 'date_range',
+
+    // OPTIONALS
+    // default values for start_date & end_date
+    'default'            => ['2019-03-28 01:01', '2019-04-05 02:00'], 
+    // options sent to daterangepicker.js
+    'date_range_options' => [
+        'drops' => 'down', // can be one of [down/up/auto]
+        'timePicker' => true,
+        'locale' => ['format' => 'DD/MM/YYYY HH:mm']
+    ]
+],
+```
+
+Please note it is recommended that you use [attribute casting](https://laravel.com/docs/5.3/eloquent-mutators#attribute-casting) on your model (cast to date).
+
+Your end result will look like this:
+
+Input preview: 
+
+![CRUD Field - date_range](https://backpackforlaravel.com/uploads/docs-4-2/fields/date_range.png)
+
+<hr>
+
+<a name="datetime"></a>
+### datetime
+
+```php
+[   // DateTime
+    'name'  => 'start',
+    'label' => 'Event start',
+    'type'  => 'datetime'
+],
+```
+
+**Please note:** if you're using datetime [attribute casting](https://laravel.com/docs/5.3/eloquent-mutators#attribute-casting) on your model, you also need to place this mutator inside your model:
+```php
+	public function setDatetimeAttribute($value) {
+		$this->attributes['datetime'] = \Carbon\Carbon::parse($value);
+	}
+```
+Otherwise the input's datetime-local format will cause some errors.
+
+Input preview: 
+
+![CRUD Field - datetime](https://backpackforlaravel.com/uploads/docs-4-2/fields/datetime.png)
+
+<hr>
+
+<a name="datetime-picker"></a>
+### datetime_picker
+
+Show a [Bootstrap Datetime Picker](https://eonasdan.github.io/bootstrap-datetimepicker/).
+
+```php
+[   // DateTime
+    'name'  => 'start',
+    'label' => 'Event start',
+    'type'  => 'datetime_picker',
+
+    // optional:
+    'datetime_picker_options' => [
+        'format' => 'DD/MM/YYYY HH:mm',
+        'language' => 'pt',
+        'tooltips' => [ //use this to translate the tooltips in the field
+                'today' => 'Hoje',
+                'selectDate' => 'Selecione a data',
+                // available tooltips: today, clear, close, selectMonth, prevMonth, nextMonth, selectYear, prevYear, nextYear, selectDecade, prevDecade, nextDecade, prevCentury, nextCentury, pickHour, incrementHour, decrementHour, pickMinute, incrementMinute, decrementMinute, pickSecond, incrementSecond, decrementSecond, togglePeriod, selectTime, selectDate
+        ]
+    ],
+    'allows_null' => true,
+    // 'default' => '2017-05-12 11:59:59',
+],
+```
+
+**Please note:** if you're using date [attribute casting](https://laravel.com/docs/5.3/eloquent-mutators#attribute-casting) on your model, you may also need to place this mutator inside your model:
+```php
+	public function setDatetimeAttribute($value) {
+		$this->attributes['datetime'] = \Carbon\Carbon::parse($value);
+	}
+```
+Otherwise the input's datetime-local format will cause some errors. Remember to change "datetime" with the name of your attribute (column name).
+
+Input preview: 
+
+![CRUD Field - datetime_picker](https://backpackforlaravel.com/uploads/docs-4-2/fields/datetime_picker.png)
+
+<hr>
+
+<a name="easymde"></a>
+### easymde
+
+Show an [EasyMDE - Markdown Editor](https://easy-markdown-editor.tk/) to the user. EasyMDE is a well-maintained fork of SimpleMDE.
+
+```php
+[   // easymde
+    'name'  => 'description',
+    'label' => 'Description',
+    'type'  => 'easymde',
+    // optional
+    // 'easymdeAttributes' => [
+    //   'promptURLs'   => true,
+    //   'status'       => false,
+    //   'spellChecker' => false,
+    //   'forceSync'    => true,
+    // ],
+    // 'easymdeAttributesRaw' => $some_json
+],
+```
+
+> NOTE: The contents displayed in this editor are NOT stripped, sanitized or escaped by default. Whenever you store Markdown or HTML inside your database, it's HIGHLY recommended that you sanitize the input or output. Laravel makes it super-easy to do that on the model using [accessors](https://laravel.com/docs/8.x/eloquent-mutators#accessors-and-mutators). If you do NOT trust the admins who have access to this field (or end-users can also store information to this db column), please make sure this attribute is always escaped, before it's shown. You can do that by running the value through `strip_tags()` in an accessor on the model (here's [an example](https://github.com/Laravel-Backpack/demo/commit/509c0bf0d8b9ee6a52c50f0d2caed65f1f986385)) or better yet, using an [HTML Purifier package](https://github.com/mewebstudio/Purifier) (here's [an example](https://github.com/Laravel-Backpack/demo/commit/7342cffb418bb568b9e4ee279859685ddc0456c1)). 
+
+Input preview: 
+
+![CRUD Field - easymde](https://backpackforlaravel.com/uploads/docs-4-2/fields/easymde.png)
+
+<hr>
+
+<a name="email"></a>
+### email
+
+```php
+[   // Email
+    'name'  => 'email',
+    'label' => 'Email Address',
+    'type'  => 'email'
+],
+```
+
+Input preview: 
+
+![CRUD Field - email](https://backpackforlaravel.com/uploads/docs-4-2/fields/email.png)
+
+
+<hr>
+
+<a name="enum"></a>
+### enum
+
+Show a select with the values in the database for that ENUM field. Requires that the db column type is "enum". If the db column allows null, the " - " value will also show up in the select.
+
+```php
+[   // Enum
+    'name'  => 'status',
+    'label' => 'Status',
+    'type'  => 'enum'
+],
+```
+
+PLEASE NOTE the enum field only works for MySQL databases.
+
+Input preview: 
+
+![CRUD Field - enum](https://backpackforlaravel.com/uploads/docs-4-2/fields/enum.png)
+
+<hr>
+
+<a name="hidden"></a>
+### hidden
+
+Include an `<input type="hidden">` in the form.
+
+```php
+[   // Hidden
+    'name'  => 'status',
+    'type'  => 'hidden',
+    'value' => 'active',
+],
+```
+
+<hr>
+
+<a name="icon-picker"></a>
+### icon_picker
+
+Show an icon picker. Supported icon sets are fontawesome, lineawesome, glyphicon, ionicon, weathericon, mapicon, octicon, typicon, elusiveicon, materialdesign as per the jQuery plugin, [bootstrap-iconpicker](http://victor-valencia.github.io/bootstrap-iconpicker/).
+
+The stored value will be the class name (ex: fa-home).
+
+```php
+[   // icon_picker
+    'label'   => "Icon",
+    'name'    => 'icon',
+    'type'    => 'icon_picker',
+    'iconset' => 'fontawesome' // options: fontawesome, lineawesome, glyphicon, ionicon, weathericon, mapicon, octicon, typicon, elusiveicon, materialdesign
+],
+```
+
+Your input will look like button, with a dropdown where the user can search or pick an icon:
+
+Input preview: 
+
+![CRUD Field - icon_picker](https://backpackforlaravel.com/uploads/docs-4-2/fields/icon_picker.png)
+
+<hr>
+
+<a name="image"></a>
+### image
+
+Upload an image and store it on the disk. 
+
+**Step 1.** Show the field. 
+```php
+// image
+$this->crud->addField([
+    'label' => "Profile Image",
+    'name' => "image",
+    'type' => 'image',
+    'crop' => true, // set to true to allow cropping, false to disable
+    'aspect_ratio' => 1, // omit or set to 0 to allow any aspect ratio
+    // 'disk'      => 's3_bucket', // in case you need to show images from a different disk
+    // 'prefix'    => 'uploads/images/profile_pictures/' // in case your db value is only the file name (no path), you can use this to prepend your path to the image src (in HTML), before it's shown to the user;
+]);
+```
+
+**Step 2.** Add a [mutator](https://laravel.com/docs/7.x/eloquent-mutators#defining-a-mutator) to your Model, where you pick up the uploaded file and store it wherever you want. You can use this boilerplate code and modify it to match your use case. 
+
+**NOTE: The code below requires that you have ```intervention/image``` installed. If you don't, please do ```composer require intervention/image``` first.**
+
+```php
+// ..
+
+use Illuminate\Support\Str;
+use Intervention\Image\ImageManagerStatic as Image;
+
+// ..
+
+Class Product extends Model
+{
+    // ..
+
+    public function setImageAttribute($value)
+    {
+        $attribute_name = "image";
+        // or use your own disk, defined in config/filesystems.php
+        $disk = config('backpack.base.root_disk_name'); 
+        // destination path relative to the disk above
+        $destination_path = "public/uploads/folder_1/folder_2"; 
+
+        // if the image was erased
+        if ($value==null) {
+            // delete the image from disk
+            \Storage::disk($disk)->delete($this->{$attribute_name});
+
+            // set null in the database column
+            $this->attributes[$attribute_name] = null;
+        }
+
+        // if a base64 was sent, store it in the db
+        if (Str::startsWith($value, 'data:image'))
+        {
+            // 0. Make the image
+            $image = \Image::make($value)->encode('jpg', 90);
+            
+	        // 1. Generate a filename.
+            $filename = md5($value.time()).'.jpg';
+            
+	        // 2. Store the image on disk.
+            \Storage::disk($disk)->put($destination_path.'/'.$filename, $image->stream());
+	    
+	        // 3. Delete the previous image, if there was one.
+            \Storage::disk($disk)->delete($this->{$attribute_name});
+		
+            // 4. Save the public path to the database
+	        // but first, remove "public/" from the path, since we're pointing to it 
+            // from the root folder; that way, what gets saved in the db
+	        // is the public URL (everything that comes after the domain name)
+            $public_destination_path = Str::replaceFirst('public/', '', $destination_path);
+            $this->attributes[$attribute_name] = $public_destination_path.'/'.$filename;
+        }
+    }
+    
+// ..
+```
+> **The uploaded images are not deleted for you.** If you delete an entry (using the CRUD or anywhere inside your app), the image file won't be deleted from the disk.
+> If you're NOT using soft deletes on that Model and want the image to be deleted at the same time the entry is, just specify that in your Model's ```deleting``` event:
+> ```php
+>	public static function boot()
+>	{
+>		parent::boot();
+>		static::deleted(function($obj) {
+>			\Storage::disk('public_folder')->delete($obj->image);
+>		});
+>	}
+> ```
+
+**A note about aspect_ratio**
+The value for aspect ratio is a float that represents the ratio of the cropping rectangle height and width. By way of example,
+
+- Square = 1
+- Landscape = 2
+- Portrait = 0.5
+
+And you can, of course, use any value for more extreme rectangles.
+
+Input preview: 
+
+![CRUD Field - image](https://backpackforlaravel.com/uploads/docs-4-2/fields/image.png)
+
+> NOTE: if you are having trouble uploading big images, please check your php extensions **apcu** and/or **opcache**, users have reported some issues with these extensions when trying to upload very big images. REFS: https://github.com/Laravel-Backpack/CRUD/issues/3457
+
+<hr>
+
+<a name="month"></a>
+### month
+
+```php
+[   // Month
+    'name'  => 'month',
+    'label' => 'Month',
+    'type'  => 'month'
+],
+```
+
+Input preview: 
+
+![CRUD Field - month](https://backpackforlaravel.com/uploads/docs-4-2/fields/month.png)
+
+<hr>
+
+<a name="number"></a>
+### number
+
+Shows an input type=number to the user, with optional prefix and suffix:
+
+```php
+[   // Number
+    'name' => 'number',
+    'label' => 'Number',
+    'type' => 'number',
+
+    // optionals
+    // 'attributes' => ["step" => "any"], // allow decimals
+    // 'prefix'     => "$",
+    // 'suffix'     => ".00",
+],
+```
+
+Input preview: 
+
+![CRUD Field - number](https://backpackforlaravel.com/uploads/docs-4-2/fields/number.png)
+
+<hr>
+
+<a name="password"></a>
+### password
+
+```php
+[   // Password
+    'name'  => 'password',
+    'label' => 'Password',
+    'type'  => 'password'
+],
+```
+
+Input preview: 
+
+![CRUD Field - password](https://backpackforlaravel.com/uploads/docs-4-2/fields/password.png)
+
+
+Please note that this will NOT hash/encrypt the string before it stores it to the database. You need to hash the password manually. The most popular way to do that are:
+
+1. Using [a mutator on your Model](https://laravel.com/docs/7.x/eloquent-mutators#defining-a-mutator). For example:
+
+```php
+public function setPasswordAttribute($value) {
+    $this->attributes['password'] = Hash::make($value);
+}
+```
+
+2. By overwriting the Create/Update operation methods, inside the Controller. There's a working example [in our PermissionManager package](https://github.com/Laravel-Backpack/PermissionManager/blob/master/src/app/Http/Controllers/UserCrudController.php#L103-L124) but the gist of it is this:
+
+```php
+    use \Backpack\CRUD\app\Http\Controllers\Operations\CreateOperation { store as traitStore; }
+    
+    public function store()
+    {
+        $this->crud->setRequest($this->crud->validateRequest());
+    
+        /** @var \Illuminate\Http\Request $request */
+        $request = $this->crud->getRequest();
+
+        // Encrypt password if specified.
+        if ($request->input('password')) {
+            $request->request->set('password', Hash::make($request->input('password')));
+        } else {
+            $request->request->remove('password');
+        }
+
+        $this->crud->setRequest($request);
+        $this->crud->unsetValidation(); // Validation has already been run
+
+        return $this->traitStore();
+    }
+```
+
+
+<hr>
+
+<a name="radio"></a>
+### radio
+
+Show radios according to an associative array you give the input and let the user pick from them. You can choose for the radio options to be displayed inline or one-per-line.
+
+```php
+[   // radio
+    'name'        => 'status', // the name of the db column
+    'label'       => 'Status', // the input label
+    'type'        => 'radio',
+    'options'     => [
+        // the key will be stored in the db, the value will be shown as label; 
+        0 => "Draft",
+        1 => "Published"
+    ],
+    // optional
+    //'inline'      => false, // show the radios all on the same line?
+],
+```
+
+Input preview: 
+
+![CRUD Field - radio](https://backpackforlaravel.com/uploads/docs-4-2/fields/radio.png)
+
+<hr>
+
+<a name="range"></a>
+### range
+
+Shows an HTML5 range element, allowing the user to drag a cursor left-right, to pick a number from a defined range.
+
+```php
+[   // Range
+    'name'  => 'range',
+    'label' => 'Range',
+    'type'  => 'range',
+    //optional
+    'attributes' => [
+        'min' => 0,
+        'max' => 10,
+    ],
+],
+```
+
+Input preview: 
+
+![CRUD Field - range](https://backpackforlaravel.com/uploads/docs-4-2/fields/range.png)
+
+<hr>
+
+<a name="relationship"></a>
+### relationship
+
+Shows the user a `select2` input, allowing them to choose one/more entries of a related Eloquent Model. In order to work, the relationships need to be properly defined on the Model.
+
+Input preview (for both 1-n and n-n relationships):
+
+![CRUD Field - relationship](https://backpackforlaravel.com/uploads/docs-4-2/fields/relationship.png)
+
+To achieve the above, you just need to point the field to the relationship method on your Model (eg. `category`, not `category_id`):
+
+```php
+[   // relationship
+    'name' => 'category', // the method on your model that defines the relationship
+    'type' => "relationship",
+
+    // OPTIONALS:
+    // 'label' => "Category",
+    // 'attribute' => "title", // attribute on model that is shown to user
+    // 'placeholder' => "Select a category", // placeholder for the select2 input
+ ],
+```
+
+More more optional attributes on relationship fields [look here](#optional-attributes-for-fields-containing-related-entries).
+
+Out of the box, it supports all common relationships:
+- ✅ `hasOne` (1-1) - shows subform if you define `subfields`
+- ✅ `belongsTo` (n-1) - shows a select2 (single)
+- ✅ `hasMany` (1-n) - shows a select2_multiple OR a subform if you define `subfields`
+- ✅ `belongsToMany` (n-n) - shows a select2_multiple OR a subform if you define `subfields` for pivot extras
+- ✅ `morphOne` (1-1) - shows a subform if you define `subfields`
+- ✅ `morphMany` (1-n) - shows a select2_multiple OR a subform if you define `subfields`
+- ✅ `morphToMany` (n-n) - shows a select2_multiple OR a subform if you define `subfields` for pivot extras
+
+It does NOT support the following Eloquent relationships, since they don't make sense in this context:
+- ❌ `hasOneThrough` (1-1-1) - it's read-only, no sense having a field for it;
+- ❌ `hasManyThrough` (1-1-n) - it's read-only, no sense having a field for it;
+- ❌ Has One Of Many (1-n turned into 1-1) - it's read-only, no sense having a field for it;
+- ❌ Morph One Of Many (1-n turned into 1-1) - it's read-only, no sense having a field for it;
+- ❌ `morphTo` (n-1) - never needed, UI would be very difficult to understand & use;
+- ❌ `morphedByMany` (n-n inverse) - never needed, UI would be very difficult to understand & use;
+
+The relationship field is a plug-and-play solution, 90% of the time it will cover all you need by just pointing it to a relationship on the model. But it also has a few optional features, that will greatly help you out in more complex use cases:
+
+<a name="load-entries-from-ajax-calls-using-the-fetch-operation"></a>
+#### Load entries from AJAX calls - using the Fetch Operation
+
+If your related entry has hundreds, thousands or millions of entries, it's not practical to load the options using an onpage Eloquent query, because the Create/Update page would be very slow to load. In this case, you should instruct the `relationship` field to fetch the entries using AJAX calls.
+
+**Step 1.** Add `'ajax' => true` to your relationship field definition:
+
+```php
+[   // relationship
+    'type' => "relationship",
+    'name' => 'category', // the method on your model that defines the relationship
+    'ajax' => true,
+
+    // OPTIONALS:
+    // 'label' => "Category",
+    // 'attribute' => "name", // foreign key attribute that is shown to user (identifiable attribute)
+    // 'entity' => 'category', // the method that defines the relationship in your Model
+    // 'model' => "App\Models\Category", // foreign key Eloquent model
+    // 'placeholder' => "Select a category", // placeholder for the select2 input
+
+    // AJAX OPTIONALS:
+    // 'delay' => 500, // the minimum amount of time between ajax requests when searching in the field
+    // 'data_source' => url("fetch/category"), // url to controller search function (with /{id} should return model)
+    // 'minimum_input_length' => 2, // minimum characters to type before querying results
+    // 'dependencies'         => ['category'], // when a dependency changes, this select2 is reset to null
+    // 'include_all_form_fields'  => false, // optional - only send the current field through AJAX (for a smaller payload if you're not using multiple chained select2s)
+ ],
+```
+
+**Step 2.** Create the route and method that responds to the AJAX calls. Fortunately, the `FetchOperation` allows you to easily do just that. Inside the same CrudController where you've defined the `relationship` field, use the `FetchOperation` trait, and define a new method that will respond to AJAX queries for that entity:
+
+```php
+    use \Backpack\CRUD\app\Http\Controllers\Operations\FetchOperation;
+
+    public function fetchCategory()
+    {
+        return $this->fetch(\App\Models\Category::class);
+    }
+```
+
+This will set up a ```/fetch/category``` route, which points to ```fetchCategory()```, which returns the search results. For more on how this operation works (and how you can customize it), see the [FetchOperation docs](/docs/{{version}}/crud-operation-fetch).
+
+
+<a name="create-related-entries-in-a-modal-using-the-inlinecreate-operation"></a>
+#### Create related entries in a modal - using the InlineCreate Operation
+
+Works for the `BelongsTo`, `BelongsToMany` and `MorphToMany` relationships.
+
+Searching with AJAX provides a great UX. But what if the user doesn't find what they're looking for? In that case, it would be useful to add a related entry on-the-fly, without leaving the main form:
+
+![CRUD Field - relationship fetch with inline create](https://backpackforlaravel.com/uploads/docs-4-2/fields/relationship_inlineCreate.gif)
+
+If you are using the Fetch operation to get the entries, you're already halfway there. In addition to using Fetch as instructed in the section above, you should perform two additional steps:
+
+**Step 1.** Add `inline_create` to your field definition in **the current CrudController**:
+
+```php
+// for 1-n relationships (ex: category)
+[
+    'type'          => "relationship",
+    'name'          => 'category',
+    'ajax'          => true,
+    'inline_create' => true, // <--- THIS
+],
+// for n-n relationships (ex: tags)
+[
+    'type'          => "relationship",
+    'name'          => 'tags', // the method on your model that defines the relationship
+    'ajax'          => true,
+    'inline_create' => [ 'entity' => 'tag' ]  // <--- OR THIS
+],
+// in this second example, the relation is called `tags` (plural),
+// but we need to define the entity as "tag" (singural)
+```
+
+**Step 2.** On the CrudController of that secondary entity (that the user will be able to create on-the-fly, eg. `CategoryCrudController` or `TagCrudController`), you'll need to enable the InlineCreate operation:
+```php
+class CategoryCrudController extends CrudController
+{
+    use \Backpack\CRUD\app\Http\Controllers\Operations\InlineCreateOperation;
+
+   // ...
+}
+```
+
+This ```InlineCreateOperation``` will allow us to show _the same fields that are inside the Create operation_, inside a new operation _InlineCreate_, that is available in a modal. For more information, check out the [InlineCreate Operation docs](/docs/{{version}}/crud-operation-inline-create).
+
+Remember, ```FetchOperation``` is still needed on the main crud (ex: ```ArticleCrudController```) so that the entries are fetched by ```select2``` using AJAX.
+
+#### Save additional data to pivot table
+
+For relationships with a pivot table (n-n relationships: `BelongsToMany`, `MorphToMany`), that contain other columns other than the foreign keys themselves, the `relationship` field provides a quick way for your admin to edit those "extra attributes on the pivot table". For example, if you have these database tables:
+
+```php
+// - companies: id, name
+// - company_person: company_id, person_id, job_title, job_description
+// - persons: id, first_name, last_name
+```
+
+You might want the admin to define the `job_title` and `job_description` of a person, when creating/editing a company. So instead of this:
+
+
+![CRUD Field - belongsToMany relationship without custom pivot table attributes](https://backpackforlaravel.com/uploads/docs-4-2/fields/relationship_belongsToMany_noPivot.png)
+
+you might your admin to see this:
+
+![CRUD Field - belongsToMany relationship with custom pivot table attributes](https://backpackforlaravel.com/uploads/docs-4-2/fields/relationship_belongsToMany_withPivot.png)
+
+
+
+The `relationship` field allows you to easily do that. Here's how:
+
+**Step 1.** On your models, make sure the extra database columns are defined, using `withPivot()`:
+
+```php
+// inside the Company model
+public function people()
+{
+    return $this->belongsToMany(\App\Models\Person::class)
+                ->withPivot('job_title', 'job_description');
+}
+// inside the Person model
+public function companies()
+{
+    return $this->belongsToMany(\App\Models\Company::class)
+                ->withPivot('job_title', 'job_description');
+}
+```
+
+**Step 2.** Inside your `relationship` field definition, add `subfields` for those two db columns:
+
+```php
+// Inside PersonCrudController
+[
+    'name'          => 'companies',
+    'type'          => "relationship",
+     // ..
+    'subfields'   => [
+        [
+            'name' => 'job_title',
+            'type' => 'text',
+            'wrapper' => [
+                'class' => 'form-group col-md-3',
+            ],
+        ],
+        [
+            'name' => 'job_description',
+            'type' => 'text',
+            'wrapper' => [
+                'class' => 'form-group col-md-9',
+            ],
+        ],
+    ],
+],
+```
+
+**That's it.** Backpack now will save those additional inputs on the pivot table.
+
+Additionally, if you want to change something about the primary select, you can do that using the `pivotSelect` attribute:
+
+```php
+[
+    'name'          => 'companies',
+    'type'          => "relationship",
+    'subfields'   => [ ... ],
+     // ..
+    'pivotSelect'=> [
+        // 'ajax' => true,
+        'placeholder' => 'Pick a company',
+        'wrapper' => [
+            'class' => 'col-md-6',
+        ],
+    ],
+]
+```
+
+#### Manage related entries in the same form (create, update, delete)
+
+Sometimes for `hasMany` and `morphMany` relationships, the secondary entry cannot stand on its own. It's so dependant on the primary entry, that you don't want it to have a Create/Update form of its own - you just want it to be managed inside its parent. Let's take `Invoice` and `InvoiceItem` as an example, with the following database structure:
+
+```php
+// - invoices: id, number, due_date, payment_status
+// - invoice_items: id, order, description, unit, quantity, unit_price
+```
+
+Most likely, what you _really_ want is to be able to create/update/delete `InvoiceItems` right inside the `Invoice` form:
+
+![CRUD Field - hasMany relationship editing the items on-the-fly](https://backpackforlaravel.com/uploads/docs-4-2/fields/repeatable_hasMany_entries.png)
+
+To achieve the above, you just need to add a `relationship` field for your `hasMany` or `morphMany` relationship and define the `subfields` you want for that secondary Model:
+
+```php
+[
+    'name'          => 'items',
+    'type'          => "relationship",
+    'subfields'   => [
+        [
+            'name' => 'order',
+            'type' => 'number',
+            'wrapper' => [
+                'class' => 'form-group col-md-1',
+            ],
+        ],
+        [
+            'name' => 'description',
+            'type' => 'text',
+            'wrapper' => [
+                'class' => 'form-group col-md-6',
+            ],
+        ],
+        [
+            'name' => 'unit',
+            'label' => 'U.M.',
+            'type' => 'text',
+            'wrapper' => [
+                'class' => 'form-group col-md-1',
+            ],
+        ],
+        [
+            'name' => 'quantity',
+            'type' => 'number',
+            'attributes' => ["step" => "any"],
+            'wrapper' => [
+                'class' => 'form-group col-md-2',
+            ],
+        ],
+        [
+            'name' => 'unit_price',
+            'type' => 'number',
+            'attributes' => ["step" => "any"],
+            'wrapper' => [
+                'class' => 'form-group col-md-2',
+            ],
+        ],
+    ],
+]
+```
+
+Backpack will then take care of the creating/updating/deleting of the secondary model, after the "Save" button is clicked on the form.
+
+
+<a name="create-related-entries-in-a-modal-using-the-inlinecreate-operation"></a>
+#### Delete related entries or fall back to default
+
+Normally, when the admin removes a relationship from the "select", only the relationship gets deleted, _not_ the related entry. But for the `hasMany` and `morphMany` relationships, it can also make sense to want to remove the related entry entirely. That's why for those relationships, you can also instruct Backpack to remove the _related entry_ upon saving OR change the foreign key to a default value (fallback).
+
+```php
+// Inside ArticleCrudController
+[
+    'type'          => "relationship",
+    'name'          => 'comments',
+    // when removed, use fallback_id
+    'fallback_id'   => 3, // will relate to the comment with ID "3"
+    // when removed, delete the entry
+    'force_delete'  => true, // will delete that comment
+],
+```
+
+<hr>
+
+<a name="repeatable"></a>
+### repeatable
+
+Shows a group of inputs to the user, and allows the user to add or remove groups of that kind:
+
+![CRUD Field - repeatable](https://backpackforlaravel.com/uploads/docs-4-2/fields/repeatable.png)
+
+**Since 4.2**: repeatable returns an array when the form is submitted instead of the already parsed json. **You must cast** the repeatable field to **ARRAY** or **JSON** in your model.
+
+Clicking on the "New Item" button will add another group with the same subfields (in the example, another Testimonial).
+
+You can use most field types inside the field groups, add as many subfields you need, and change their width using ```wrapper``` like you would do outside the repeatable field. But please note that:
+- **all subfields defined inside a field group need to have their definition valid and complete**; you can't use shorthands, you shouldn't assume fields will guess attributes for you;
+- some field types do not make sense as subfields inside repeatable (for example, relationship fields might not make sense; they will work if the relationship is defined on the main model, but upon save the selected entries will NOT be saved as relationships, they will be saved as JSON; you can intercept the saving if you want and do whatever you want);
+- a few fields _make sense_, but _cannot_ work inside repeatable (ex: upload, upload_multiple); [see the notes inside the PR](https://github.com/Laravel-Backpack/CRUD/pull/2266#issuecomment-559436214) for more details, and a complete list of the fields; the few fields that do not work inside repeatable have sensible alternatives;
+- **VALIDATION**: you can validate subfields the same way you validate [nested arrays in Laravel]([https://laravel.com/docs/8.x/validation#validating-nested-array-input) Eg: `testimonial.*.name => 'required'`
+
+```php
+[   // repeatable
+    'name'  => 'testimonials',
+    'label' => 'Testimonials',
+    'type'  => 'repeatable',
+    'subfields' => [ // also works as: "fields"
+        [
+            'name'    => 'name',
+            'type'    => 'text',
+            'label'   => 'Name',
+            'wrapper' => ['class' => 'form-group col-md-4'],
+        ],
+        [
+            'name'    => 'position',
+            'type'    => 'text',
+            'label'   => 'Position',
+            'wrapper' => ['class' => 'form-group col-md-4'],
+        ],
+        [
+            'name'    => 'company',
+            'type'    => 'text',
+            'label'   => 'Company',
+            'wrapper' => ['class' => 'form-group col-md-4'],
+        ],
+        [
+            'name'  => 'quote',
+            'type'  => 'ckeditor',
+            'label' => 'Quote',
+        ],
+    ],
+    
+    // optional
+    'new_item_label'  => 'Add Group', // customize the text of the button
+    'init_rows' => 2, // number of empty rows to be initialized, by default 1
+    'min_rows' => 2, // minimum rows allowed, when reached the "delete" buttons will be hidden
+    'max_rows' => 2, // maximum rows allowed, when reached the "new item" button will be hidden
+    // allow reordering?
+    'reorder' => false, // hide up&down arrows next to each row (no reordering)
+    'reorder' => true, // show up&down arrows next to each row
+    'reorder' => 'order', // show arrows AND add a hidden subfield with that name (value gets updated when rows move)
+    'reorder' => ['name' => 'order', 'type' => 'number', 'attributes' => ['data-reorder-input' => true]], // show arrows AND add a visible number subfield
+],
+```
+
+
+<hr>
+
+<a name="select"></a>
+### select (1-n relationship)
+
+Show a Select with the names of the connected entity and let the user select one of them.
+Your relationships should already be defined on your models as hasOne() or belongsTo().
+
+```php
+[  // Select
+   'label'     => "Category",
+   'type'      => 'select',
+   'name'      => 'category_id', // the db column for the foreign key
+
+   // optional 
+   // 'entity' should point to the method that defines the relationship in your Model
+   // defining entity will make Backpack guess 'model' and 'attribute'
+   'entity'    => 'category', 
+
+   // optional - manually specify the related model and attribute
+   'model'     => "App\Models\Category", // related model
+   'attribute' => 'name', // foreign key attribute that is shown to user
+
+   // optional - force the related options to be a custom query, instead of all();
+   'options'   => (function ($query) {
+        return $query->orderBy('name', 'ASC')->where('depth', 1)->get();
+    }), //  you can use this to filter the results show in the select
+],
+```
+
+For more information about the optional attributes that fields use when they interact with related entries - [look here](#optional-attributes-for-fields-containing-related-entries).
+
+Input preview: 
+
+![CRUD Field - select](https://backpackforlaravel.com/uploads/docs-4-2/fields/select.png)
+
+
+<hr>
+
+
+<a name="select-grouped"></a>
+### select_grouped
+
+Display a select where the options are grouped by a second entity (like Categories).
+
+```php
+[   // select_grouped
+    'label'     => 'Articles grouped by categories',
+    'type'      => 'select_grouped', //https://github.com/Laravel-Backpack/CRUD/issues/502
+    'name'      => 'article_id',
+    'entity'    => 'article',
+    'attribute' => 'title',
+    'group_by'  => 'category', // the relationship to entity you want to use for grouping
+    'group_by_attribute' => 'name', // the attribute on related model, that you want shown
+    'group_by_relationship_back' => 'articles', // relationship from related model back to this model
+],
+```
+
+For more information about the optional attributes that fields use when they interact with related entries - [look here](#optional-attributes-for-fields-containing-related-entries).
+
+Input preview:
+
+![CRUD Field - select_grouped](https://backpackforlaravel.com/uploads/docs-4-2/fields/select_grouped.png)
+
+<hr>
+
+<a name="select2"></a>
+### select2 (1-n relationship)
+
+Works just like the SELECT field, but prettier. Shows a Select2 with the names of the connected entity and let the user select one of them. 
+Your relationships should already be defined on your models as hasOne() or belongsTo().
+
+```php
+[  // Select2
+   'label'     => "Category",
+   'type'      => 'select2',
+   'name'      => 'category_id', // the db column for the foreign key
+
+   // optional
+   'entity'    => 'category', // the method that defines the relationship in your Model
+   'model'     => "App\Models\Category", // foreign key model
+   'attribute' => 'name', // foreign key attribute that is shown to user
+   'default'   => 2, // set the default value of the select2
+
+    // also optional
+   'options'   => (function ($query) {
+        return $query->orderBy('name', 'ASC')->where('depth', 1)->get();
+    }), // force the related options to be a custom query, instead of all(); you can use this to filter the results show in the select
+],
+```
+
+For more information about the optional attributes that fields use when they interact with related entries - [look here](#optional-attributes-for-fields-containing-related-entries).
+
+Input preview: 
+
+![CRUD Field - select2](https://backpackforlaravel.com/uploads/docs-4-2/fields/select2_nested.png)
+
+<hr>
+
+<a name="select-multiple"></a>
+### select_multiple (n-n relationship)
+
+Show a Select with the names of the connected entity and let the user select any number of them.
+Your relationship should already be defined on your models as belongsToMany().
+
+```php
+[   // SelectMultiple = n-n relationship (with pivot table)
+    'label'     => "Tags",
+    'type'      => 'select_multiple',
+    'name'      => 'tags', // the method that defines the relationship in your Model
+
+    // optional
+    'entity'    => 'tags', // the method that defines the relationship in your Model
+    'model'     => "App\Models\Tag", // foreign key model
+    'attribute' => 'name', // foreign key attribute that is shown to user
+    'pivot'     => true, // on create&update, do you need to add/delete pivot table entries?
+
+    // also optional
+    'options'   => (function ($query) {
+        return $query->orderBy('name', 'ASC')->where('depth', 1)->get();
+    }), // force the related options to be a custom query, instead of all(); you can use this to filter the results show in the select
+],
+```
+
+For more information about the optional attributes that fields use when they interact with related entries - [look here](#optional-attributes-for-fields-containing-related-entries).
+
+Input preview: 
+
+![CRUD Field - select_multiple](https://backpackforlaravel.com/uploads/docs-4-2/fields/select_multiple.png)
+
+
+<hr>
+
+<a name="select2-multiple"></a>
+### select2_multiple (n-n relationship)
+
+[Works just like the SELECT field, but prettier]
+
+Shows a Select2 with the names of the connected entity and let the user select any number of them.
+Your relationship should already be defined on your models as belongsToMany().
+
+```php
+[    // Select2Multiple = n-n relationship (with pivot table)
+     'label'     => "Tags",
+     'type'      => 'select2_multiple',
+     'name'      => 'tags', // the method that defines the relationship in your Model
+
+     // optional
+     'entity'    => 'tags', // the method that defines the relationship in your Model
+     'model'     => "App\Models\Tag", // foreign key model
+     'attribute' => 'name', // foreign key attribute that is shown to user
+     'pivot'     => true, // on create&update, do you need to add/delete pivot table entries?
+     // 'select_all' => true, // show Select All and Clear buttons?
+
+     // optional
+     'options'   => (function ($query) {
+         return $query->orderBy('name', 'ASC')->where('depth', 1)->get();
+     }), // force the related options to be a custom query, instead of all(); you can use this to filter the results show in the select
+],
+```
+
+For more information about the optional attributes that fields use when they interact with related entries - [look here](#optional-attributes-for-fields-containing-related-entries).
+
+Input preview: 
+
+![CRUD Field - select2_multiple](https://backpackforlaravel.com/uploads/docs-4-2/fields/select2_multiple.png)
+
+<hr>
+
+<a name="select2-nested"></a>
+### select2_nested
+
+Display a select2 with the values ordered hierarchically and indented, for an entity where you use Reorder. Please mind that the connected model needs:
+- a ```children()``` relationship pointing to itself;
+- the usual ```lft```, ```rgt```, ```depth``` attributes;
+
+```php
+[   // select2_nested
+    'name'      => 'category_id',
+    'label'     => "Category",
+    'type'      => 'select2_nested',
+    'entity'    => 'category', // the method that defines the relationship in your Model
+    'attribute' => 'name', // foreign key attribute that is shown to user
+    
+    // optional
+    'model'     => "App\Models\Category", // force foreign key model
+],
+```
+
+For more information about the optional attributes that fields use when they interact with related entries - [look here](#optional-attributes-for-fields-containing-related-entries).
+
+Input preview:
+
+![CRUD Field - select2_nested](https://backpackforlaravel.com/uploads/docs-4-2/fields/select2_nested.png)
+
+<hr>
+
+<a name="select2-grouped"></a>
+### select2_grouped
+
+Display a select2 where the options are grouped by a second entity (like Categories).
+
+```php
+[   // select2_grouped
+    'label'     => 'Articles grouped by categories',
+    'type'      => 'select2_grouped', //https://github.com/Laravel-Backpack/CRUD/issues/502
+    'name'      => 'article_id',
+    'entity'    => 'article', // the method that defines the relationship in your Model
+    'attribute' => 'title',
+    'group_by'  => 'category', // the relationship to entity you want to use for grouping
+    'group_by_attribute' => 'name', // the attribute on related model, that you want shown
+    'group_by_relationship_back' => 'articles', // relationship from related model back to this model
+],
+```
+
+For more information about the optional attributes that fields use when they interact with related entries - [look here](#optional-attributes-for-fields-containing-related-entries).
+
+Input preview:
+
+![CRUD Field - select2_grouped](https://backpackforlaravel.com/uploads/docs-4-2/fields/select2_grouped.png)
+
+
+<hr>
+
+<a name="select_and_order"></a>
+### select_and_order
+
+Display items on two columns and let the user drag&drop between them to choose which items are selected and which are not, and reorder the selected items with drag&drop.
+
+Its definition is exactly as ```select_from_array```, but the value will be stored as JSON in the database: ```["3","5","7","6"]```, so it needs the attribute to be cast to array on the Model:
+
+```php
+protected $casts = [
+    'featured' => 'array'
+];
+```
+
+Definition:
+
+```php
+[   // select_and_order
+    'name'  => 'featured',
+    'label' => "Featured",
+    'type'  => 'select_and_order',
+    'options' => [
+        1 => "Option 1",
+        2 => "Option 2"
+    ]
+],
+```
+
+Also possible:
+
+```php
+[   // select_and_order
+    'name'    => 'featured',
+    'label'   => 'Featured',
+    'type'    => 'select_and_order',
+    'options' => Product::get()->pluck('title','id')->toArray(),
+],
+```
+
+Input preview: 
+
+![CRUD Field - select_and_order](https://backpackforlaravel.com/uploads/docs-4-2/fields/select_and_order.png)
+
+
+<hr>
+
+<a name="select-from-array"></a>
+### select_from_array
+
+Display a select with the values you want:
+
+```php
+[   // select_from_array
+    'name'        => 'template',
+    'label'       => "Template",
+    'type'        => 'select_from_array',
+    'options'     => ['one' => 'One', 'two' => 'Two'],
+    'allows_null' => false,
+    'default'     => 'one',
+    // 'allows_multiple' => true, // OPTIONAL; needs you to cast this to array in your model;
+],
+```
+
+Input preview: 
+
+![CRUD Field - select_from_array](https://backpackforlaravel.com/uploads/docs-4-2/fields/select_from_array.png)
+
+<hr>
+
+<a name="select2-from-array"></a>
+### select2_from_array
+
+Display a select2 with the values you want:
+
+```php
+[   // select2_from_array
+    'name'        => 'template',
+    'label'       => "Template",
+    'type'        => 'select2_from_array',
+    'options'     => ['one' => 'One', 'two' => 'Two'],
+    'allows_null' => false,
+    'default'     => 'one',
+    // 'allows_multiple' => true, // OPTIONAL; needs you to cast this to array in your model;
+],
+```
+
+Input preview: 
+
+![CRUD Field - select2_from_array](https://backpackforlaravel.com/uploads/docs-4-2/fields/select2_from_array.png)
+
+<hr>
+
+<a name="select2-from-ajax"></a>
+### select2_from_ajax
+
+Display a select2 that takes its values from an AJAX call.
+
+```php
+[   // 1-n relationship
+    'label'       => "End", // Table column heading
+    'type'        => "select2_from_ajax",
+    'name'        => 'category_id', // the column that contains the ID of that connected entity
+    'entity'      => 'category', // the method that defines the relationship in your Model
+    'attribute'   => "name", // foreign key attribute that is shown to user
+    'data_source' => url("api/category"), // url to controller search function (with /{id} should return model)
+
+    // OPTIONAL
+    // 'delay' => 500, // the minimum amount of time between ajax requests when searching in the field
+    // 'placeholder'             => "Select a category", // placeholder for the select
+    // 'minimum_input_length'    => 2, // minimum characters to type before querying results
+    // 'model'                   => "App\Models\Category", // foreign key model
+    // 'dependencies'            => ['category'], // when a dependency changes, this select2 is reset to null
+    // 'method'                  => 'GET', // optional - HTTP method to use for the AJAX call (GET, POST)
+    // 'include_all_form_fields' => false, // optional - only send the current field through AJAX (for a smaller payload if you're not using multiple chained select2s)
+],
+```
+
+For more information about the optional attributes that fields use when they interact with related entries - [look here](#optional-attributes-for-fields-containing-related-entries).
+
+Of course, you also need to create make the data_source above respond to AJAX calls. You can use the [FetchOperation](https://backpackforlaravel.com/docs/4.1/crud-operation-fetch) to quickly do that in your current CrudController, or you can set up your custom API by creating a custom Route and Controller. Here's an example:
+
+```php
+Route::get('/api/category', 'Api\CategoryController@index');
+```
+
+```php
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+use Backpack\NewsCRUD\app\Models\Category;
+
+class CategoryController extends Controller
+{
+    public function index(Request $request)
+    {
+        $search_term = $request->input('q');
+
+        if ($search_term)
+        {
+            $results = Category::where('name', 'LIKE', '%'.$search_term.'%')->paginate(10);
+        }
+        else
+        {
+            $results = Category::paginate(10);
+        }
+
+        return $results;
+    }
+}
+```
+
+**Note:** If you want to also make this field work inside `repeatable` too, your API endpoint will also need to respond to the `keys` parameter, with the actual items that have those keys. For example:
+
+```php
+        if ($request->has('keys')) { 
+            return Category::findMany($request->input('keys'));
+        }
+```
+
+Input preview: 
+
+![CRUD Field - select2_from_array](https://backpackforlaravel.com/uploads/docs-4-2/fields/select2_from_array.png)
+
+<hr>
+
+<a name="select2-from-ajax-multiple"></a>
+### select2_from_ajax_multiple
+
+Display a select2 that takes its values from an AJAX call. Same as [select2_from_ajax](#section-select2_from_ajax) above, but allows for multiple items to be selected. The only difference in the field definition is the "pivot" attribute.
+
+```php
+[   // n-n relationship
+    'label'       => "Cities", // Table column heading
+    'type'        => "select2_from_ajax_multiple",
+    'name'        => 'cities', // a unique identifier (usually the method that defines the relationship in your Model) 
+    'entity'      => 'cities', // the method that defines the relationship in your Model
+    'attribute'   => "name", // foreign key attribute that is shown to user
+    'data_source' => url("api/city"), // url to controller search function (with /{id} should return model)
+    'pivot'       => true, // on create&update, do you need to add/delete pivot table entries?
+    
+    // OPTIONAL
+    'delay' => 500, // the minimum amount of time between ajax requests when searching in the field
+    'model'                => "App\Models\City", // foreign key model
+    'placeholder'          => "Select a city", // placeholder for the select
+    'minimum_input_length' => 2, // minimum characters to type before querying results
+    // 'include_all_form_fields'  => false, // optional - only send the current field through AJAX (for a smaller payload if you're not using multiple chained select2s)
+],
+```
+
+For more information about the optional attributes that fields use when they interact with related entries - [look here](#optional-attributes-for-fields-containing-related-entries).
+
+Of course, you also need to create a controller and routes for the data_source above. Here's an example:
+
+```php
+Route::get('/api/city', 'Api\CityController@index');
+Route::get('/api/city/{id}', 'Api\CityController@show');
+```
+
+```php
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+use App\Models\City;
+
+class CityController extends Controller
+{
+    public function index(Request $request)
+    {
+        $search_term = $request->input('q');
+        $page = $request->input('page');
+
+        if ($search_term)
+        {
+            $results = City::where('name', 'LIKE', '%'.$search_term.'%')->paginate(10);
+        }
+        else
+        {
+            $results = City::paginate(10);
+        }
+
+        return $results;
+    }
+
+    public function show($id)
+    {
+        return City::find($id);
+    }
+}
+```
+
+Input preview: 
+
+![CRUD Field - select2_from_ajax_multiple](https://backpackforlaravel.com/uploads/docs-4-2/fields/select2_from_ajax_multiple.png)
+
+**Note:** If you want to also make this field work inside `repeatable` too, your API endpoint will also need to respond to the `keys` parameter, with the actual items that have those keys. For example:
+
+```php
+        if ($request->has('keys')) { 
+            return City::findMany($request->input('keys'));
+        }
+```
+
+
+<hr>
+
+<a name="summernote"></a>
+### summernote
+
+Show a [Summernote wysiwyg editor](http://summernote.org/) to the user.
+
+```php
+[   // Summernote
+    'name'  => 'description',
+    'label' => 'Description',
+    'type'  => 'summernote',
+    'options' => [],
+],
+
+// the summernote field works with the default configuration options but allow developer to configure to his needs
+// optional configuration check https://summernote.org/deep-dive/ for a list of available configs
+[   
+    'name'  => 'description',
+    'label' => 'Description',
+    'type'  => 'summernote',
+    'options' => [ 
+        'toolbar' => [
+            ['font', ['bold', 'underline', 'italic']]
+        ]
+    ],
+],
+
+```
+
+> NOTE: Summernote does NOT sanitize the input. If you do not trust the users of this field, you should sanitize the input or output using something like HTML Purifier. Personally we like to use install [mewebstudio/Purifier](https://github.com/mewebstudio/Purifier) and add an [accessor or mutator](https://laravel.com/docs/8.x/eloquent-mutators#accessors-and-mutators) on the Model, so that wherever the model is created from (admin panel or app), the output will always be clean. [Example here](https://github.com/Laravel-Backpack/demo/commit/7342cffb418bb568b9e4ee279859685ddc0456c1).
+
+Input preview: 
+
+![CRUD Field - summernote](https://backpackforlaravel.com/uploads/docs-4-2/fields/summernote.png)
+
+<hr>
+
+<a name="table"></a>
+### table
+
+Show a table with multiple inputs per row and store the values as JSON array of objects in the database. The user can add more rows and reorder the rows as they please.
+
+```php
+[   // Table
+    'name'            => 'options',
+    'label'           => 'Options',
+    'type'            => 'table',
+    'entity_singular' => 'option', // used on the "Add X" button
+    'columns'         => [
+        'name'  => 'Name',
+        'desc'  => 'Description',
+        'price' => 'Price'
+    ],
+    'max' => 5, // maximum rows allowed in the table
+    'min' => 0, // minimum rows allowed in the table
+],
+```
+
+>It's highly recommended that you use [attribute casting](https://mattstauffer.co/blog/laravel-5.0-eloquent-attribute-casting) on your model when working with JSON arrays stored in database columns, and cast this attribute to either ```object``` or ```array``` in your Model.
+
+Input preview: 
+
+![CRUD Field - table](https://backpackforlaravel.com/uploads/docs-4-2/fields/table.png)
+
+<hr>
+
+<a name="text"></a>
+### text
+
+The basic field type, all it needs is the two mandatory parameters: name and label.
+
+```php
+[   // Text
+    'name'  => 'title',
+    'label' => "Title",
+    'type'  => 'text',
+
+    // optional
+    //'prefix'     => '',
+    //'suffix'     => '',
+    //'default'    => 'some value', // default value
+    //'hint'       => 'Some hint text', // helpful text, show up after input
+    //'attributes' => [
+       //'placeholder' => 'Some text when empty',
+       //'class' => 'form-control some-class',
+       //'readonly'  => 'readonly',
+       //'disabled'  => 'disabled',
+     //], // extra HTML attributes and values your input might need
+     //'wrapper'   => [
+       //'class' => 'form-group col-md-12'
+     //], // extra HTML attributes for the field wrapper - mostly for resizing fields 
+    
+],
+```
+
+You can use the optional 'prefix' and 'suffix' attributes to display something before and after the input, like icons, path prefix, etc:
+
+Input preview: 
+
+![CRUD Field - text](https://backpackforlaravel.com/uploads/docs-4-2/fields/text.png)
+
+<hr>
+
+<a name="textarea"></a>
+### textarea
+
+Show a textarea to the user.
+
+```php
+[   // Textarea
+    'name'  => 'description',
+    'label' => 'Description',
+    'type'  => 'textarea'
+],
+```
+
+Input preview: 
+
+![CRUD Field - textarea](https://backpackforlaravel.com/uploads/docs-4-2/fields/textarea.png)
+
+<hr>
+
+<a name="time"></a>
+### time
+
+```php
+[   // Time
+    'name'  => 'start',
+    'label' => 'Start time',
+    'type'  => 'time'
+],
+```
+
+<hr>
+
+<a name="tinymce"></a>
+### tinymce
+
+Show a wysiwyg (TinyMCE) to the user.
+
+```php
+[   // TinyMCE
+    'name'  => 'description',
+    'label' => 'Description',
+    'type'  => 'tinymce',
+    // optional overwrite of the configuration array
+    // 'options' => [ 'selector' => 'textarea.tinymce',  'skin' => 'dick-light', 'plugins' => 'image,link,media,anchor' ],
+],
+```
+
+Input preview: 
+
+![CRUD Field - tinymce](https://backpackforlaravel.com/uploads/docs-4-2/fields/tinymce.png)
+
+<hr>
+
+<a name="upload"></a>
+### upload
+
+**Step 1.** Show a file input to the user:
+```php
+[   // Upload
+    'name'      => 'image',
+    'label'     => 'Image',
+    'type'      => 'upload',
+    'upload'    => true,
+    'disk'      => 'uploads', // if you store files in the /public folder, please omit this; if you store them in /storage or S3, please specify it;
+    // optional:
+    'temporary' => 10 // if using a service, such as S3, that requires you to make temporary URLs this will make a URL that is valid for the number of minutes specified
+],
+```
+
+**Step 2.** In order to save/update/delete the file from disk&db, we need to create [a mutator](https://laravel.com/docs/5.3/eloquent-mutators#defining-a-mutator) on your model:
+```php
+public function setImageAttribute($value)
+    {
+    	$attribute_name = "image";
+    	$disk = "public";
+    	$destination_path = "folder_1/subfolder_1";
+
+    	$this->uploadFileToDisk($value, $attribute_name, $disk, $destination_path);
+	
+	// return $this->attributes[{$attribute_name}]; // uncomment if this is a translatable field
+    }
+```
+
+**How it works:**
+
+The field sends the file, through a Request, to the Controller. The Controller then tries to create/update the Model. That's when the mutator on your model will run. That also means we can do any [file validation](https://laravel.com/docs/5.3/validation#rule-file) (```file```, ```image```, ```mimetypes```, ```mimes```) in the Request, before the file is stored on the disk.
+
+>NOTE: If this field is mandatory (required in validation) please use the [sometimes laravel validation rule](https://laravel.com/docs/5.8/validation#conditionally-adding-rules) together with **required** in your validation. (sometimes|required|file etc... )
+
+[The ```uploadFileToDisk()``` method](https://github.com/Laravel-Backpack/CRUD/blob/master/src/app/Models/Traits/HasUploadFields.php#L31-L59) will take care of everything for most use cases:
+
+```php
+/**
+     * Handle file upload and DB storage for a file:
+     * - on CREATE
+     *     - stores the file at the destination path
+     *     - generates a name
+     *     - stores the full path in the DB;
+     * - on UPDATE
+     *     - if the value is null, deletes the file and sets null in the DB
+     *     - if the value is different, stores the different file and updates DB value
+     * /
+public function uploadFileToDisk($value, $attribute_name, $disk, $destination_path) {}
+```
+
+If you wish to have a different functionality, you can delete the method call from your mutator and do your own thing.
+
+>**The uploaded files are not deleted for you.** When you delete an entry (whether through CRUD or the application), the uploaded files will not be deleted.
+
+If you're NOT using soft deletes on that Model and want the file to be deleted at the same time the entry is, just specify that in your Model's ```deleting``` event:
+```php
+	public static function boot()
+	{
+		parent::boot();
+		static::deleting(function($obj) {
+			\Storage::disk('public_folder')->delete($obj->image);
+		});
+	}
+```
+
+Input preview: 
+
+![CRUD Field - upload](https://backpackforlaravel.com/uploads/docs-4-2/fields/upload.png)
+
+<hr>
+
+<a name="upload-multiple"></a>
+### upload_multiple
+
+Shows a multiple file input to the user and stores the values as a JSON array in the database.
+
+**Step 0.** Make sure the db column can hold the amount of text this field will have. For example, for MySQL, VARCHAR(255) might not be enough all the time (for 3+ files), so it's better to go with TEXT. Make sure you're using a big column type in your migration or db.
+
+**Step 1.** Show a multiple file input to the user:
+```php
+[   // Upload
+    'name'      => 'photos',
+    'label'     => 'Photos',
+    'type'      => 'upload_multiple',
+    'upload'    => true,
+    'disk'      => 'uploads', // if you store files in the /public folder, please omit this; if you store them in /storage or S3, please specify it;
+    // optional:
+    'temporary' => 10 // if using a service, such as S3, that requires you to make temporary URLs this will make a URL that is valid for the number of minutes specified
+],
+```
+
+**Step 2.** In order to save/update/delete the files from disk&db, we need to create [a mutator](https://laravel.com/docs/5.3/eloquent-mutators#defining-a-mutator) on your model:
+```php
+public function setPhotosAttribute($value)
+    {
+    	$attribute_name = "photos";
+    	$disk = "public";
+    	$destination_path = "folder_1/subfolder_1";
+
+    	$this->uploadMultipleFilesToDisk($value, $attribute_name, $disk, $destination_path);
+    }
+```
+
+**Step 3.** Since the filenames are stored in the database as a JSON array, we're going to use [attribute casting](https://laravel.com/docs/5.3/eloquent-mutators#attribute-casting) on your model, so every time we get the filenames array from the database it's converted from a JSON array to a PHP array:
+```php
+    protected $casts = [
+    	'photos' => 'array'
+    ];
+```
+
+**How it works:**
+
+The field sends the files, through a Request, to the Controller. The Controller then tries to create/update the Model. That's when the mutator on your model will run. That also means we can do any [file validation](https://laravel.com/docs/5.3/validation#rule-file) (```file```, ```image```, ```mimetypes```, ```mimes```) in the Request, before the files are stored on the disk.
+
+[The ```uploadMultipleFilesToDisk()``` method](https://github.com/Laravel-Backpack/CRUD/blob/master/src/app/Models/Traits/HasUploadFields.php#L76-L113) will take care of everything for most use cases:
+
+```
+/**
+     * Handle multiple file upload and DB storage:
+     * - if files are sent
+     *     - stores the files at the destination path
+     *     - generates random names
+     *     - stores the full path in the DB, as JSON array;
+     * - if a hidden input is sent to clear one or more files
+     *     - deletes the file
+     *     - removes that file from the DB.
+     * /
+public function uploadMultipleFilesToDisk($value, $attribute_name, $disk, $destination_path) {}
+```
+
+If you wish to have a different functionality, you can delete the method call from your mutator and do your own thing.
+
+>**The uploaded files are not deleted for you.** When you delete an entry (whether through CRUD or the application), the uploaded files will not be deleted.
+
+If you're NOT using soft deletes on that Model and want the files to be deleted at the same time the entry is, just specify that in your Model's ```deleting``` event:
+```php
+	public static function boot()
+	{
+		parent::boot();
+		static::deleting(function($obj) {
+			if (count((array)$obj->photos)) {
+				foreach ($obj->photos as $file_path) {
+					\Storage::disk('public_folder')->delete($file_path);
+				}
+			}
+		});
+	}
+```
+
+You might notice the field is using a ```clear_photos``` variable. Don't worry, you don't need it in your db table. That's just used to delete photos upon "update". If you use ```$fillable``` on your model, just don't include it. If you use ```$guarded``` on your model, place it in guarded.
+
+Input preview: 
+
+![CRUD Field - upload_multiple](https://backpackforlaravel.com/uploads/docs-4-2/fields/upload_multiple.png)
+
+
+### url
+
+```php
+[   // URL
+    'name'  => 'link',
+    'label' => 'Link to video file',
+    'type'  => 'url'
+],
+```
+
+<hr>
+
+<a name="video"></a>
+### video
+
+Allow the user to paste a YouTube/Vimeo link. That will get the video information with JavaScript and store it as a JSON in the database.
+
+Field definition:
+```php
+[   // URL
+    'name'            => 'video',
+    'label'           => 'Link to video file on YouTube or Vimeo',
+    'type'            => 'video',
+    'youtube_api_key' => 'AIzaSycLRoVwovRmbIf_BH3X12IcTCudAErRlCE',
+],
+```
+
+An entry stored in the database will look like this:
+```
+$video = {
+    id: 234324,
+    title: 'my video title',
+    image: 'https://provider.com/image.jpg',
+    url: 'http://provider.com/video',
+    provider: 'youtube'
+}
+```
+
+So you should use [attribute casting](https://mattstauffer.co/blog/laravel-5.0-eloquent-attribute-casting) in your model, to cast the video as ```array``` or ```object```.
+
+Vimeo does not require an API key in order to query their DB, but YouTube does, even though their free quota is generous. You can get a free YouTube API Key inside [Google Developers Console](https://console.developers.google.com/) ([video tutorial here](https://www.youtube.com/watch?v=pP4zvduVAqo)). Please DO NOT use our API Key - create your own. The key above is there just for your convenience, to easily try out the field. As soon as you decide to use this field type, create an API Key and use _your_ API Key. Our key hits its ceiling every month, so if you use our key most of the time it won't work.
+
+
+<hr>
+
+<a name="view"></a>
+### view
+
+Load a custom view in the form.
+
+```php
+[   // view
+    'name' => 'custom-ajax-button',
+    'type' => 'view',
+    'view' => 'partials/custom-ajax-button'
+],
+```
+
+**Note:** the same functionality can be achieved using a [custom field type](/docs/{{version}}/crud-fields#creating-a-custom-field-type), or using the [custom_html field type](/docs/{{version}}/crud-fields#custom-html) (if the content is really simple).
+
+<hr>
+
+<a name="week"></a>
+### week
+
+```php
+[   // Week
+    'name'  => 'first_week',
+    'label' => 'First week',
+    'type'  => 'week'
+],
+```
+
+Input preview: 
+
+![CRUD Field - week](https://backpackforlaravel.com/uploads/docs-4-2/fields/week.png)
+
+<hr>
+
+<a name="wysiwyg"></a>
+### wysiwyg
+
+Show a wysiwyg (CKEditor) to the user.
+
+```php
+[   // WYSIWYG Editor
+    'name'  => 'description',
+    'label' => 'Description',
+    'type'  => 'wysiwyg'
+],
+```
+
+<a name="overwriting-default-field-types"></a>
+## Overwriting Default Field Types
+
+The actual field types are stored in the Backpack/CRUD package in ```/resources/views/fields```. If you need to change an existing field, you don't need to modify the package, you just need to add a blade file in your application in ```/resources/views/vendor/backpack/crud/fields```, with the same name. The package checks there first, and only if there's no file there, will it load it from the package.
+
+To quickly publish a field blade file in your project, you can use ```php artisan backpack:publish crud/fields/field_name```. For example, to publish the number field type, you'd type ```php artisan backpack:publish crud/fields/number```
+
+>Please keep in mind that if you're using _your_ file for a field type, you're not using the _package file_. So any updates we push to that file, you're not getting them. In most cases, it's recommended you create a custom field type for your use case, instead of overwriting default field types.
+
+<a name="creating-a-custom-field-type"></a>
+## Creating a Custom Field Type
+
+If you need to extend the CRUD with a new field type, you create a new file in your application in ```/resources/views/vendor/backpack/crud/fields```. Use a name that's different from all default field types. That's it, you'll now be able to use it just like a default field type.
+
+Your field definition will be something like:
+
+```php
+[   // Custom Field
+    'name'  => 'address',
+    'label' => 'Home address',
+    'type'  => 'address'
+    /// 'view_namespace' => 'yourpackage' // use a custom namespace of your package to load views within a custom view folder.
+],
+```
+
+And your blade file something like:
+```php
+<!-- field_type_name -->
+@include('crud::fields.inc.wrapper_start')
+    <label>{!! $field['label'] !!}</label>
+    <input
+        type="text"
+        name="{{ $field['name'] }}"
+        value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
+        @include('crud::fields.inc.attributes')
+    >
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+@include('crud::fields.inc.wrapper_end')
+
+
+@if ($crud->fieldTypeNotLoaded($field))
+    @php
+        $crud->markFieldTypeAsLoaded($field);
+    @endphp
+
+    {{-- FIELD EXTRA CSS  --}}
+    {{-- push things in the after_styles section --}}
+    @push('crud_fields_styles')
+        <!-- no styles -->
+    @endpush
+
+
+    {{-- FIELD EXTRA JS --}}
+    {{-- push things in the after_scripts section --}}
+    @push('crud_fields_scripts')
+        <!-- no scripts -->
+    @endpush
+@endif
+```
+
+Inside your custom field type, you can use these variables:
+- ```$crud``` - all the CRUD Panel settings, options and variables;
+- ```$entry``` - in the Update operation, the current entry being modified (the actual values);
+- ```$field``` - all attributes that have been passed for this field;
+
+If your field type uses JavaScript, we recommend you:
+- put a ```data-init-function="bpFieldInitMyCustomField"``` attribute on your input;
+- place your logic inside the scripts section mentioned above, inside ```function bpFieldInitMyCustomField(element) {}```; of course, you choose the name of the function but it has to match whatever you specified as data attribute on the input, and it has to be pretty unique; inside this method, you'll find that ```element``` is jQuery-wrapped object of the element where you specified ```data-init-function```; this should be enough for you to not have to use IDs, or any other tricks, to determine other elements inside the DOM - determine them in relation to the main element; if you want, you can choose to put the ```data-init-function``` attribute on a different element, like the wrapping div;

--- a/5.x-dev/crud-filters.md
+++ b/5.x-dev/crud-filters.md
@@ -82,7 +82,7 @@ function() { // if the filter is active
 <hr>
 
 <a name="text"></a>
-### Text
+### Text <span class="badge badge-pill badge-info">PRO</span>
 
 Shows a text input. Most useful for letting the user filter through information that's not shown as a column in the CRUD table - otherwise they could just use the DataTables search field.
 
@@ -126,7 +126,7 @@ function ($value) { // if the filter is active, apply these constraints
 <hr>
 
 <a name="date-range"></a>
-### Date range
+### Date range <span class="badge badge-pill badge-info">PRO</span>
 
 Show a daterange picker. The user can select a start date and an end date.
 
@@ -175,7 +175,7 @@ $this->crud->addFilter([
 <hr>
 
 <a name="select2"></a>
-### Select2
+### Select2 <span class="badge badge-pill badge-info">PRO</span>
 
 Shows a select2 and allows the user to select one item from the list or search for an item. Useful when the values list is long (over 10 elements).
 
@@ -204,7 +204,7 @@ $this->crud->addFilter([
 <hr>
 
 <a name="select2_multiple"></a>
-### Select2_multiple
+### Select2_multiple <span class="badge badge-pill badge-info">PRO</span>
 
 Shows a select2 and allows the user to select one or more items from the list or search for an item. Useful when the values list is long (over 10 elements) and your user should be able to select multiple elements.
 
@@ -231,11 +231,11 @@ $this->crud->addFilter([
 <hr>
 
 <a name="select2_ajax"></a>
-### Select2_ajax
+### Select2_ajax <span class="badge badge-pill badge-info">PRO</span>
 
 Shows a select2 and allows the user to select one item from the list or search for an item. This list is fetched through an AJAX call by the select2. Useful when the values list is long (over 1000 elements).
 
-<small>NOTE: if you want to setup your ajax routes using FetchOperation, have a look at: <a href="https://backpackforlaravel.com/docs/4.2/crud-operation-fetch#fetch-ajax-filter">FetchOperation with ajax filter</a></small>
+<small>NOTE: if you want to setup your ajax routes using FetchOperation, have a look at: <a href="https://backpackforlaravel.com/docs/5.x/crud-operation-fetch#fetch-ajax-filter">FetchOperation with ajax filter</a></small>
 
 ![Backpack CRUD Select2_ajax Filter](https://backpackforlaravel.com/uploads/docs-4-0/filters/select2_ajax.png)
 
@@ -275,7 +275,7 @@ function($value) { // if the filter is active
 <hr>
 
 <a name="range"></a>
-### Range
+### Range <span class="badge badge-pill badge-info">PRO</span>
 
 Shows two number inputs, for min and max.
 

--- a/5.x-dev/crud-filters.md
+++ b/5.x-dev/crud-filters.md
@@ -1,0 +1,494 @@
+# Filters
+
+---
+
+<a name="about"></a>
+## About
+
+Backpack CRUD allows you to show a filters bar right above the entries table. When selected or modified, they reload the DataTables results. The search will then search within the filtered elements.
+
+![Backpack CRUD Filters](https://backpackforlaravel.com/uploads/docs-4-0/filters/filters.png)
+
+Just like with fields, columns or buttons, you can add existing filters or create a custom filter that fits to your particular needs. Everything's done inside your ```EntityCrudController::setupListOperation()```. 
+
+<a name="methods"></a>
+### Filters API
+
+In order to manipulate filters, you can use:
+
+```php
+$this->crud->addFilter($options, $values, $filter_logic);
+
+$this->crud->removeFilter($name);
+$this->crud->removeAllFilters();
+
+$this->crud->filters(); // gets all the filters
+```
+
+<a name="adding-a-filter"></a>
+### Adding a filter
+
+When adding a filter you need to specify the 3 parameters of the ```addFilter()``` method:
+- $options - an array of options (name, type, label are most important)
+- $values - filter values - can be an array or a closure
+- $filter_logic - what should happen if the filter is applied (usually add a clause to the query) - can be a closure, a string for a simple operation or false for a simple "where";
+
+Here's a simple example, with comments that explain what we're doing:
+```php
+// add a "simple" filter called Draft
+$this->crud->addFilter([ 
+  'type'  => 'simple',
+  'name'  => 'draft',
+  'label' => 'Draft'
+],
+false, // the simple filter has no values, just the "Draft" label specified above
+function() { // if the filter is active (the GET parameter "draft" exits)
+  $this->crud->addClause('where', 'draft', '1'); 
+  // we've added a clause to the CRUD so that only elements with draft=1 are shown in the table
+  // an alternative syntax to this would have been
+  // $this->crud->query = $this->crud->query->where('draft', '1'); 
+  // another alternative syntax, in case you had a scopeDraft() on your model:
+  // $this->crud->addClause('draft'); 
+});
+```
+> Notes about the filter logic closure
+> - the code will only be run on the controller's ```index()``` or ```search()``` methods;
+> - you can get the filter value by specifying a parameter to the function (ex: ```$value```);
+> - you have access to other request variables using ```$this->crud->getRequest()```;
+> - you also have read/write access to public properties using ```$this->crud```;
+> - when building complicated "OR" logic, make sure the first "where" in your closure is a "where" and only the subsequent are "orWhere"; Laravel 5.3+ no longer converts the first "orWhere" into a "where";
+
+<a name="filter-types"></a>
+## Filter types
+
+<a name="simple"></a>
+### Simple
+
+Only shows a label and can be toggled on/off. Useful for things like active/inactive and easily paired with [Eloquent Scopes](https://laravel.com/docs/5.3/eloquent#local-scopes). The "Draft" and "Has Video" filters in the screenshot above are simple filters.
+
+```php
+// simple filter
+$this->crud->addFilter([
+  'type'  => 'simple',
+  'name'  => 'active',
+  'label' => 'Active'
+], 
+false, 
+function() { // if the filter is active
+  // $this->crud->addClause('active'); // apply the "active" eloquent scope 
+} );
+```
+
+<hr>
+
+<a name="text"></a>
+### Text
+
+Shows a text input. Most useful for letting the user filter through information that's not shown as a column in the CRUD table - otherwise they could just use the DataTables search field.
+
+![Backpack CRUD Text Filter](https://backpackforlaravel.com/uploads/docs-4-0/filters/text.png)
+
+```php
+// simple filter
+$this->crud->addFilter([
+  'type'  => 'text',
+  'name'  => 'description',
+  'label' => 'Description'
+], 
+false, 
+function($value) { // if the filter is active
+  // $this->crud->addClause('where', 'description', 'LIKE', "%$value%");
+});
+```
+
+<hr>
+
+<a name="date"></a>
+### Date
+
+Show a datepicker. The user can select one day.
+
+![Backpack CRUD Date Filter](https://backpackforlaravel.com/uploads/docs-4-0/filters/date.png)
+
+```php
+// date filter
+$this->crud->addFilter([
+  'type'  => 'date',
+  'name'  => 'date',
+  'label' => 'Date'
+],
+  false,
+function ($value) { // if the filter is active, apply these constraints
+  // $this->crud->addClause('where', 'date', $value);
+});
+```
+
+<hr>
+
+<a name="date-range"></a>
+### Date range
+
+Show a daterange picker. The user can select a start date and an end date.
+
+![Backpack CRUD Date Range Filter](https://backpackforlaravel.com/uploads/docs-4-0/filters/date_range.png)
+
+```php
+// daterange filter
+$this->crud->addFilter([
+  'type'  => 'date_range',
+  'name'  => 'from_to',
+  'label' => 'Date range'
+],
+false,
+function ($value) { // if the filter is active, apply these constraints
+  // $dates = json_decode($value);
+  // $this->crud->addClause('where', 'date', '>=', $dates->from);
+  // $this->crud->addClause('where', 'date', '<=', $dates->to . ' 23:59:59');
+});
+```
+
+<hr>
+
+<a name="dropdown"></a>
+### Dropdown
+
+Shows a list of elements (that you provide) in a dropdown. The user can only select one of these elements.
+
+![Backpack CRUD Dropdown Filter](https://backpackforlaravel.com/uploads/docs-4-0/filters/dropdown.png)
+
+```php
+// dropdown filter
+$this->crud->addFilter([
+  'name'  => 'status',
+  'type'  => 'dropdown',
+  'label' => 'Status'
+], [
+  1 => 'In stock',
+  2 => 'In provider stock',
+  3 => 'Available upon ordering',
+  4 => 'Not available',
+], function($value) { // if the filter is active
+  // $this->crud->addClause('where', 'status', $value);
+});
+```
+
+<hr>
+
+<a name="select2"></a>
+### Select2
+
+Shows a select2 and allows the user to select one item from the list or search for an item. Useful when the values list is long (over 10 elements).
+
+![Backpack CRUD Select2 Filter](https://backpackforlaravel.com/uploads/docs-4-0/filters/select2.png)
+
+```php
+// select2 filter
+$this->crud->addFilter([
+  'name'  => 'status',
+  'type'  => 'select2',
+  'label' => 'Status'
+], function () {
+  return [
+    1 => 'In stock',
+    2 => 'In provider stock',
+    3 => 'Available upon ordering',
+    4 => 'Not available',
+  ];
+}, function ($value) { // if the filter is active
+  // $this->crud->addClause('where', 'status', $value);
+});
+```
+
+**Note:** If you want to pass all entries of a Laravel model to your filter, you can do it in the second parameter (the closure), with something like ```return \Backpack\NewsCRUD\app\Models\Category::all()->keyBy('id')->pluck('name', 'id')->toArray();```;
+
+<hr>
+
+<a name="select2_multiple"></a>
+### Select2_multiple
+
+Shows a select2 and allows the user to select one or more items from the list or search for an item. Useful when the values list is long (over 10 elements) and your user should be able to select multiple elements.
+
+![Backpack CRUD Select2_multiple Filter](https://backpackforlaravel.com/uploads/docs-4-0/filters/select2_multiple.png)
+
+```php
+// select2_multiple filter
+$this->crud->addFilter([
+  'name'  => 'status',
+  'type'  => 'select2_multiple',
+  'label' => 'Status'
+], function() {
+    return [
+      1 => 'In stock',
+      2 => 'In provider stock',
+      3 => 'Available upon ordering',
+      4 => 'Not available',
+    ];
+}, function($values) { // if the filter is active
+    // $this->crud->addClause('whereIn', 'status', json_decode($values));
+});
+```
+
+<hr>
+
+<a name="select2_ajax"></a>
+### Select2_ajax
+
+Shows a select2 and allows the user to select one item from the list or search for an item. This list is fetched through an AJAX call by the select2. Useful when the values list is long (over 1000 elements).
+
+<small>NOTE: if you want to setup your ajax routes using FetchOperation, have a look at: <a href="https://backpackforlaravel.com/docs/4.2/crud-operation-fetch#fetch-ajax-filter">FetchOperation with ajax filter</a></small>
+
+![Backpack CRUD Select2_ajax Filter](https://backpackforlaravel.com/uploads/docs-4-0/filters/select2_ajax.png)
+
+1. Add a route for the ajax search, right above your usual ```CRUD::resource()``` route. Example:
+
+```php
+Route::get('test/ajax-category-options', 'TestCrudController@categoryOptions');
+CRUD::resource('test', 'TestCrudController');
+```
+
+2. Add a method to your EntityCrudController that responds to a search term. The result should be an array with ```id => value```. Example for a 1-n relationship:
+
+```php
+public function categoryOptions(Request $request) {
+  $term = $request->input('term');
+  $options = App\Models\Category::where('name', 'like', '%'.$term.'%')->get()->pluck('name', 'id');
+  return $options;
+}
+```
+
+3. Add the select2_ajax filter and for the second parameter ("values") specify the exact route.
+
+```php
+// select2_ajax filter
+$this->crud->addFilter([
+  'name'        => 'category_id',
+  'type'        => 'select2_ajax',
+  'label'       => 'Category',
+  'placeholder' => 'Pick a category'
+],
+url('admin/test/ajax-category-options'), // the ajax route
+function($value) { // if the filter is active
+    // $this->crud->addClause('where', 'category_id', $value);
+});
+```
+
+<hr>
+
+<a name="range"></a>
+### Range
+
+Shows two number inputs, for min and max.
+
+![Backpack CRUD Range Filter](https://backpackforlaravel.com/uploads/docs-4-0/filters/range.png)
+
+```php
+$this->crud->addFilter([
+  'name'       => 'number',
+  'type'       => 'range',
+  'label'      => 'Range',
+  'label_from' => 'min value',
+  'label_to'   => 'max value'
+],
+false,
+function($value) { // if the filter is active
+    $range = json_decode($value);
+    if ($range->from) {
+        $this->crud->addClause('where', 'number', '>=', (float) $range->from);
+    }
+    if ($range->to) {
+        $this->crud->addClause('where', 'number', '<=', (float) $range->to);
+    }
+});
+```
+
+<hr>
+
+<a name="view"></a>
+### View
+
+Display any custom column filter you want. Usually used by Backpack package developers, to use views from within their packages, instead of having to publish them. 
+
+```php
+// custom filter view
+$this->crud->addFilter([
+  'name'        => 'category_id',
+  'type'        => 'view',
+  'view'        => 'package::columns.column_type_name', // or path to blade file
+  'label'       => 'Category',
+  'placeholder' => 'Pick a category',
+],
+false, 
+function($value) { // if the filter is active
+    // $this->crud->addClause('where', 'category_id', $value);
+});
+```
+
+<hr>
+
+<a name="creating-a-custom-filter-type"></a>
+## Creating custom filters
+
+Creating a new filter type is as easy as using the template below and placing a new view in your ```resources/views/vendor/backpack/crud/filters``` folder. You can then call this new filter by its view's name (ex: ```custom_select.blade.php``` will mean your filter type is called ```custom_select```).
+
+The filters bar is actually a [bootstrap navbar](http://getbootstrap.com/components/#navbar) at its core, but slimmer.  So adding a new filter will be just like adding a menu item (for the HTML). Start from the ```text``` filter below and build your functionality.
+
+Inside this file, you'll have:
+- ```$filter``` object - includes everything you've defined on the current field;
+- ```$crud``` - the CrudPanel object;
+
+```php
+{{-- Text Backpack CRUD filter --}}
+
+<li filter-name="{{ $filter->name }}"
+  filter-type="{{ $filter->type }}"
+  class="dropdown {{ Request::get($filter->name) ? 'active' : '' }}">
+  <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">{{ $filter->label }} <span class="caret"></span></a>
+  <div class="dropdown-menu">
+    <div class="form-group backpack-filter m-b-0">
+      <div class="input-group">
+            <input class="form-control pull-right"
+                id="text-filter-{{ str_slug($filter->name) }}"
+                type="text"
+            @if ($filter->currentValue)
+              value="{{ $filter->currentValue }}"
+            @endif
+                >
+            <div class="input-group-addon">
+              <a class="text-filter-{{ str_slug($filter->name) }}-clear-button" href="#"><i class="fa fa-times"></i></a>
+            </div>
+        </div>
+    </div>
+  </div>
+</li>
+
+{{-- ########################################### --}}
+{{-- Extra CSS and JS for this particular filter --}}
+
+
+{{-- FILTERS EXTRA JS --}}
+{{-- push things in the after_scripts section --}}
+
+@push('crud_list_scripts')
+  <!-- include select2 js-->
+  <script>
+    jQuery(document).ready(function($) {
+      $('#text-filter-{{ str_slug($filter->name) }}').on('change', function(e) {
+
+        var parameter = '{{ $filter->name }}';
+        var value = $(this).val();
+
+          // behaviour for ajax table
+        var ajax_table = $('#crudTable').DataTable();
+        var current_url = ajax_table.ajax.url();
+        var new_url = addOrUpdateUriParameter(current_url, parameter, value);
+
+        // replace the datatables ajax url with new_url and reload it
+        new_url = normalizeAmpersand(new_url.toString());
+        ajax_table.ajax.url(new_url).load();
+
+        // mark this filter as active in the navbar-filters
+        if (URI(new_url).hasQuery('{{ $filter->name }}', true)) {
+          $('li[filter-name={{ $filter->name }}]').removeClass('active').addClass('active');
+        } else {
+          $('li[filter-name={{ $filter->name }}]').trigger('filter:clear');
+        }
+      });
+
+      $('li[filter-name={{ str_slug($filter->name) }}]').on('filter:clear', function(e) {
+        $('li[filter-name={{ $filter->name }}]').removeClass('active');
+        $('#text-filter-{{ str_slug($filter->name) }}').val('');
+      });
+
+      // datepicker clear button
+      $(".text-filter-{{ str_slug($filter->name) }}-clear-button").click(function(e) {
+        e.preventDefault();
+
+        $('li[filter-name={{ str_slug($filter->name) }}]').trigger('filter:clear');
+        $('#text-filter-{{ str_slug($filter->name) }}').val('');
+        $('#text-filter-{{ str_slug($filter->name) }}').trigger('change');
+      })
+    });
+  </script>
+@endpush
+{{-- End of Extra CSS and JS --}}
+{{-- ########################################## --}}
+```
+
+<hr>
+
+<a name="examples"></a>
+## Examples
+
+Use a dropdown to filter by the values of a MySQL ENUM column:
+
+```php
+// select2 filter
+$this->crud->addFilter([
+  'name'  => 'published',
+  'type'  => 'select2',
+  'label' => 'Published'
+], function() {
+    return \App\Models\Test::getEnumValuesAsAssociativeArray('published');
+}, function($value) { // if the filter is active
+    $this->crud->addClause('where', 'published', $value);
+});
+```
+
+Use a select2 to filter by a 1-n relationship:
+```php
+// select2 filter
+$this->crud->addFilter([
+  'name'  => 'category_id',
+  'type'  => 'select2',
+  'label' => 'Category'
+], function() {
+    return \App\Models\Category::all()->pluck('name', 'id')->toArray();
+}, function($value) { // if the filter is active
+    $this->crud->addClause('where', 'category_id', $value);
+});
+```
+
+Use a select2_multiple to filter Products by an n-n relationship:
+```php
+// select2_multiple filter
+$this->crud->addFilter([
+  'name'  => 'tags',
+  'type'  => 'select2_multiple',
+  'label' => 'Tags'
+], function() { // the options that show up in the select2
+    return Product::all()->pluck('name', 'id')->toArray();
+}, function($values) { // if the filter is active
+    foreach (json_decode($values) as $key => $value) {
+        $this->crud->query = $this->crud->query->whereHas('tags', function ($query) use ($value) {
+            $query->where('tag_id', $value);
+        });
+    }
+});
+```
+    
+Use a simple filter to add a scope if the filter is active:
+```php
+// add a "simple" filter called Published 
+$this->crud->addFilter([
+  'type'  => 'simple',
+  'name'  => 'published',
+  'label' => 'Published'
+], 
+false,
+function() { // if the filter is active (the GET parameter "published" exits)
+    $this->crud->addClause('published');
+});
+```
+
+Use a simple filter to show the softDeleted items (trashed):
+```php
+$this->crud->addFilter([
+  'type'  => 'simple',
+  'name'  => 'trashed',
+  'label' => 'Trashed'
+],
+false,
+function($values) { // if the filter is active
+    $this->crud->query = $this->crud->query->onlyTrashed();
+});
+```

--- a/5.x-dev/crud-fluent-syntax.md
+++ b/5.x-dev/crud-fluent-syntax.md
@@ -1,0 +1,722 @@
+# CRUD Fluent API
+
+---
+
+
+<a name="fluent-syntax-about"></a>
+## About
+
+Starting with Backpack 4.1, working with Fields, Columns, Filters, Buttons and Widgets **inside your EntityCrudController** can also be done using a fluent syntax. For example, instead of doing:
+
+```php
+$this->crud->addField([   // Number
+    'name'   => 'price',
+    'label'  => 'Price',
+    'type'   => 'number',
+    'prefix' => "$",
+    'suffix' => ".00",
+]);
+```
+
+You can now do:
+```php
+$this->crud->field('price')
+		->type('number')
+		->label('Price')
+		->prefix('$')
+		->suffix('.00');
+```
+
+But you can go a little further, by using the CrudPanel class at the top of your controller with an alias:
+
+```php
+use Backpack\CRUD\app\Library\CrudPanel\CrudPanel as CRUD;
+
+CRUD::field('price')
+	->type('number')
+	->label('Price')
+	->prefix('$')
+	->suffix('.00');
+```
+
+Or maybe even condense it on just one line:
+```php
+CRUD::field('price')->type('number')->label('Price')->prefix('$')->suffix('.00');
+```
+
+Those who prefer this new fluent syntax do so because:
+- method chains have better highlighting and suggestions in most IDEs;
+- method chains take up slightly fewer lines of code than arrays;
+- method chains are faster to write & modify than arrays;
+- you no longer have to decide if you're adding or modifying a field, since ```CRUD::field()``` basically functions as a ```CRUD::addOrModifyField()```;
+- it allows us to add methods that are exclusive to the fluent syntax, that will make our lives easier; for example, to make a field take up only 6 bootstrap columns, using the non-fluent syntax you'd have to write ```'wrapper' => ['class' => 'form-group col-md-6'],``` - but using the fluent syntax you can just do ```size(6)```;
+
+But keep in mind that it does have downsides: it's more difficult to debug and arguably makes it more difficult to understand how the admin panel works. Developers who are not already comfortable with Backpack might not understand that:
+- referencing ```$this->crud``` is the same thing as ```CRUD``` because it's actually a ```singleton```, a "global" instance of the ```CrudPanel``` object, which gets defined in the Controller and is then read inside the views;
+- the fluent syntax merely turns those chained methods into an array, which gets stored inside ```$this->crud``` like it does with ```addField()``` or ```modifyField()```; 
+
+<a name="fluent-fields-api"></a>
+## Fluent Fields
+
+These methods should be used inside your CrudController for operations that use Fields, most likely inside the ```setupCreateOperation()``` or ```setupUpdateOperation()``` methods.
+
+<a name="general-fluent-fields-api"></a>
+### General
+
+```field('name')``` - By specifying **field('name')** you add a field with that name to the current operation, at the end of the stack, or modify the field that already exists with that name; it accepts a single parameter, a string, that will become that field's ```name```; needs to be called directly, not chained;
+```php
+CRUD::field('name'); 
+```
+
+Anything you chain to the ```field()``` method gets turned into an attribute on that field. Except for the methods below.
+
+<a name="fluent-fields-chained-methods"></a>
+### Chained Methods
+
+If you chain the following methods to a ```CRUD::field('name')```, they will do something very specific instead of adding that attribute to the field:
+
+- ```->remove()``` - By chaining **remove()** on a field you remove it from the current operation;
+
+```php
+CRUD::field('name')->remove();
+```
+
+- ```->forget('attribute_name')``` - By chaining **forget('attribute_name')** to a field you remove that attribute from the field definition array;
+
+```php
+CRUD::field('name')->forget('suffix');
+```
+
+- ```->after('destination')``` - By chaining **after('destination_field_name')** you will move the current field after the given field;
+
+```php
+CRUD::field('name')->after('description');
+```
+
+- ```->before('destination')``` - By chaining **before('destination_field_name')** you will move the current field before the given field;
+
+```php
+CRUD::field('name')->before('description');
+```
+
+- ```->makeFirst()``` - By chaining **makeFirst()** you will make the current field the first one for the current operation;
+
+```php
+CRUD::field('name')->makeFirst();
+```
+
+- ```->makeLast()``` - By chaining **makeLast()** you will make the current field the last one for the current operation;
+
+```php
+CRUD::field('name')->makeLast();
+```
+
+- ```->size(6)``` - By chaining **size(4)** you will make the field span across this many bootstrap columns (instead of the default 12 columns which is a full row); it accepts a single parameter, an integer from 1 to 12; for more information and to see how you can create convenience methods like this one, see [the PR](https://github.com/Laravel-Backpack/CRUD/pull/2638);
+
+```php
+CRUD::field('name')->size(6);
+
+// alternative to
+CRUD::addField([
+	'name' => 'name',
+	'wrapper' => ['class' => 'form-group col-md-6'],
+]);
+```
+
+- Do you have an idea for a new chained method aka. convenience method? [Let us know](https://github.com/laravel-backpack/crud/issues).
+
+<a name="fluent-fields-examples"></a>
+### Examples
+
+```php
+// a text field
+CRUD::field('last_name');
+
+// an email field, put inside a tab and resized to half the width
+CRUD::field('email')->type('email')->size(6)->tab('Simple');
+
+// a number field with prefix and suffix (stored as fake in extras)
+CRUD::field('price')->type('number')->prefix('$')->suffix(".00")->fake(true);
+
+// a date picker field with custom options
+CRUD::field('birthday')
+	    ->type('date_picker')
+	    ->label('Birthday')
+	    ->date_picker_options([
+	        'todayBtn' => true,
+	        'format'   => 'dd-mm-yyyy',
+	        'language' => 'en',
+	    ])
+	    ->size(6);
+
+// a select field, half the width
+CRUD::field('category_id')
+        ->type('select')
+        ->label('Category')
+        ->entity('category')
+        ->attribute('name')
+        // ->model('Backpack\NewsCRUD\app\Models\Category') // optional; guessed from entity;
+        // ->wrapper(['class' => 'form-group col-md-6']) // possible, but easier with size below;
+        ->size(6);
+
+// a select2_from_ajax field
+CRUD::field('article')
+        ->type('select2_from_ajax')
+        ->label("Article")
+        ->entity('article')
+        // ->attribute('title') // starting with Backpack 4.1 this is optional & guessed
+        // ->model('Backpack\NewsCRUD\app\Models\Article') // optional; guessed;
+        ->data_source(url('api/article'))
+        ->placeholder('Select an article')
+        ->minimum_input_length(2);
+
+// a relationship field for an n-n relationship
+// also uses the Fetch and InlineCreate operations
+CRUD::field('products')
+        ->type('relationship')
+        ->label('Products')
+        // ->entity('products') // optional
+        // ->attribute('name') // optional
+        ->ajax(true)
+        ->data_source(backpack_url('monster/fetch/product'))
+        ->inline_create(['entity' => 'product'])
+        // ->wrapper(['class' => 'form-group col-md-6'])
+        ->tab('Others');
+```
+
+<a name="fluent-columns-api"></a>
+## Fluent Columns
+
+These methods should be used inside your CrudController for operations that use Columns, most likely inside the ```setupListOperation()``` or ```setupShowOperation()``` methods.
+
+
+<a name="general-fluent-columns-api"></a>
+### General
+
+- ```column('name')``` - By specifying **column('name')** you add a column with that name to the current operation, at the end of the stack, or modify the column that already exists with that name; takes a single parameter, a string, that will become that column's ```name``` and ```key```; needs to be called directly, not chained;
+```php
+CRUD::column('name'); 
+```
+
+Anything you chain to the ```column()``` method gets turned into an attribute on that column. Except for the methods below:
+
+
+<a name="fluent-columns-chained-methods"></a>
+### Chained Methods
+
+If you chain the following methods to a ```CRUD::column('name')```, they will do something very specific instead of adding that attribute to the column:
+
+- ```->remove()``` - By chaining **remove()** on a column you remove it from the current operation;
+
+```php
+CRUD::column('name')->remove();
+```
+
+- ```->forget('attribute_name')``` - By chaining **forget('attribute_name')** to a column you remove that attribute from the column definition array;
+
+```php
+CRUD::column('name')->forget('suffix');
+```
+
+- ```->after('destination')``` - By chaining **after('destination_column_name')** you will move the current column after the given column;
+
+```php
+CRUD::column('name')->after('description');
+```
+
+- ```->before('destination')``` - By chaining **before('destination_column_name')** you will move the current column before the given column;
+
+```php
+CRUD::column('name')->before('description');
+```
+
+- ```->makeFirst()``` - By chaining **makeFirst()** you will make the current column the first one for the current operation;
+
+```php
+CRUD::column('name')->makeFirst();
+```
+
+- ```->makeLast()``` - By chaining **makeLast()** you will make the current column the last one for the current operation;
+
+```php
+CRUD::column('name')->makeLast();
+```
+
+
+<a name="fluent-columns-examples"></a>
+### Examples
+
+```php
+// a text column
+CRUD::column('last_name');
+
+// a textarea column
+CRUD::column('description')->type('textarea');
+
+// an image column
+CRUD::column('profile_photo')->type('image');
+
+// a select column with links
+CRUD::column('select')
+        ->type('select')
+        ->entity('category')
+        ->attribute('name')
+        ->model("Backpack\NewsCRUD\app\Models\Category")
+        ->wrapper([
+            'href' => function ($crud, $column, $entry, $related_key) {
+                return backpack_url('category/'.$related_key.'/show');
+            },
+        ]);
+
+// a select_multiple column
+CRUD::column('tags')->type('select_multiple')->entity('tags');
+
+// a select_multiple column with everything explicitly defined, plus links
+CRUD::column('tags')
+        ->type('select_multiple')
+        ->label('Select_multiple')
+        ->entity('tags')
+        ->attribute('name')
+        ->model('Backpack\NewsCRUD\app\Models\Tag')
+        ->wrapper([
+            'href' => function ($crud, $column, $entry, $related_key) {
+                return backpack_url('tag/'.$related_key.'/show');
+            },
+        ]);
+
+// a checkbox column that turns a boolean into green labels if true
+CRUD::column('active')
+        ->type('boolean')
+        ->label('Active')
+        ->options([0 => 'Yes', 1 => 'No'])
+        ->wrapper([
+            'element' => 'span',
+            'class'   => function ($crud, $column, $entry, $related_key) {
+                if ($column['text'] == 'Yes') {
+                    return 'badge badge-success';
+                }
+
+                return 'badge badge-default';
+            },
+        ]);
+
+// a select_from_array column
+CRUD::column('status')
+        ->type('select_from_array')
+        ->label('Status')
+        ->options(['1' => 'New', '2' => 'Processing', '3' => 'Delivered']);
+
+// a model function column, with custom search logic
+CRUD::column('text_and_email')
+	    ->type('model_function')
+	    ->label('Text and Email')
+	    ->function_name('getTextAndEmailAttribute')
+	    ->searchLogic(function ($query, $column, $searchTerm) {
+	        $query->orWhere('email', 'like', '%'.$searchTerm.'%');
+	        $query->orWhere('text', 'like', '%'.$searchTerm.'%');
+	    }); 
+```
+
+<a name="fluent-buttons-api"></a>
+## Fluent Buttons
+
+These methods should be used inside your CrudController for operations that use Buttons, most likely inside the ```setupListOperation()``` or ```setupShowOperation()``` methods.
+
+
+<a name="general-fluent-buttons-api"></a>
+### General
+
+- ```button('name')``` - By specifying **button('name')** you add a button with that name to the current operation, at the end of the stack, or modify the button that already exists with that name; takes a single parameter, a string, that will become that button's ```name```; needs to be called directly, not chained;
+```php
+CRUD::button('name'); 
+```
+
+Anything you chain to the ```button()``` method gets turned into an attribute on that button. Except for the methods listed below. Keep in mind in most cases you will still need to chain ```stack```, ```view``` and maybe ```type``` to this method, to define those attributes. Details in the examples section below.
+
+
+<a name="fluent-buttons-chained-methods"></a>
+### Chained Methods
+
+If you chain the following methods to a ```CRUD::button('name')```, they will do something very specific instead of adding that attribute to the button:
+
+- ```->remove()``` - By chaining **remove()** on a button you remove it from the current operation;
+
+```php
+CRUD::button('name')->remove();
+```
+
+- ```->forget('attribute_name')``` - By chaining **forget('attribute_name')** to a button you remove that attribute from the button;
+
+```php
+CRUD::button('name')->forget('suffix');
+```
+
+- ```->after('destination')``` - By chaining **after('destination_button_name')** you will move the current button after the given button;
+
+```php
+CRUD::button('name')->after('description');
+```
+
+- ```->before('destination')``` - By chaining **before('destination_button_name')** you will move the current button before the given button;
+
+```php
+CRUD::button('name')->before('description');
+```
+
+- ```->makeFirst()``` - By chaining **makeFirst()** you will make the current button the first one for the current operation;
+
+```php
+CRUD::button('name')->makeFirst();
+```
+
+- ```->makeLast()``` - By chaining **makeLast()** you will make the current button the last one for the current operation;
+
+```php
+CRUD::button('name')->makeLast();
+```
+
+
+<a name="fluent-buttons-examples"></a>
+### Examples
+
+```php
+// ---------
+// Example 1
+// ---------
+// instead of
+$this->crud->addButton('top', 'create', 'view', 'crud::buttons.create');
+// you can now do
+CRUD::button('create')->stack('top')->view('crud::buttons.create');
+
+// ---------
+// Example 2
+// ---------
+// instead of
+$this->crud->addButton('line', 'update', 'view', 'crud::buttons.update', 'end');
+// you can now do
+CRUD::button('edit')->stack('line')->view('crud::buttons.edit');
+
+// ---------
+// Example 3
+// ---------
+// instead of
+$this->crud->addButtonFromModelFunction('line', 'open_google', 'openGoogle', 'beginning');
+// you can now do
+CRUD::button('open_google')
+	->stack('line')
+	->type('model_function')
+	->content('openGoogle')
+	->makeFirst();
+
+// ---------
+// Example 4
+// ---------
+// instead of
+$this->crud->addButtonFromView('top', 'create', 'crud::buttons.create', 'beginning');
+// you can now do
+CRUD::button('create')->stack('top')->view('crud::buttons.create');
+
+// ---------
+// Example 5
+// ---------
+// instead of
+$this->crud->removeButton('create');
+// you can now do
+CRUD::button('create')->remove();
+
+// ------
+// Extras
+// ------
+// but you don't have to give it a name, so you can also do
+CRUD::button()->stack('line')->type('model_function')->content('openGoogle')->makeFirst();
+// and we also have helpers for setting both the type to view/model_function and its content
+CRUD::button()->stack('line')->modelFunction('openGoogle')->makeFirst();
+
+// -------
+// Aliases
+// -------
+// the "stack" attribute can also be set using the "group", "section" and "to" aliases
+// all of the calls below do the exact same thing
+CRUD::buton('create')->stack('top')->view('crud::butons.create');
+CRUD::buton('create')->to('top')->view('crud::butons.create');
+CRUD::buton('create')->group('top')->view('crud::butons.create');
+CRUD::buton('create')->section('top')->view('crud::butons.create');
+```
+
+
+<a name="fluent-filters-api"></a>
+## Fluent Filters
+
+
+These methods should be used inside your CrudController for operations that use Filters, most likely inside ```setupListOperation()```.
+
+
+<a name="general-fluent-filters-api"></a>
+### General
+
+```filter('name')``` - By specifying **filter('name')** you add a filter with that name to the current operation, at the end of the stack, or modify the filter that already exists with that name; takes a single parameter, a string, that will become that filter's ```name```; needs to be called directly, not chained;
+```php
+CRUD::filter('name'); 
+```
+
+Anything you chain to the ```filter()``` method gets turned into an attribute on that filter. Except for the methods listed below. Keep in mind in most cases you will still need to chain ```type```, ```logic```, ```fallbackLogic``` and maybe ```apply``` to this method, to define those attributes and apply the appropriate logic. Details in the examples section below.
+
+<a name="fluent-filters-main-chained-methods"></a>
+### Main Chained Methods
+
+- ```->type('date')``` - By chaining **type()** on a filter you make sure you use that filter type; it accepts a string that represents the type of filter you want to use;
+
+```php
+CRUD::filter('birthday')->type('date');
+```
+
+- ```->label('Name')``` - By chaining **label()** on a filter you define what is shown to the user as the filter label; it accepts a string;
+
+```php
+CRUD::filter('name')->label('Name');
+```
+
+- ```->logic(function($value) {})``` - By chaining **logic()** on a filter you define should be done when that filter is active; it accepts a closure that is called when the filter is active - either immediately by further chaining ```apply()``` on the filter, or automatically after all filters are defined, by the List operation itself; you can also use ```->whenActive()``` or ```->ifActive()``` which are its aliases:
+
+```php
+// logic method
+CRUD::filter('active')
+	->type('simple')
+	->logic(function ($value) {
+	    $this->crud->addClause('where', 'active', '1');
+	})->apply();
+
+// whenActive alias
+CRUD::filter('active')
+	->type('simple')
+	->whenActive(function ($value) {
+	    $this->crud->addClause('where', 'active', '1');
+	})->apply();
+
+// ifActive alias, left to be applied by the operation itself
+CRUD::filter('active')
+	->type('simple')
+	->whenActive(function ($value) {
+	    $this->crud->addClause('where', 'active', '1');
+	});
+```
+
+- ```->fallbackLogic(function($value) {})``` - By chaining **fallbackLogic()** on a filter you define should be done when that filter is NOT active; it accepts a closure that is called when the filter is NOT active - either immediately by further chaining ```apply()``` on the filter, or automatically after all filters are defined, by the List operation itself; you can also use ```->else()```, ```->whenInactive()```, ```->whenNotActive()```, ```->ifInactive()``` and ```->ifNotActive()``` which are its aliases:
+
+```php
+// fallbackLogic method, applied immediately
+CRUD::filter('active')
+	->type('simple')
+	->logic(function ($value) {
+	    $this->crud->addClause('where', 'active', '1');
+	})->fallbackLogic(function ($value) {
+	    $this->crud->addClause('where', 'active', '0');
+	})->apply();
+
+// else alias, left to be applied by the operation itself
+CRUD::filter('active')
+	->type('simple')
+	->label('Simple')
+	->ifActive(function ($value) {
+	    $this->crud->addClause('where', 'active', '1');
+	})->else(function ($value) {
+	    $this->crud->addClause('where', 'active', '0');
+	});
+```
+
+<a name="fluent-filters-other-chained-methods"></a>
+### Other Chained Methods
+
+If you chain the following methods to a ```CRUD::filter('name')```, they will do something very specific instead of adding that attribute to the filter:
+
+- ```->remove()``` - By chaining **remove()** on a filter you remove it from the current operation;
+
+```php
+CRUD::filter('name')->remove();
+```
+
+- ```->forget('attribute_name')``` - By chaining **forget('attribute_name')** to a filter you remove that attribute from the filter;
+
+```php
+CRUD::filter('name')->forget('suffix');
+```
+
+- ```->after('destination')``` - By chaining **after('destination_filter_name')** you will move the current filter after the given filter;
+
+```php
+CRUD::filter('name')->after('description');
+```
+
+- ```->before('destination')``` - By chaining **before('destination_filter_name')** you will move the current filter before the given filter;
+
+```php
+CRUD::filter('name')->before('description');
+```
+
+- ```->makeFirst()``` - By chaining **makeFirst()** you will make the current filter the first one for the current operation;
+
+```php
+CRUD::filter('name')->makeFirst();
+```
+
+- ```->makeLast()``` - By chaining **makeLast()** you will make the current filter the last one for the current operation;
+
+```php
+CRUD::filter('name')->makeLast();
+```
+
+
+<a name="fluent-filters-examples"></a>
+### Examples
+
+```php
+// instead of
+CRUD::addFilter([
+    'type'  => 'simple',
+    'name'  => 'checkbox',
+    'label' => 'Simple',
+],
+false,
+function () {
+    $this->crud->addClause('where', 'checkbox', '1');
+});
+
+// you can do
+CRUD::filter('checkbox')
+    ->type('simple')
+    ->label('Simple')
+    ->logic(function($value) {
+        $this->crud->addClause('where', 'checkbox', '1');
+    })->apply();
+
+// or
+CRUD::filter('checkbox')
+    ->type('simple')
+    ->label('Simple')
+    ->whenActive(function($value) { // filter logic
+        $this->crud->addClause('where', 'checkbox', '1');
+    })->whenInactive(function($value) { // fallback logic
+        $this->crud->addClause('inactive');
+    })->apply();
+
+// or 
+CRUD::filter('checkbox')
+    ->type('simple')
+    ->label('Simple')
+    ->ifActive(function($value) { // filter logic
+        $this->crud->addClause('where', 'checkbox', '1');
+    })->else(function($value) { // fallback logic
+        $this->crud->addClause('inactive');
+    })->apply();
+
+// -------------------
+// you can also now do
+// -------------------
+CRUD::filter('select_from_array')->label('Modified Dropdown');
+CRUD::filter('select_from_array')->whenActive(function($value) {
+    dd('select_from_array filter logic got modified');
+})->apply();
+CRUD::filter('select_from_array')->remove();
+CRUD::filter('select_from_array')->forget('label');
+CRUD::filter('select_from_array')->after('text');
+CRUD::filter('select_from_array')->before('text');
+CRUD::filter('select_from_array')->makeFirst();
+CRUD::filter('select_from_array')->makeLast();
+
+// --------------
+// other examples
+// --------------
+// checkbox filter
+CRUD::filter('checkbox')
+    ->type('simple')
+    ->label('Simple')
+    ->logic(function($value) {
+        $this->crud->addClause('where', 'checkbox', '1');
+    })->apply();
+
+// select_from_array filter
+CRUD::filter('select_from_array')
+    ->type('dropdown')
+    ->label('DropDOWN')
+    ->values([
+        'one'   => 'One', 
+        'two'   => 'Two', 
+        'three' => 'Three'
+    ])
+    ->whenActive(function($value) {
+        $this->crud->addClause('where', 'select_from_array', $value);
+    })
+    ->apply();
+
+// text filter
+CRUD::filter('text')
+    ->type('text')
+    ->label('Text')
+    ->whenActive(function($value) {
+        $this->crud->addClause('where', 'text', 'LIKE', "%$value%");
+    })->apply();
+
+// number filter
+CRUD::filter('number')
+    ->type('range')
+    ->label('Range')->label_from('min value')->label_to('max value')
+    ->whenActive(function($value) {
+        $range = json_decode($value);
+        if ($range->from && $range->to) {
+            $this->crud->addClause('where', 'number', '>=', (float) $range->from);
+            $this->crud->addClause('where', 'number', '<=', (float) $range->to);
+        }
+    })->apply();
+
+// date filter
+CRUD::filter('date')
+    ->type('date')
+    ->label('Date')
+    ->whenActive(function($value) {
+        $this->crud->addClause('where', 'date', '=', $value);
+    })->apply();
+
+// date_range filter
+CRUD::filter('date_range')
+    ->type('date_range')
+    ->label('Date range')
+    ->whenActive(function($value) {
+         $dates = json_decode($value);
+         $this->crud->addClause('where', 'date', '>=', $dates->from);
+         $this->crud->addClause('where', 'date', '<=', $dates->to);
+    })->apply();
+
+// select2 filter
+CRUD::filter('select2')
+    ->type('select2')
+    ->label('Select2')
+    ->values(function() {
+        return \Backpack\NewsCRUD\app\Models\Category::all()->keyBy('id')->pluck('name', 'id')->toArray();
+    })
+    ->whenActive(function($value) {
+        $this->crud->addClause('where', 'select2', $value);
+    })->apply();
+
+// select2_multiple filter
+CRUD::filter('select2_multiple')
+    ->type('select2_multiple')
+    ->label('S2 multiple')
+    ->values(function() {
+        return \Backpack\NewsCRUD\app\Models\Category::all()->keyBy('id')->pluck('name', 'id')->toArray();
+    })
+    ->whenActive(function($value) {
+        foreach (json_decode($values) as $key => $value) {
+            $this->crud->addClause('orWhere', 'select2', $value);
+        }
+    })->apply();
+
+// select2_from_ajax filter
+CRUD::filter('select2_from_ajax')
+    ->type('select2_ajax')
+    ->label('S2 Ajax')
+    ->placeholder('Pick an article')
+    ->values('api/article-search')
+    ->whenActive(function($value) {
+        $this->crud->addClause('where', 'select2_from_ajax', $value);
+    })->apply();
+```

--- a/5.x-dev/crud-how-to.md
+++ b/5.x-dev/crud-how-to.md
@@ -1,0 +1,765 @@
+# FAQs for CRUDs
+
+---
+
+In addition the usual CRUD functionality, Backpack also allows you to do a few more complicated things:
+
+
+<a name="routes"></a>
+## Routes
+
+<a name="how-to-add-extra-crud-routes"></a>
+### How to add extra CRUD routes
+
+Starting with Backpack\CRUD 4.0, routes are defined inside the Controller, in methods that look like ```setupOperationNameRoutes()```; you can use this naming convention to setup extra routes, for your custom operations:
+
+```php
+protected function setupModerateRoutes($segment, $routeName, $controller) {
+  Route::get($segment.'/{id}/moderate', [
+      'as'        => $routeName.'.moderate',
+      'uses'      => $controller.'@moderate',
+      'operation' => 'moderate',
+  ]);
+
+  Route::post($segment.'/{id}/moderate', [
+      'as'        => $routeName.'.saveModeration',
+      'uses'      => $controller.'@saveModeration',
+      'operation' => 'moderate',
+  ]);
+}
+```
+
+If you want the route to point to a different controller, you can add the route in ```routes/backpack/custom.php``` instead.
+
+<a name="views"></a>
+## Views
+
+<a name="how-to-customize-views-for-each-crud-panel"></a>
+### How to customize views for each CRUD panel
+
+Backpack loads its views through a double-fallback mechanism:
+- by default, it will load the views in the vendor folder (the package views);
+- if you've included views with the exact same name in your ```resources/views/vendor/backpack/crud``` folder, it will pick up those instead; you can use this method to overwrite a blade file for all CRUDs;
+- alternatively, if you only want to change a blade file for one CRUD, you can use the methods below in your ```setup()``` method, to change a particular view:
+```php
+$this->crud->setShowView('your-view');
+$this->crud->setEditView('your-view');
+$this->crud->setCreateView('your-view');
+$this->crud->setListView('your-view');
+$this->crud->setReorderView('your-view');
+$this->crud->setDetailsRowView('your-view');
+```
+
+<a name="how-to-customize-css-and-js-for-default-crud-operations"></a>
+### How to add CSS or JS to a page or operation
+
+If you want to add extra CSS or JS to a certain page, use the `script` and `style` widgets to add a new file of that type onpage, either from your CrudController or a custom blade file:
+
+```php
+use Backpack\CRUD\app\Library\Widget;
+
+// script widget - works the same for both local paths and CDN
+Widget::add()->type('script')->content('assets/js/custom-script.js');
+Widget::add()->type('script')->content('https://code.jquery.com/ui/1.12.0/jquery-ui.min.js');
+Widget::add()->type('script')
+             ->content('https://code.jquery.com/ui/1.12.0/jquery-ui.min.js')
+             ->integrity('sha256-0YPKAwZP7Mp3ALMRVB2i8GXeEndvCq3eSl/WsAl1Ryk=')
+             ->crossorigin('anonymous');
+
+// style widget - works the same for both local paths and CDN
+Widget::add()->type('style')->content('assets/css/custom-style.css');
+Widget::add()->type('style')->content('https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.58/dist/themes/light.css');
+Widget::add()->type('style')
+             ->content('https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.58/dist/themes/light.css')
+             ->integrity('sha256-0YPKAwZP7Mp3ALMRVB2i8GXeEndvCq3eSl/WsAl1Ryk=')
+             ->crossorigin('anonymous');
+```
+
+For more details please see the `script` and `style` sections in the [Widgets](/docs/{{version}}/base-widgets) page.
+
+You can limit where that CSS/JS is added by making the `Widget::add()` call in the right place in your CrudController:
+- if you do `Widget::add()` inside the `setupListOperation()` method, it will only be loaded there;
+- if you do `Widget::add()` inside the `setup()` method, it will be loaded on all pages for that CRUD;
+- if you want it to be loaded on all pages for all CRUDs, you can create a CustomCrudController that extends our CrudController, do it there and then make sure all your CRUDs extend `CustomCrudController`;
+- if you want it to be loaded on all pages (even non-CRUD like dashboards) you can add the CSS/JS file on all pages by adding it in your `config/backpack/base.php`, under `scripts` and `styles`;
+
+
+<a name="columns"></a>
+## Columns
+
+<a name="how-to-use-the-same-column-name-multiple-times-in-a-crud"></a>
+### How to use the same column name multiple times in a CRUD
+
+If you try to add multiple columns with the same ```name```, by default Backpack will only show the last one. That's because ```name``` is also used as a key in the ```$column``` array. So when you ```addColumn()``` with the same name twice, it just overwrites the previous one.
+
+In order to insert two columns with the same name, use the ```key``` attribute on the second column (or both columns). If this attribute is present for a column, Backpack will use ```key``` instead of ```name```. Example:
+
+```diff
+        $this->crud->addColumn([
+           'label' => "Location",
+           'type' => 'select',
+           'name' => 'location_id',
+           'entity' => 'location',
+           'attribute' => 'title',
+           'model' => "App\Models\Location"
+        ]);
+
+        $this->crud->addColumn([
+           'label' => "Location Type",
+           'type' => 'radio_location_type',
+           'options' => [
+               1 => "Country",
+               2 => "Region"
+           ],
+           'name' => 'location_id',
++          'key' => 'location_type',
+           'entity' => 'location',
+           'attribute' => 'type',
+           'model' => "App\Models\Location"
+        ]);
+```
+
+<a name="fields"></a>
+## Fields
+
+<a name="how-to-publish-a-column-field-filter-button-to-modify"></a>
+### How to publish a column / field / filter / button and modify it
+
+All Backpack packages allow you to easily overwrite and customize the views. If you want Backpack to pick up _your_ file, instead of the one in the package, you can do that by just placing a file with the same name in your views. So if you want to overwrite the select2 field (```vendor/backpack/crud/src/resources/views/fields/select2.blade.php```) to change some functionality, you need to create ```resources/views/vendor/backpack/crud/fields/select2.blade.php```. You can do that manually, or use this command:
+```shell
+php artisan backpack:publish crud/fields/select2
+```
+This will look for the blade file and copy it inside the folder, so you can edit it.
+
+>**Please note:** Once you place a file with the same name inside your project, Backpack will pick that one up instead of the one in the package. That means that even though the file in the package is updated, you won't be getting those updates, since you're not using that file. Blade modifications are almost never breaking changes, but it's a good thing to receive updates with zero effort. Even small ones. So please overwrite the files as little as possible. Best to create your own custom fields/column/filters/buttons, whenever you can.
+
+<a name="how-to-filter-the-options-in-a-select-field"></a>
+### How to filter the options in a select field
+
+This also applies to: select2, select2_multiple, select2_from_ajax, select2_from_ajax_multiple.
+
+There are 3 possible solutions:
+1. If there will be few options (dozens), the easiest way would be to use ```select_from_array``` or ```select2_from_array``` instead. Since you tell it what the options are, you can do any filtering you want there.
+2. If there are a lot of options (100+), best to use ```select2_from_ajax``` instead. You'll be able to filter the results any way you want in the controller method (the one that responds with the results to the AJAX call).
+3. If you can't use ```select2_from_array``` for ```select2_from_ajax```, you can create another model and add a global scope to it. For example, say you only want to show the users that belong to the user's company. You can create ```App\Models\CompanyUser``` and use that in your ```select2``` field instead of ```App\Models\User```:
+
+```php
+<?php
+
+namespace App\Models;
+
+use App\User;
+use Auth;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+
+class CompanyUser extends User
+{
+    /**
+     * The "booting" method of the model.
+     *
+     * @return void
+     */
+    protected static function boot()
+    {
+        parent::boot();
+
+        // never let a company user see the users of other companies
+        if (Auth::check() && Auth::user()->company_id) {
+            $companyId = Auth::user()->company->id;
+
+            static::addGlobalScope('company_id', function (Builder $builder) use ($companyId) {
+                $builder->where('company_id', $companyId);
+            });
+        }
+    }
+}
+```
+
+
+<a name="how-to-load-fields-from-a-different-folder"></a>
+### How to load fields from a different folder
+
+If you're developing a package, you might need Backpack to pick up fields from your package folder, instead of having to publish them upon installation.
+
+Fields, Columns and Filters all have a ```view_namespace``` parameter you can use. Type your folder there, and Backpack will check that folder first, then where the views are published, then Backpack's package folder. Example:
+
+```php
+$this->crud->addFilter([ // add a "simple" filter called Draft
+  'type'  => 'complex',
+  'name'  => 'checkbox',
+  'label' => 'Checked',
+  'view_namespace' => 'custom_filters'
+],
+false, // the simple filter has no values, just the "Draft" label specified above
+function () { // if the filter is active (the GET parameter "draft" exits)
+    $this->crud->addClause('where', 'checkbox', '1');
+});
+```
+This will make Backpack look for the ```resources/views/custom_filters/complex.blade.php```, and pick that up before anything else.
+
+<a name="how-to-add-a-select-that-depends-on-another-field"></a>
+### How to add a select2 field that depends on another field
+
+The ```select2_from_ajax``` and ```select2_from_ajax_multiple``` fields allow you to filter the results of a select2, depending on what has already been selected in a form. Say you have to select2 fields. When the AJAX call is made to the second field, all other variables in the page also get passed - that means you can filter the results of the second select2.
+
+Say you want to show two selects:
+- the first one shows Categories
+- the second one shows Articles, but only from the category above
+
+1. In your CrudController you would do:
+
+```php
+$this->crud->addField([    // SELECT2
+    'label'         => 'Category',
+    'type'          => 'select',
+    'name'          => 'category',
+    'entity'        => 'category',
+    'attribute'     => 'name',
+]);
+
+$this->crud->addField([ // select2_from_ajax: 1-n relationship
+    'label'                => "Article", // Table column heading
+    'type'                 => 'select2_from_ajax_multiple',
+    'name'                 => 'articles', // the column that contains the ID of that connected entity;
+    'entity'               => 'article', // the method that defines the relationship in your Model
+    'attribute'            => 'title', // foreign key attribute that is shown to user
+    'data_source'          => url('api/article'), // url to controller search function (with /{id} should return model)
+    'placeholder'          => 'Select an article', // placeholder for the select
+    'include_all_form_fields' => true, //sends the other form fields along with the request so it can be filtered.
+    'minimum_input_length' => 0, // minimum characters to type before querying results
+    'dependencies'         => ['category'], // when a dependency changes, this select2 is reset to null
+    // 'method'                    => 'GET', // optional - HTTP method to use for the AJAX call (GET, POST)
+]);
+```
+
+**DIFFERENT HERE**: ```minimum_input_length```,  ```dependencies``` and ```include_all_form_fields```.
+
+2. That second select points to routes that need to be registered:
+
+```php
+Route::get('api/article', 'App\Http\Controllers\Api\ArticleController@index');
+Route::get('api/article/{id}', 'App\Http\Controllers\Api\ArticleController@show');
+```
+
+**DIFFERENT HERE**: Nothing.
+
+3. Then that controller would look something like this:
+
+```php
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Backpack\NewsCRUD\app\Models\Article;
+use Illuminate\Http\Request;
+
+class ArticleController extends Controller
+{
+    public function index(Request $request)
+    {
+        $search_term = $request->input('q');
+
+        // NOTE: this is a Backpack helper that parses your form input into an usable array.
+        // you still have the original request as `request('form')`
+        $form = backpack_form_input();
+
+        $options = Article::query();
+
+        // if no category has been selected, show no options
+        if (! $form['category']) {
+            return [];
+        }
+
+        // if a category has been selected, only show articles in that category
+        if ($form['category']) {
+            $options = $options->where('category_id', $form['category']);
+        }
+
+        if ($search_term) {
+            $results = $options->where('title', 'LIKE', '%'.$search_term.'%')->paginate(10);
+        } else {
+            $results = $options->paginate(10);
+        }
+
+        return $results;
+    }
+
+    public function show($id)
+    {
+        return Article::find($id);
+    }
+}
+```
+
+**DIFFERENT HERE**: We use ```$form``` to determine what other variables have been selected in the form, and modify the result accordingly.
+
+
+<a name="what-field-should-i-use-for-a-relationship"></a>
+### What field should I use for a relationship?
+
+With so many field types, it can be a little overwhelming to understand what field type to use for a _particular_ Eloquent relationship. Here's a quick summary of all possible relationships, and the interface you might want for them. Click on the relationship you're interested in, for more details and an example:
+
+
+- **[hasOne (1-1)](#hasone-1-1-relationship)** ✅
+    - (A) show a subform - add a `relationship` field with `subfields`
+    - (B) show a separate field for each attribute on the related entry - add any field type, with dot notation for the field name (`passport.title`)
+- **[belongsTo (n-1)](#belongsto-n-1-relationship)** ✅
+    - show a select2 (single) - add a `relationship` field
+- **[hasMany (1-n)](#hasmany-1-n-relationship)** ✅
+    - (A) show a select2_multiple - add a `relationship` field
+    - (B) show a subform - add a `relationship` field with `subfields`
+- **[belongsToMany (n-n)](#belongstomany-n-n-relationship)** ✅
+    - (A) show a select2_multiple - add a `relationship` field
+    - (B) show a subform - add a `relationship` field and define `subfields`
+- **[morphOne (1-1)](#morphone-1-1-polymorphic-relationship)** ✅
+    - (A) show a subform - add a `relationship` field with `subfields`
+    - (B) show a separate field for each attribute on the related entry - add any field type, with dot notation for the field name (`passport.title`)
+- **[morphMany (1-n)](#morphmany-1-n-polymorphic-relationship)** ✅
+    - (A) show a select2_multiple - add a `relationship` field
+    - (B) show a subform - add a `relationship` field with `subfields`
+- **[morphToMany (n-n)](#morphtomany-n-n-polymorphic-relationship)** ✅
+    - (A) show a select2_multiple - add a `relationship` field
+    - (B) show a subform - add a `relationship` field and define `subfields`
+- **[hasOneThrough (1-1-1)](#hasonethrough-1-1-1-relationship)** ❌
+    - it's read-only, no sense having a field for it;
+- **[hasManyThrough (1-1-n)](#hasmanythrough-1-1-n-relationship)** ❌
+    - it's read-only, no sense having a field for it;
+- **[Has One Of Many (1-n turned into 1-1)](#has-one-of-many-1-1-relationship-out-of-1-n-relationship)** ❌
+    - it's read-only, no sense having a field for it;
+- **[Morph One Of Many (1-n turned into 1-1)](#morph-one-of-many-1-1-relationship-out-of-1-n-relationship)** ❌
+    - it's read-only, no sense having a field for it;
+- **[morphTo (n-1)](#morphto-n-1-relationship)** ❌
+    - never needed, UI would be very difficult to understand & use;
+- **[morphedByMany (n-n inverse)](#morphedbymany-n-n-inverse-relationship)** ❌
+    - never needed, UI would be very difficult to understand & use;
+
+
+<a name="hasone"></a>
+#### hasOne (1-1 relationship)
+
+- example:
+    - `User -> hasOne -> Phone`
+    - the foreign key is stored on the Phone (`user_id` on `phones` table)
+- what to use:
+    - the `relationship` field with `subfields` defined for each column on the related entry
+- how to use:
+    - [the `hasOne` relationship should be properly defined](https://laravel.com/docs/eloquent-relationships#one-to-one) in the User model;
+
+```php
+// inside UserCrudController::setupCreateOperation()
+CRUD::field('phone')->type('relationship')->subfields([
+    'prefix',
+    'number',
+    [
+        'name' => 'type',
+        'type' => 'select_from_array',
+        'options' => ['mobile' => 'Mobile Phone', 'landline' => 'Landline', 'fax' => 'Fax'],
+    ]
+]);
+```
+
+<a name="hasone"></a>
+#### hasOne (1-1 relationship) - one field for each attribute of the related entry
+
+- example:
+    - `User -> hasOne -> Phone`
+    - the foreign key is stored on the Phone (`user_id` on `phones` table)
+- what to use:
+    -  any field (eg. `text`, `number`, `textarea`), with the field name prefixed by the relationship name (dot notation);
+- how to use:
+    - [the `hasOne` relationship should be properly defined](https://laravel.com/docs/eloquent-relationships#one-to-one) in the User model;
+    - you can easily add fields for each individual attribute on the related entry; you just need to specify in the field name that the value should not be stored on the _main model_, but on _a related model_; you can do that using dot notation (`relationship_name.column_name`); note that the prefix (before the dot) is the **Relation** name, not the table name;
+    - all fields types should work fine - depending on your needs you could choose to add a [`text`](#text) field, [`number`](#number) field, [`textarea`](#textarea) field, [`select`](#select) field etc.;
+
+```php
+// inside UserCrudController::setupCreateOperation()
+CRUD::field('phone.number')->type('number');
+CRUD::field('phone.prefix')->type('text');
+CRUD::field('phone.type')->type('select_from_array')->options(['mobile' => 'Mobile Phone', 'landline' => 'Landline', 'fax' => 'Fax']);
+```
+
+<a name="belongsto"></a>
+#### belongsTo (n-1 relationship)
+
+- example:
+    - `Phone -> User`
+    - a Phone belongs to one User; a Phone can only belong to one User
+    - the foreign key is stored on the Phone (`user_id` on `phones` table)
+- how to use:
+    - [the `belongsTo` relationship should be properly defined](https://laravel.com/docs/eloquent-relationships#one-to-many-inverse) in the Phone model;
+    - you can easily add a dropdown to let the admin pick which User the Phone belongs; you can use any of the dropdown fields, but for convenience we've made a list here, and broken them down depending on aproximately how many entries the dropdown will have:
+        - for 0-10 dropdown items - we recommend you use the [`relationship`](#relationship) or [`select`](#select) field;
+        - for 0-500 dropdown items - we recommend you use the [`relationship`](#relationship) or [`select2`](#select2) field;
+        - for 500-1.000.000+ dropdown items - we recommend you load the dropdown items using AJAX, by using the [`relationship`](#relationship) field and Fetch operation (alternatively, use the [`select2_from_ajax`](#select2-from-ajax) field);
+
+```php
+// inside PhoneCrudController::setupCreateOperation()
+CRUD::field('user'); // notice the name is the relationship name and backpack will auto-infer the field type as [`relationship`](#relationship)
+CRUD::field('user_id')->type('select')->model('App\Models\User')->attribute('name')->entity('user'); // notice the name is the foreign key attribute
+CRUD::field('user_id')->type('select2')->model('App\Models\User')->attribute('name')->entity('user'); // notice the name is the foreign key attribute
+```
+
+- notes:
+    - if you choose to use the [`relationship`](#relationship) field, you could also use [the InlineCreate operation](/docs/{{version}}/crud-operation-inline-create), which will add a [+ Add Item] button next to the dropdown, to let the admin create a User in a modal, without leaving the current Create Phone form;
+
+<a name="hasmany"></a>
+#### hasMany (1-n relationship)
+
+- example:
+    - `Post -> HasMany -> Comment`
+    - the foreign key is stored on the Comment (`post_id` on `comments` table)
+- what to use:
+    - use the `relationship` field;
+- how to use:
+    - [the `hasMany` relationship should be properly defined](https://laravel.com/docs/eloquent-relationships#one-to-many) in the Post model;
+
+```php
+// inside PostCrudController::setupCreateOperation()
+CRUD::field('comments'); // when unselected, will set foreign key to null
+CRUD::field('comments')->fallback_id(3); // when unselected, will set foreign key to 3
+CRUD::field('comments')->force_delete(true);  // when unselected, will delete the related entry
+```
+
+- notes:
+    - when a related entry is unselected (removed), Backpack will:
+        - set the foreign key to `null`, if that db column is nullable (eg. `post_id`);
+        - set the foreign key to a default value, if you define a `fallback_id` on the field;
+        - delete related entry entirely, if you define `'force_delete' => false` on the field;
+    - you can use [the InlineCreate operation](/docs/{{version}}/crud-operation-inline-create) to show a [+ Add Item] button next to the dropdown; for it to work `post_id` on comments table need to nullable or have a default setup in database;
+
+
+<a name="hasmany-1-n-relationship-with-subform-to-create-update-and-delet"></a>
+#### hasMany (1-n relationship) with subform to create, update and delete related entries
+
+If you want the admin to not only _select_ an entry, but also create them, edit their attributes or delete related entries.
+
+- example:
+    - `Post -> HasMany -> Comment`
+    - the foreign key is stored on the Comment (`post_id` on `comments` table)
+- what to use:
+    - use the `relationship` field;
+- how to use:
+    - [the `hasMany` relationship should be properly defined](https://laravel.com/docs/eloquent-relationships#one-to-many) in the Post model;
+
+```php
+// inside PostCrudController::setupCreateOperation()
+CRUD::field('comments')->subfields([['name' => 'body']]);
+// where body is a text field in the comment table.
+```
+
+<a name="belongstomany"></a>
+#### belongsToMany (n-n relationship)
+
+Note: Starting in 4.2, `BelongsToMany` relation had been improved to simplify the scenario where your pivot table has extra database columns (in addition to the foreign keys).
+
+- example:
+    - `User -> BelongsToMany -> Role`
+    - the foreign keys are stored on a pivot table (usually the `user_roles` table has both `user_id` and `role_id`)
+- how to use:
+    - [the `belongsToMany` relationship should be properly defined](https://laravel.com/docs/eloquent-relationships#many-to-many) in both the User and Role models;
+    - you can add a dropdown on your User to pick the Roles that are connected to it; for that, use the [`relationship`](#relationship), [`select_multiple`](#select-multiple), [`select2_multiple`](#select2-multiple) or  [`select2_from_ajax_multiple`](#select2-from-ajax-multiple) fields;
+
+```php
+// inside UserCrudController::setupCreateOperation()
+CRUD::field('roles');
+
+// inside RoleCrudController::setupCreateOperation()
+CRUD::field('users');
+```
+
+- notes:
+    - if you choose to use the [`relationship`](#relationship) field type, you can also use [the InlineCreate operation](/docs/{{version}}/crud-operation-inline-create), which will add a `[+ Add Item]` button next to the dropdown, to let the admin create a User/Role in a modal, without leaving the current Create User/Role form;
+
+##### EXTRA: Saving aditional attributes to the pivot table
+
+If your pivot table has additional database columns (eg. not only `user_id` and `role_id` but also `notes` or `supervisor`, you can use the `relationship` field to show a subform, instead of a `select2`, and show `subfields` for each of those attributes you want edited on the pivot table. For the example above (`User -> BelongsToMany -> Roles`) you should do the following:
+
+
+**Step 1.** Setup the pivot fields in your relation definition:
+
+```php
+// inside App\Models\User
+public function roles() {
+    return $this->belongsToMany('App\Models\Role')->withPivot('notes', 'some_other_field'); // `notes` and `some_other_field` are aditional fields in the pivot table that you plan to show in the form.
+}
+```
+
+**Step 2.** Setup the pivot fields in your relation definition:
+
+```php
+// inside UserCrudController::setupCreateOperation()
+CRUD::field('roles')->subfields([
+    ['name' => 'notes', 'type' => 'textarea'],
+    ['name' => 'some_other_field']
+]);
+```
+
+And you are done: a subform will shown, with a select for the pivot connected entity field and the defined fields and Backpack will take care of the saving process.
+
+**Need to change the pivot `select` field?** You can add any configuration to the pivot field as you would do in a [relationship](#relationship) select field, the only difference is is that it should go inside the `pivotSelect` key:
+```php
+CRUD::field('users')->subfields([ ['name' => 'notes'] ])
+    ->pivotSelect([
+        'ajax' => true,
+        'data_source' => backpack_url('role/fetch/user'),
+        'placeholder' => 'some placeholder',
+        'wrapper' => [
+            'class' => 'col-md-6'
+        ]
+    ]);
+```
+
+<a name="morphone"></a>
+#### morphOne (1-1 polymorphic relationship)
+
+- example:
+    - Post/User -> morphOne -> Video.
+    - The User model and the Post model have 1 Video each.
+    - [the `morphOne` relationship should be properly defined](https://laravel.com/docs/8.x/eloquent-relationships#one-to-one-polymorphic-relations) in both the Post/User and Video models;
+
+You can add a subform for the related entry to be created/edited/deleted from the main form:
+
+```php
+CRUD::field('video.description')->type('relationship')->subfields([
+    'url',
+    [
+        'name' => 'description',
+        'type' => 'ckeditor',
+    ]
+]);
+```
+
+Backpack will take care of the saving process and deal with the morphable relation.
+
+
+<a name="morphone"></a>
+#### morphOne (1-1 polymorphic relationship) one field for each related entry attribute
+
+- example:
+    - Post/User -> morphOne -> Video.
+    - The User model and the Post model have 1 Video each.
+    - [the `morphOne` relationship should be properly defined](https://laravel.com/docs/8.x/eloquent-relationships#one-to-one-polymorphic-relations) in both the Post/User and Video models;
+
+You can add any type of field to change the attribute on the related entry, but make sure to prefix the field name with the name of the relationship:
+
+```php
+CRUD::field('video.description')->type('ckeditor');
+CRUD::field('video.url');
+```
+
+Backpack will take care of the saving process and deal with the morphable relation.
+
+
+<a name="morphmany"></a>
+#### morphMany (1-n polymorphic relationship)
+
+This is in all aspects similar to [HasMany](#hasmany) relation, the difference is that it's stored in a pivot table.
+- example:
+    - Video/Post -> morphMany -> Comment.
+    - The Video model and the Post model can have multiple Comment model but the comment belongs to only one of them.
+    - [the `morphMany` relationship should be properly defined](https://laravel.com/docs/8.x/eloquent-relationships#one-to-many-polymorphic-relations) in both the Post/Video and Comment models;
+
+There is no sense in using this a `select` when using a polymorphic relation because the items that could/would be select might belong to different entities. So you should setup this relation as you would setup a [HasMany creatable](#hasmany-creatable).
+
+```php
+// inside PostCrudController::setupCreateOperation() and inside VideoCrudController::setupCreateOperation()
+CRUD::field('comments')->subfields([['name' => 'comment_text']]); //note comment_text is a text field in the comment table.
+```
+
+
+<a name="morphtomany"></a>
+#### morphToMany (n-n polymorphic relationship)
+
+This is in all aspects similar to [BelongsToMany](#belongstomany) relation, the difference is that it stores the `morphable` entity in the pivot table:
+    - Video/Post -> belongsToMany -> Tag.
+    - The Video model and the Post model can have multiple Tag model and each Tag model can belong to one or more of them.
+    - [the `morphToMany` relationship should be properly defined](https://laravel.com/docs/8.x/eloquent-relationships#many-to-many-polymorphic-relations) in both the Post/Video and Tag models;
+
+Please read the relationship [BelongsToMany](#belongstomany) documentation, everything is the same in regards to fields definition and Backpack will take care of the morphable relation saving.
+
+
+#### hasOneThrough (1-1-1 relationship)
+
+- This is a "read-only" relationship. It does not make sense to add a field for it.
+
+
+#### hasManyThrough (1-1-n relationship)
+
+- This is a "read-only" relationship. It does not make sense to add a field for it.
+
+
+#### Has One of Many (1-1 relationship out of 1-n relationship)
+
+- This is a "read-only" relationship. It does not make sense to add a field for it. Please use the general-purpose relationship towards this entity (the 1-n relationship, without `latestOfMany()` or `oldestOfMany()`).
+
+
+#### Morph One of Many (1-1 relationship out of 1-n relationship)
+
+- This is a "read-only" relationship. It does not make sense to add a field for it. Please use the general-purpose relationship towards this entity (the 1-n relationship, without `latestOfMany()` or `oldestOfMany()`).
+
+#### MorphTo (n-1 relationship)
+
+- We do not provide an interface to edit this relationship. We never needed it, nobody ever asked for it and it would be very difficult to create an interface that is easy-to-use and easy-to-understand for the admin. If you find yourself needing this, please let us know by opening an issue on Github.
+
+#### MorphedByMany (n-n inverse relationship)
+
+- We do not provide an interface to edit this relationship. We never needed it, nobody ever asked for it and it would be very difficult to create an interface that is easy-to-use and easy-to-understand for the admin. If you find yourself needing this, please let us know by opening an issue on Github.
+
+
+<a name="operations"></a>
+## Operations
+
+
+<a name="overwrite-a-method-on-the-crud-panel-object"></a>
+### Add an Uneditable Input inside Create or Update Operation
+
+You might want to add a new attribute to the Model that gets saved. Let's say you want to add an `updated_by` indicator to the Update operation, containing the ID of the user currently logged in (`backpack_user()->id`).
+
+**Option 1.** Sure, in your `ProductCrudController::setupUpdateOperation()` can do `CRUD::field('updated_by')->type('hidden')->value(backpack_user()->id);`, but because that hidden field is inside the HTML, it opens up the possiblity that a malicious actor will edit the value of the input, in the browser.
+
+
+**Option 2.** You can change the `strippedRequest` closure inside your `ProductCrudController::setup()`:
+```php
+public function setupUpdateOperation()
+{
+    CRUD::setOperationSetting('strippedRequest', function ($request) {
+        // keep the recommended Backpack stripping (remove anything that doesn't have a field)
+        // but add 'updated_by' too
+        $input = $request->only(CRUD::getAllFieldNames());
+        $input['updated_by'] = backpack_user()->id;
+
+        return $input;
+    });
+}
+```
+
+**Option 3.** You can change the same `strippedRequest` closure inside the `ProductFormRequest` that contains your validation:
+```php
+    protected function prepareForValidation()
+    {
+        \CRUD::set('update.strippedRequest', function ($request) {
+            // keep the recommended Backpack stripping (remove anything that doesn't have a field)
+            // but add 'updated_by' too
+            $input = $request->only(\CRUD::getAllFieldNames());
+            $input['updated_by'] = backpack_user()->id;
+
+            return $input;
+        });
+    }
+```
+
+
+<a name="how-to-make-the-form-smaller-or-bigger"></a>
+### How to make the form smaller or bigger
+
+In practice, what you want is to change the class on the main `<div>` of the Create/Update operation. To learn how to do that, please take a look at the next section - how to make an operation wider or narrower.
+
+<a name="how-to-make-an-operation-wider-or-narrower"></a>
+### How to make an operation wider or narrower
+
+If you want to make the contents of an operation take more / less space from the window, you can easily do that. You just need to change the class on the main `<div>` of that operation, what we call the "content class". Depending on the scope of your change (for one or all CRUDs) here's how you can do that:
+
+(A) for all CRUDs, by specifying the custom content class in your ```config/backpack/crud.php```:
+
+```php
+    // Here you may override the css-classes for the content section of the create view globally
+    // To override per view use $this->crud->setCreateContentClass('class-string')
+    'create_content_class' => 'col-md-8 col-md-offset-2',
+
+    // Here you may override the css-classes for the content section of the edit view globally
+    // To override per view use $this->crud->setEditContentClass('class-string')
+    'edit_content_class'   => 'col-md-8 col-md-offset-2',
+
+    // Here you may override the css-classes for the content section of the revisions timeline view globally
+    // To override per view use $this->crud->setRevisionsTimelineContentClass('class-string')
+    'revisions_timeline_content_class'   => 'col-md-10 col-md-offset-1',
+
+    // Here you may override the css-class for the content section of the list view globally
+    // To override per view use $this->crud->setListContentClass('class-string')
+    'list_content_class' => 'col-md-12',
+
+    // Here you may override the css-classes for the content section of the show view globally
+    // To override per view use $this->crud->setShowContentClass('class-string')
+    'show_content_class'   => 'col-md-8 col-md-offset-2',
+
+    // Here you may override the css-classes for the content section of the reorder view globally
+    // To override per view use $this->crud->setReorderContentClass('class-string')
+    'reorder_content_class'   => 'col-md-8 col-md-offset-2',
+```
+
+(B) for a single CRUD, by using:
+
+```php
+$this->crud->setCreateContentClass('col-md-8 col-md-offset-2');
+$this->crud->setUpdateContentClass('col-md-8 col-md-offset-2');
+$this->crud->setListContentClass('col-md-8 col-md-offset-2');
+$this->crud->setShowContentClass('col-md-8 col-md-offset-2');
+$this->crud->setReorderContentClass('col-md-8 col-md-offset-2');
+$this->crud->setRevisionsTimelineContentClass('col-md-8 col-md-offset-2');
+```
+
+
+<a name="miscellaneous"></a>
+## Miscellaneous
+
+<a name="use-the-media-library"></a>
+### Use the Media Library (File Manager)
+
+The default Backpack installation doesn't come with a file management component. Because most projects don't need it. But we've created a first-party add-on that brings the power of [elFinder](http://elfinder.org/) to your Laravel projects. To install it, [follow the instructions on the add-ons page](https://github.com/Laravel-Backpack/FileManager). It's as easy as running:
+
+```bash
+# require the package
+composer require backpack/filemanager
+
+# then run the installation process
+php artisan backpack:filemanager:install
+```
+
+If you've chosen to install [backpack/filemanager](https://github.com/Laravel-Backpack/FileManager), you'll have elFinder integrated into:
+- TinyMCE (as "tinymce" field type)
+- CKEditor (as "ckeditor" field type)
+- CRUD (as "browse" and "browse_multiple" field types)
+- stand-alone, at the */admin/elfinder* route;
+
+For the integration, we use [barryvdh/laravel-elfinder](https://github.com/barryvdh/laravel-elfinder).
+
+![Backpack CRUD ListEntries](https://backpackforlaravel.com/uploads/docs-4-0/media_library.png)
+
+<a name="how-to-manually-install-backpack-crud"></a>
+### How to manually install Backpack
+
+If the automatic installation doesn't work for you and you need to manually install CRUD, here are all the commands it is running:
+
+1) In your terminal:
+
+``` bash
+composer require backpack/crud:"4.2.x-dev as 4.1.99"
+```
+
+2) Instead of running ```php artisan backpack:install``` you can run:
+```bash
+php artisan vendor:publish --provider="Backpack\CRUD\BackpackServiceProvider" --tag="minimum"
+php artisan migrate
+php artisan backpack:publish-middleware
+```
+
+
+<a name="overwrite-a-method-on-the-crud-panel-object"></a>
+### Overwrite a Method on the CrudPanel Object
+
+Starting with Backpack v4, you can use a custom CrudPanel object instead of the one in the package. In your custom CrudPanel object, you can overwrite any method you want, but please note that this means that you're overwriting core components, and will be making it more difficult to upgrade to newer versions of Backpack.
+
+You can do this in any of your service providers (ex: ```app/Providers/AppServiceProvider.php```) to load your class instead of the one in the package:
+
+```php
+$this->app->extend('crud', function () {
+    return new \App\MyExtendedCrudPanel;
+});
+```
+
+Details and implementation [here](https://github.com/Laravel-Backpack/CRUD/pull/1990).
+
+
+

--- a/5.x-dev/crud-how-to.md
+++ b/5.x-dev/crud-how-to.md
@@ -452,7 +452,7 @@ CRUD::field('comments')->subfields([['name' => 'body']]);
 <a name="belongstomany"></a>
 #### belongsToMany (n-n relationship)
 
-Note: Starting in 4.2, `BelongsToMany` relation had been improved to simplify the scenario where your pivot table has extra database columns (in addition to the foreign keys).
+Note: Starting with v5, the `BelongsToMany` relation had been improved to simplify the scenario where your pivot table has extra database columns (in addition to the foreign keys).
 
 - example:
     - `User -> BelongsToMany -> Role`
@@ -735,7 +735,7 @@ If the automatic installation doesn't work for you and you need to manually inst
 1) In your terminal:
 
 ``` bash
-composer require backpack/crud:"4.2.x-dev as 4.1.99"
+composer require backpack/crud:"5.x-dev as 4.1.99"
 ```
 
 2) Instead of running ```php artisan backpack:install``` you can run:

--- a/5.x-dev/crud-operation-clone.md
+++ b/5.x-dev/crud-operation-clone.md
@@ -1,0 +1,127 @@
+# Clone Operation
+
+--
+
+<a name="about"></a>
+## About
+
+This CRUD operation allows your admins to duplicate one or more entries from the database.
+
+>**IMPORTANT:** The clone operation does NOT duplicate related entries. So n-n relationships will be unaffected. However, this also means that n-n relationships are ignored. So when you clone an entry, the new entry:
+>- will NOT have the same 1-1 relationships
+>- will have the same 1-n relationships
+>- will NOT have the same n-1 relationships
+>- will NOT have the same n-n relationships
+>
+>This might be somewhat counterintuitive for end users - though it should make perfect sense for us developers. This is why the Clone operation is NOT enabled by default.
+
+<a name="clone-a-single-item"></a>
+## Clone a Single Item
+
+<a name="how-it-works"></a>
+### How it Works
+
+Using AJAX, a POST request is performed towards ```/entity-name/{id}/clone```, which points to the ```clone()``` method in your EntityCrudController.
+
+<a name="enabling"></a>
+### How to Use
+
+To enable it, you need to ```use \Backpack\CRUD\app\Http\Controllers\Operations\CloneOperation;``` on your EntityCrudController. For example:
+
+```php
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+
+class ProductCrudController extends CrudController
+{
+    use \Backpack\CRUD\app\Http\Controllers\Operations\CloneOperation;
+
+    public function setup() 
+    {
+        $this->crud->setModel(\App\Models\Product::class);
+        $this->crud->setRoute(backpack_url('product'));
+        $this->crud->setEntityNameStrings('product', 'products');
+    }
+}
+```
+
+This will make the Clone button appear in the table view, and will allow access to the controller method if manually accessed.
+
+<a name="how-to-overwrite"></a>
+### How to Overwrite
+
+In case you need to change how this operation works, overwrite the ```clone()``` trait method in your EntityCrudController; make sure you give the method in the trait a different name, so that there are no conflicts:
+
+```php
+use \Backpack\CRUD\app\Http\Controllers\Operations\CloneOperation { clone as traitClone; }
+
+public function clone($id)
+{
+    $this->crud->hasAccessOrFail('clone');
+    $this->crud->setOperation('clone');
+
+    // whatever you want
+    
+    // if you still want to call the old clone method
+    $this->traitClone($id);
+}
+```
+
+You can also overwrite the clone button by creating a file with the same name inside your ```resources/views/vendor/backpack/crud/buttons/```. You can easily publish the clone button there to make changes using:
+
+```zsh
+php artisan backpack:publish crud/buttons/clone
+```
+
+<a name="clone-multiple-items-bulk-clone"></a>
+## Clone Multiple Items (Bulk Clone)
+
+In addition to the button for each entry, you can show checkboxes next to each element, and allow your admin to clone multiple entries at once.
+
+
+<a name="how-it-works"></a>
+### How it Works
+
+Using AJAX, a POST request is performed towards ```/entity-name/bulk-clone```, which points to the ```bulkClone()``` method in your EntityCrudController.
+
+<a name="enabling"></a>
+### How to Use
+
+To enable it, you need to ```use \Backpack\CRUD\app\Http\Controllers\Operations\BulkCloneOperation;``` on your EntityCrudController.
+
+<a name="how-to-overwrite"></a>
+### How to Overwrite
+
+In case you need to change how this operation works, just create a ```bulkClone()``` method in your EntityCrudController:
+
+```php
+use \Backpack\CRUD\app\Http\Controllers\Operations\BulkCloneOperation { bulkClone as traitBulkClone; }
+
+public function bulkClone($id)
+{
+    // your custom code here
+    // 
+    // then you can call the old bulk clone if you want
+    $this->traitBulkClone($id);
+}
+```
+
+You can also overwrite the bulk clone button by creating a file with the same name inside your ```resources/views/vendor/backpack/crud/buttons/```. You can easily publish the clone button there to make changes using:
+
+```zsh
+php artisan backpack:publish crud/buttons/bulk_clone
+```
+
+<a name="exempt-attribute-when-cloning"></a>
+## Exempt attributes when cloning
+If you have attributes that should not be cloned (eg. a SKU with an unique constraint), you can overwrite the replicate method on your model:
+
+```php
+    public function replicate(array $except = null) {
+    
+        return parent::replicate(['sku']);
+    }
+```

--- a/5.x-dev/crud-operation-create.md
+++ b/5.x-dev/crud-operation-create.md
@@ -1,0 +1,265 @@
+# Create Operation
+
+---
+
+<a name="about"></a>
+## About
+
+This operation allows your admins to add new entries to a database table.
+
+![CRUD Create Operation](https://backpackforlaravel.com/uploads/docs-4-2/operations/create.png)
+
+<a name="requirements"></a>
+## Requirements
+
+All editable attributes should be ```$fillable``` on your Model.
+
+<a name="how-to-use"></a>
+## How to Use
+
+To use the Create operation, you must:
+
+**Step 0. Use the operation trait on your EntityCrudController**. This should be as simple as this:
+
+```php
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+
+class ProductCrudController extends CrudController
+{
+    use \Backpack\CRUD\app\Http\Controllers\Operations\CreateOperation;
+    
+    protected function setupCreateOperation()
+	{
+		// $this->crud->setValidation(StoreRequest::class);
+		// $this->crud->addField($field_definition_array);
+	}
+}
+```
+
+**Step 1. Specify what field types** you'd like to show for each editable attribute, in your EntityCrudController's ```setupCreateOperation()``` method. You can do that using the [Fields API](/docs/{{version}}/crud-fields#fields-api). In short you can:
+
+```php
+protected function setupCreateOperation()
+{
+	$this->crud->addField($field_definition_array);
+}
+```
+
+**Step 2. Specify validation rules, in your the EntityCrudRequest file**. Then make sure that file is used for validation, by telling the CRUD to validate that request file in ```setupCreateOperation()```:
+```php
+$this->crud->setValidation(StoreRequest::class);
+```
+
+For more on how to manipulate fields, please read the [Fields documentation page](/docs/{{version}}/crud-fields). For more on validation rules, check out [Laravel's validation docs](https://laravel.com/docs/master/validation#available-validation-rules).
+
+<a name="how-it-works"></a>
+## How It Works
+
+CrudController is a RESTful controller, so the ```Create``` operation uses two routes:
+- GET to ```/entity-name/create``` - points to ```create()``` which shows the Add New Entry form (```create.blade.php```);
+- POST to ```/entity-name``` - points to ```store()``` which does the actual storing operation;
+
+The ```create()``` method will show all the fields you've defined for this operation using the [Fields API](/docs/{{version}}/crud-fields#fields-api), then upon Save the ```store()``` method will first check the validation from the FormRequest you've specified, then create the entry using the Eloquent model. Only attributes that are specified as fields, and are ```$fillable``` on the model will actually be stored in the database.
+
+
+<a name="advanced-features-and-techniques"></a>
+## Advanced Features and Techniques
+
+<a name="validation"></a>
+### Validation
+
+There are three ways you can define the [validation rules](https://laravel.com/docs/validation#available-validation-rules) for your fields:
+
+#### Validating fields using FormRequests
+
+When you generate a CrudController, you'll notice a [Laravel FormRequest](https://laravel.com/docs/validation#form-request-validation) has also been generated, and that FormRequest is mentioned as the source of your validation rules:
+```php
+protected function setupCreateOperation()
+{
+	$this->crud->setValidation(StoreRequest::class);
+}
+```
+
+This works particularly well for bigger models, because you can mention a lot of rules, messages and attributes in your `FormRequest` and it will not increase the size of your `CrudController`.
+
+**Differences between the Create and Update validations?** Then create a separate request file for each operation and instruct your EntityCrudController to use those files:
+
+```php
+use App\Http\Requests\CreateTagRequest as StoreRequest;
+use App\Http\Requests\UpdateTagRequest as UpdateRequest;
+
+// ...
+
+public function setupCreateOperation()
+{
+    $this->crud->setValidation(CreateRequest::class);
+}
+
+public function setupUpdateOperation()
+{
+    $this->crud->setValidation(UpdateRequest::class);
+}
+```
+
+#### Validating fields using a rules array
+
+For smaller models (with just a few validation rules), creating an entire FormRequest file to hold them might be overkill. If you prefer, you can pass an array of [validation rules](https://laravel.com/docs/validation#available-validation-rules) to the same `setValidation()` method (with an optional second parameter for the validation messages):
+
+```php
+protected function setupCreateOperation()
+{
+	$this->crud->setValidation([
+		'name' => 'required|min:2',
+	]);
+
+	// or maybe
+	$rules = ['name' => 'required|min:2'];
+	$messages = [
+	    'name.required' => 'You gotta give it a name, man.',
+	    'name.min' => 'You came up short. Try more than 2 characters.',
+	];
+	$this->crud->setValidation($rules, $messages);
+}
+```
+
+This is more convenient for small and medium models. Plus, it's very easy to read.
+
+#### Validating fields using field attributes
+
+Another good option for small & medium models is to define the [validation rules](https://laravel.com/docs/validation#available-validation-rules) directly on your fields:
+
+```php
+protected function setupCreateOperation()
+{
+	$this->crud->addField([
+	    'name' => 'content',
+	    'label' => 'Content',
+	    'type' => 'ckeditor',
+	    'placeholder' => 'Your textarea text here',
+	    'validationRules' => 'required|min:10',
+	    'validationMessages' => [
+	        'required' => 'You gotta write smth man.',
+	        'min' => 'More than 10 characters, bro. Wtf... You can do this!',
+	    ]
+	]);
+	$this->crud->setValidation(); // This MUST be called AFTER the fields are defined, NEVER BEFORE
+}
+```
+
+You must then call `setValidation()` without a parameter, and Backpack will go through all defined fields, get their `validationRules` and validate them. It is VERY IMPORTANT to call `setValidation()` _after_ you've defined the fields! Otherwise Backpack won't find any `validationRules`.
+
+<a name="callbacks"></a>
+### Callbacks
+
+If you're coming from other CRUD systems (like GroceryCRUD) you might be looking for callbacks to run "before_insert", "before_update", "after_insert", "after_update". **There are no callbacks in Backpack**, because... they're not needed. There are plenty of other ways to do things before/after an entry is created.
+
+#### Use Events in your `setup()` method
+
+Laravel already triggers [multiple events](https://laravel.com/docs/master/eloquent#events) in an entry's lifecycle. Those also include:
+- `creating` and `created`, which are triggered by the Create operation;
+- `saving` and `saved`, which are triggered by both the Create and the Update operations;
+
+So if you want to do something to a `Product` entry _before_ it's created, you can easily do that:
+```php
+public function setupCreateOperation()
+{
+
+	// ...
+
+	Product::creating(function($entry) {
+		$entry->author_id = backpack_user()->id;
+	});
+}
+```
+
+Take a closer look at [Eloquent events](https://laravel.com/docs/master/eloquent#events) if you're not familiar with them, they're really _really_ powerful once you understand them. Please note that **these events will only get registered when the function gets called**, so if you define them in your `CrudController`, then:
+- they will NOT run when an entry is changed outside that CrudController;
+- if you want to expand the scope to cover both the `Create` and `Update` operations, you can easily do that, for example by using the `saving` and `saved` events, and moving the event-calling to your main `setup()` method;
+
+#### Use events in your field definition
+
+You can tell a field to do something to the entry when that field gets saved to the database. Rephrased, you can define standard [Eloquent events](https://laravel.com/docs/master/eloquent#events) directly on fields. For example:
+
+```php
+// FLUENT syntax - use the convenience method "on" to define just ONE event
+CRUD::field('name')->on('saving', function ($entry) {
+    $entry->author_id = backpack_user()->id;
+});
+
+// FLUENT SYNTAX - you can define multiple events in one go
+CRUD::field('name')->events([
+    'saving' => function ($entry) {
+	    $entry->author_id = backpack_user()->id;
+    },
+    'saved' => function ($entry) {
+	    // TODO: upload some file
+    },
+]);
+
+// using the ARRAY SYNTAX, define an array of events and closures
+CRUD::addField([
+    'name' => 'name',
+    'events' => [
+        'saving' => function ($entry) {
+		    $entry->author_id = backpack_user()->id;
+        },
+    ],
+]);
+```
+
+#### Override the `store()` method
+
+The store code is inside a trait, so you can easily override it, if you want:
+
+```php
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+
+class ProductCrudController extends CrudController
+{
+    use \Backpack\CRUD\app\Http\Controllers\Operations\CreateOperation { store as traitStore; }
+
+    // ...
+    
+    public function store()
+    {
+    	// do something before validation, before save, before everything; for example:
+        // $this->crud->addField(['type' => 'hidden', 'name' => 'author_id']);
+	// $this->crud->removeField('password_confirmation');
+	
+	// Note: By default Backpack ONLY saves the inputs that were added on page using Backpack fields.
+	// This is done by stripping the request of all inputs that do NOT match Backpack fields for this
+	// particular operation. This is an added security layer, to protect your database from malicious
+	// users who could theoretically add inputs using DeveloperTools or JavaScript. If you're not properly
+	// using $guarded or $fillable on your model, malicious inputs could get you into trouble.
+	
+	// However, if you know you have proper $guarded or $fillable on your model, and you want to manipulate 
+	// the request directly to add or remove request parameters, you can also do that.
+	// We have a config value you can set, either inside your operation in `config/backpack/crud.php` if
+	// you want it to apply to all CRUDs, or inside a particular CrudController:
+    	// $this->crud->setOperationSetting('saveAllInputsExcept', ['_token', '_method', 'http_referrer', 'current_tab', 'save_action']);
+	// The above will make Backpack store all inputs EXCEPT for the ones it uses for various features.
+	// So you can manipulate the request and add any request variable you'd like.
+	// $this->crud->getRequest()->request->add(['author_id'=> backpack_user()->id]);
+	// $this->crud->getRequest()->request->remove('password_confirmation');
+
+    	$response = $this->traitStore();
+    	// do something after save
+    	return $response;
+    }
+}
+```
+
+>But before you do that, ask yourself - **_is this something that should be done when an entry is added/updated/deleted from the application, too_**? Not just the admin panel? If so, a better place for it would be the Model. Remember your Model is a pure Eloquent Model, so the cleanest way might be to use [Eloquent Event Observers](https://laravel.com/docs/5.5/eloquent#events) or [accessors and mutators](https://laravel.com/docs/master/eloquent-mutators#accessors-and-mutators).
+
+<a name="translatable-models"></a>
+### Translatable models and multi-language CRUDs
+
+For UX purposes, when creating multi-language entries, the Create form will only allow the admin to add an entry in one language, the default one. The admin can then edit that entry in all available languages, to translate it. Check out [this same section in the Update operation](/docs/{{version}}/crud-operation-update#translatable-models) for how to enable multi-language functionality.

--- a/5.x-dev/crud-operation-delete.md
+++ b/5.x-dev/crud-operation-delete.md
@@ -1,0 +1,96 @@
+# Delete Operation
+
+--
+
+<a name="about"></a>
+## About
+
+This CRUD operation allows your admins to remove one or more entries from the table. 
+
+>In case your entity has SoftDeletes, it will perform a soft delete. The admin will _not_ know that his entry has been hard or soft deleted, since it will no longer show up in the ListEntries view.
+
+<a name="delete-a-single-item"></a>
+## Delete a Single Item
+
+<a name="how-it-works"></a>
+### How it Works
+
+Using AJAX, a DELETE request is performed towards ```/entity-name/{id}```, which points to the ```destroy()``` method in your EntityCrudController.
+
+<a name="enabling"></a>
+### How to Use
+
+To enable it, you need to ```use \Backpack\CRUD\app\Http\Controllers\Operations\DeleteOperation;``` on your EntityCrudController. For example:
+
+```php
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+
+class ProductCrudController extends CrudController
+{
+    use \Backpack\CRUD\app\Http\Controllers\Operations\DeleteOperation;
+}
+```
+
+This will make a Delete button show up in the list view, and will enable the routes and functionality needed for the operation.
+
+<a name="how-to-overwrite"></a>
+### How to Overwrite
+
+In case you need to change how this operation works, just create a ```destroy()``` method in your EntityCrudController:
+
+```php
+use \Backpack\CRUD\app\Http\Controllers\Operations\DeleteOperation { destroy as traitDestroy; }
+
+public function destroy($id)
+{
+    $this->crud->hasAccessOrFail('delete');
+
+    return $this->crud->delete($id);
+}
+```
+
+You can also overwrite the delete button by creating a file with the same name inside your ```resources/views/vendor/backpack/crud/buttons/```. You can easily publish the delete button there to make changes using:
+
+```zsh
+php artisan backpack:publish crud/buttons/delete
+```
+
+<a name="delete-multiple-items-bulk-delete"></a>
+## Delete Multiple Items (Bulk Delete)
+
+In addition to the button for each entry, you can show checkboxes next to each element, and allow your admin to delete multiple entries at once.
+
+
+<a name="how-it-works"></a>
+### How it Works
+
+Using AJAX, a DELETE request is performed towards ```/entity-name/bulk-delete```, which points to the ```bulkDelete()``` method in your EntityCrudController.
+
+<a name="enabling"></a>
+### How to Use
+
+You need to ```use \Backpack\CRUD\app\Http\Controllers\Operations\BulkDeleteOperation;``` on your EntityCrudController.
+
+<a name="how-to-overwrite"></a>
+### How to Overwrite
+
+In case you need to change how this operation works, just create a ```bulkDelete()``` method in your EntityCrudController:
+
+```php
+use \Backpack\CRUD\app\Http\Controllers\Operations\BulkDeleteOperation { bulkDelete as traitBulkDelete; }
+
+public function bulkDelete($id)
+{
+    // your custom code here
+}
+```
+
+You can also overwrite the bulk delete button by creating a file with the same name inside your ```resources/views/vendor/backpack/crud/buttons/```. You can easily publish the delete button there to make changes using:
+
+```zsh
+php artisan backpack:publish crud/buttons/bulk_delete
+```

--- a/5.x-dev/crud-operation-fetch.md
+++ b/5.x-dev/crud-operation-fetch.md
@@ -1,0 +1,153 @@
+# Fetch Operation
+
+---
+
+<a name="about"></a>
+## About
+
+This operation allows an EntityCrudController to respond to AJAX requests with entries in the database for _a different entity_, in a format that can be used by the ```relationship```, ```select2_from_ajax``` and ```select2_from_ajax_multiple``` fields.
+
+
+<a name="requirements"></a>
+## Requirements
+
+None.
+
+<a name="how-to-use"></a>
+## How to Use
+
+In order to enable this operation, in your CrudController you need to **use the ```FetchOperation``` trait and add a new method** that responds to the AJAX requests (following the naming convention ```fetchEntityName()```). For example, for a `Tag` model you'd do:
+
+```php
+    use \Backpack\CRUD\app\Http\Controllers\Operations\FetchOperation;
+
+    protected function fetchTag()
+    {
+        return $this->fetch(\App\Models\Tag::class);
+    }
+```
+
+To customize the FetchOperation, pass an array to the ```fetch()``` call, rather than a class name. For example:
+
+```php
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+
+class ProductCrudController extends CrudController
+{
+    use \Backpack\CRUD\app\Http\Controllers\Operations\FetchOperation;
+
+    protected function fetchTag()
+    {
+        return $this->fetch([
+            'model' => \App\Models\Tag::class, // required
+            'searchable_attributes' => ['name', 'description'],
+            'paginate' => 10, // items to show per page
+            'query' => function($model) {
+                return $model->active();
+            } // to filter the results that are returned
+        ]);
+    }
+}
+```
+
+You can now point your AJAX select to this route, which will be ```backpack_url('your-main-entity/fetch/tag')``` .
+
+
+<a name="how-it-works"></a>
+## How It Works
+
+Based on the fact that the ```fetchTag()``` method exists, the Fetch operation will create a ```/product/fetch/tag``` POST route, which points to ```fetchTag()```. Inside ```fetchTag()``` we call ```fetch()```, that responds with entries in the format ```select2``` needs.
+
+**Preventing FetchOperation from guessing the searchable attributes**
+
+If not specified `searchable_attributes` will be automatically infered from model database columns. To prevent this behaviour you can setup an empty `searchable_attributes` array. For example:
+
+```php
+public function fetchUser() {
+        return $this->fetch([
+            'model' => User::class,
+            'query' => function($model) {
+                $search = request()->input('q') ?? false;
+                if ($search) {
+                    return $model->whereRaw('CONCAT(`first_name`," ",`last_name`) LIKE "%' . $search . '%"');
+                }else{
+                    return $model;
+                }
+            },
+            'searchable_attributes' => []
+        ]);
+    }
+```
+
+<a name="fetch-ajax-filter"></a>
+## Using FetchOperation with `select2_ajax` filter
+
+The FetchOperation can also be used as the source URL for the `select2_ajax` filter. To do that, we need to:
+- change the `select2_ajax` filter method from `GET` (its default) to `POST` (what FetchOperation uses);
+- tell the filter what attribute we want to show to the user; 
+
+```
+$this->crud->addFilter([
+  'name'        => 'category_id',
+  'type'        => 'select2_ajax',
+  'label'       => 'Category',
+  'placeholder' => 'Pick a category',
+  'method' => 'POST', // mandatory change
+  // 'select_attribute' => 'name' // the attribute that will be shown to the user by default 'name'
+  // 'select_key' => 'id' // by default is ID, change it if your model uses some other key
+],
+backpack_url('product/fetch/category'), // the fetch route on the ProductCrudController 
+function($value) { // if the filter is active
+    // $this->crud->addClause('where', 'category_id', $value);
+});
+
+```
+
+
+<a name="how-to-overwrite"></a>
+## How to Overwrite
+
+In case you need to change how this operation works, it's best to take a look at the ```FetchOperation.php``` trait to understand how it works. It's a pretty simple operation. Most common ways to overwrite the Fetch operation are documented below:
+
+**Custom behaviour for one fetch method**
+
+To make a ```fetchCategory()``` method behave differently, you can copy-paste the logic inside the ```FetchOperation::fetch()``` and change it to do whatever you need. Instead of returning ```$this->fetch()``` you can return your own results.
+
+**Custom behaviour for multiple fetch methods inside a Controller**
+
+To make all calls to ```fetch()``` inside an EntityCrudController behave differently, you can easily overwrite the ```fetch()``` method in that controller:
+
+```php
+use \Backpack\CRUD\app\Http\Controllers\Operations\FetchOperation;
+
+public function fetch($arg)
+{
+    // your custom code here
+}
+```
+
+Then all ```$this->fetch()``` calls from that Controller will be using your custom code.
+
+In case you need to call the original ```fetch()``` method (from the trait) inside your custom ```fetch()``` method (inside the controller), you can do:
+
+```php
+use \Backpack\CRUD\app\Http\Controllers\Operations\FetchOperation { fetch as traitFetch; }
+
+public function fetch($arg)
+{
+    // your custom code here
+    
+    // call the method in the trait
+    return $this->traitFetch();
+}
+```
+
+**Custom behaviour for all fetch calls, in all Controllers**
+
+If you want all your ```fetch()``` calls to behave differently, no matter what Controller they are in, you can:
+- duplicate the ```FetchOperation``` trait inside your application;
+- instead of using ```\Backpack\CRUD\app\Http\Controllers\Operations\FetchOperation``` inside your controllers, use your custom operation trait;

--- a/5.x-dev/crud-operation-inline-create.md
+++ b/5.x-dev/crud-operation-inline-create.md
@@ -1,0 +1,112 @@
+# InlineCreate Operation
+
+---
+
+<a name="about"></a>
+## About
+
+This operation allows your admins to add new entries to a database table on-the-fly, from a modal. 
+
+For example:
+- if you have an ```ArticleCrudController``` where your user can also select ```Categories```;
+- this operation adds the ability to create ```Categories``` right inside the ```ArticleCrudController```'s Create form; 
+    - the admin needs to click an Add button
+    - a modal will show the form from ```CategoryCrudController```'s Create operation;
+
+![Backpack InlineCreate Operation](https://backpackforlaravel.com/uploads/docs-4-2/release_notes/inline_create_small.gif)
+
+
+<a name="requirements"></a>
+## Requirements
+
+- a working Create operation;
+- correctly defined Eloquent relationships on both the primary Model, and the secondary Model;
+- a working Fetch operation to retrieve the secondary Model from the primary Model;
+- an understanding of what we call "_main_" and "_secondary_" in this case; using the same example as above, where you want to be able to add ```Categories``` in a modal, inside ```ArticleCrudController```'s create&update forms:
+    - the _main entity_ would be Article (big form); 
+    - the _secondary entity_ would be Category (small form, in a modal);
+
+<a name="how-to-use"></a>
+## How to Use
+
+> If your field name is comprised of multiple words (eg. `contact_number` or `contactNumber`) you will need to also define the `data_source` attribute for this field; keep in mind that by to generate a route, your field name will be parsed run through `Str::kebab()` - that means `_` (underscore) or `camelCase` will be converted to `-` (hyphens), so in `fetch` your route will be `contact-number` instead of the expected `contactNumber`. To fix this, you need to define: `data_source => backpack_url('monster/fetch/contact-number')` (replace with your strings)
+
+To use the Create operation, you must:
+
+**Step 1. Use the operation trait on your secondary entity's CrudController** (aka. the entity that will gain the ability to be created inline, in our example CategoryCrudController). Make sure you use `InlineCreateOperation` *after* `CreateOperation`:
+
+```php
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+
+class TagCrudController extends CrudController
+{
+    use \Backpack\CRUD\app\Http\Controllers\Operations\CreateOperation;
+    use \Backpack\CRUD\app\Http\Controllers\Operations\InlineCreateOperation;
+    
+    // notice InlineCreateOperation is used AFTER CreateOperation
+    // that's required in order for InlineCreate to re-use whatever
+    // CreateOperation has already setup
+    
+    // OPTIONAL
+    // only if you want to make the InlineCreateOperation behave differently 
+    // from the CreateOperation, otherwise you can just skip the setup method entirely
+    // 
+    // protected function setupInlineCreateOperation()
+	// {
+		// $this->crud->setValidation(StoreRequest::class);
+		// $this->crud->addField($field_definition_array);
+	// }
+}
+```
+
+**Step 2. Use [the relationship field](/docs/{{version}}/crud-fields#relationship) inside the ```setupCreateOperation()``` or ```setupUpdateOperation()``` of the main entity** (where you'd like to be able to click a button and a modal shows up, in our example ArticleCrudController), and define ```inline_create``` on it:
+
+```php
+// for 1-n relationships (ex: category) - inside ArticleCrudController
+[
+    'type' => "relationship",
+    'name' => 'category', // the method on your model that defines the relationship
+    'ajax' => true,
+    'inline_create' => true, // assumes the URL will be "/admin/category/inline/create"
+]
+
+// for n-n relationships (ex: tags) - inside ArticleCrudController
+[
+    'type' => "relationship",
+    'name' => 'tags', // the method on your model that defines the relationship
+    'ajax' => true,
+    'inline_create' => [ 'entity' => 'tag' ] // specify the entity in singular
+    // that way the assumed URL will be "/admin/tag/inline/create"
+]
+
+// OPTIONALS - to customize behaviour
+[
+    'type' => "relationship",
+    'name' => 'tags', // the method on your model that defines the relationship
+    'ajax' => true,
+    'inline_create' => [ // specify the entity in singular
+        'entity' => 'tag', // the entity in singular
+        // OPTIONALS
+        'force_select' => true, // should the inline-created entry be immediately selected?
+        'modal_class' => 'modal-dialog modal-xl', // use modal-sm, modal-lg to change width
+        'modal_route' => route('tag-inline-create'), // InlineCreate::getInlineCreateModal()
+        'create_route' =>  route('tag-inline-create-save'), // InlineCreate::storeInlineCreate()
+        'include_main_form_fields' => ['field1', 'field2'], // pass certain fields from the main form to the modal
+    ]
+```
+
+
+**Step 3. OPTIONAL - You can create a ```setupInlineCreateOperation()``` method in the EntityCrudController**, to make the InlineCreateOperation different to the CreateOperation, for example have more/less fields, or different fields. Check out the [Fields API](/docs/{{version}}/crud-fields#fields-api) for a reference of all you can do with them.
+
+<a name="how-it-works"></a>
+## How It Works
+
+The ```CreateInline``` operation uses two routes:
+- POST to ```/entity-name/inline/create/modal``` -  ```getInlineCreateModal()``` which returns the contents of the Create form, according to how it's been defined by the CreateOperation (in ```setupCreateOperation()```, then overwritten by the InlineCreateOperation (in ```setupInlineCreateOperation()```);
+- POST to ```/entity-name/inline/create``` - points to ```storeInlineCreate()``` which does the actual saving in the database by calling the ```store()``` method from the CreateOperation;
+
+Since this operation is just a way to allow access to the Create operation from a modal, the ```getInlineCreateModal()``` method will show all the fields you've defined for this operation using the [Fields API](/docs/{{version}}/crud-fields#fields-api), then upon Save the ```store()``` method will first check the validation from the FormRequest you've specified, then create the entry using the Eloquent model. Only attributes that are specified as fields, and are ```$fillable``` on the model will actually be stored in the database.

--- a/5.x-dev/crud-operation-list-entries.md
+++ b/5.x-dev/crud-operation-list-entries.md
@@ -1,0 +1,229 @@
+# List Operation
+
+---
+
+<a name="about"></a>
+## About
+
+This operation shows a table with all database entries. It's the first page the admin lands on (for an entity), and it's usually the gateway to all other operations, because it holds all the buttons.
+
+A simple List view might look like this:
+
+![Backpack CRUD ListEntries](https://backpackforlaravel.com/uploads/docs-4-2/operations/listEntries.png)
+
+But a complex implementation of the ListEntries operation, using Columns, Filters, custom Buttons, custom Operations, responsive table, Details Row, Export Buttons will still look pretty good:
+
+![Backpack CRUD ListEntries](https://backpackforlaravel.com/uploads/docs-4-2/operations/listEntries_full.png)
+
+You can easily customize [columns](#columns), [buttons](#buttons), [filters](#filters), [enable/disable additional features we've built](#other-features), or [overwrite the view and build your own features](#how-to-overwrite).
+
+<a name="how-it-works"></a>
+## How It Works
+
+The main route leads to ```EntityCrudController::index()```, which shows the table view (```list.blade.php```. Inside that table view, we're using AJAX to fetch the entries and place them inside DataTables. That AJAX points to the same controller, ```EntityCrudController::search()```.
+
+Actions:
+- ```index()```
+- ```search()```
+
+For views, it uses:
+- ```list.blade.php```
+- ```columns/```
+- ```buttons/```
+
+<a name="how-to-use"></a>
+## How to Use
+
+Use the operation trait on your controller:
+```php
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+
+class ProductCrudController extends CrudController
+{
+    use \Backpack\CRUD\app\Http\Controllers\Operations\ListOperation;
+
+    protected function setupListOperation()
+    {
+       // $this->crud->addColumn();
+    }
+}
+```
+
+Configuration for this operation should be done inside your ```setupListOperation()``` method. **For a minimum setup, you only need to define the columns you need to show in the table.** 
+
+<a name="columns"></a>
+### Columns
+
+The List operation uses "columns" to determine how to show the attributes of an entry to the user. All column types must have their ```name```, ```label``` and ```type``` specified, but some could require some additional attributes.
+
+```php
+$this->crud->addColumn([
+  'name' => 'name', // The db column name
+  'label' => "Tag Name", // Table column heading
+  'type' => 'Text'
+]);
+```
+
+Backpack has 22+ [column types](/docs/{{version}}/crud-columns) you can use. Plus, you can easily [create your own type of column](/docs/{{version}}/crud-columns##creating-a-custom-column-type). **Check out the [Columns](/docs/{{version}}/crud-columns##creating-a-custom-column-type) documentation page** for a detailed look at column types, API and usage.
+
+<a name="buttons"></a>
+### Buttons
+
+Buttons are used to trigger other operations. Some point to entirely new routes (```create```, ```update```, ```show```), others perform the operation on the current page using AJAX (```delete```).
+
+The ShowList operation has 3 places where buttons can be placed:
+  - ```top``` (where the Add button is)
+  - ```line``` (where the Edit and Delete buttons are)
+  - ```bottom``` (after the table)
+
+Backpack adds a few buttons by default: 
+- ```add``` to the ```top``` stack;
+- ```edit``` and ```delete``` to the ```line``` stack;
+
+To learn more about buttons, **check out the [Buttons](/docs/{{version}}/crud-buttons) documentation page**.
+
+<a name="filters"></a>
+### Filters
+
+Filters show up right before the actual table, and provide a way for the admin to filter the results in the ListEntries table. To learn more about filters, **check out the [Filters](/docs/{{version}}/crud-filters) documentation page**.
+
+<a name="other-features"></a>
+### Other Features
+
+<a name="details-row"></a>
+#### Details Row
+
+The details row functionality allows you to present more information in the table view of a CRUD. When enabled, a "+" button will show up next to every row, which on click will expand a "details row" below it, showing additional information.
+
+![Backpack CRUD ListEntries Details Row](https://backpackforlaravel.com/uploads/docs-4-0/operations/listEntries_details_row.png)
+
+On click, an AJAX request is sent to the ```entity/{id}/details``` route, which calls the ```showDetailsRow()``` method on your EntityCrudController. Everything returned by that method is then shown in the details row. You'll want to overwrite that method to show anything you'd like in the details row.
+
+To use, inside your ```EntityCrudController```:
+1. Enable the functionality: ```$this->crud->enableDetailsRow();```
+2. Overwrite the ```showDetailsRow($id)``` method;
+
+Alternative for the 2nd step: overwrite ```views/backpack/crud/details_row.blade.php``` which is called by the default ```showDetailsRow($id)``` functionality.
+
+<a name="export-buttons"></a>
+#### Export Buttons
+
+Exporting the DataTable to PDF, CSV, XLS is as easy as typing ```$this->crud->enableExportButtons();``` in your constructor. 
+
+![Backpack CRUD ListEntries Details Row](https://backpackforlaravel.com/uploads/docs-4-0/operations/listEntries_export_buttons.png)
+
+**Please note that when clicked, the button will export** 
+- **the _currently visible_ table columns** (except columns marked as ```visibleInExport => false```); 
+- **the columns that are forced to export** (with ```visibleInExport => true``` or ```exportOnlyField => true```);
+
+**In the UI, the admin can use the "Visibility" button, and the "Items per page" dropdown to manipulate what is visible in the table - and consequently what will be exported.**
+
+**Export Buttons Rules**
+
+Available customization: 
+```
+'visibleInExport' => true/false
+'visibleInTable' => true/false
+'exportOnlyField' => true
+```
+
+By default, the field will start visible in the table. Users can hide it toggling visibility. Will be exported if visible in the table.
+
+If you force `visibleInExport => true` you are saying that independent of field visibility in table it will **always** be exported.
+
+Contrary is `visibleInExport => false`, even if visible in table, field will not be exported as per developer instructions.
+
+Setting `visibleInTable => true` will force the field to stay in the table no matter what. User can't hide it. (By default all fields visible in the table will be exported. If you don't want to export this field use with combination with `visibleInExport => false`)
+
+Using `'visibleInTable' => false` will make the field start hidden in the table. But users can toggle it's visibility.
+
+If you want a field that is not on table, user can't show it, but will **ALWAYS** be exported use the `exportOnlyField => true`. If used will ignore any other custom visibility you defined.
+
+<a name="custom-query"></a>
+#### Custom Query
+
+By default, all entries are shown in the ListEntries table, before filtering. If you want to restrict the entries to a subset, you can use the methods below in your EntityCrudController's ```setupListOperation()``` method:
+
+```php
+// Change what entries are shown in the table view.
+// This changes all queries on the table view,
+// as opposed to filters, who only change it when that filter is applied. 
+$this->crud->addClause('active'); // apply a local scope
+$this->crud->addClause('type', 'car'); // apply local dynamic scope
+$this->crud->addClause('where', 'name', '=', 'car');
+$this->crud->addClause('whereName', 'car');
+$this->crud->addClause('whereHas', 'posts', function($query) {
+     $query->activePosts();
+ });
+$this->crud->groupBy();
+$this->crud->limit();
+
+$this->crud->orderBy();
+// please note it's generally a good idea to use crud->orderBy() inside "if (!$this->crud->getRequest()->has('order')) {}"; that way, your custom order is applied ONLY IF the user hasn't forced another order (by clicking a column heading)
+```
+
+<a name="responsive-table"></a>
+#### Responsive Table
+
+If your CRUD table has more columns than can fit inside the viewport (on mobile / tablet or smaller desktop screens), unimportant columns will start hiding and an expansion icon (three dots) will appear to the left of each row. We call this behaviour "_responsive table_", and consider this to be the best UX. By behaviour we consider the 1st column the most important, then 2nd, then 3rd, etc; the "actions" column is considered as important as the 1st column. You can of course [change the importance of columns](/docs/{{version}}/crud-columns#define-which-columns-to-hide-in-responsive-table).
+
+If you do not like this, you can **toggle off the responsive behaviour for all CRUD tables** by changing this config value in your ```config/backpack/crud.php``` to ```false```:
+```php
+    // enable the datatables-responsive plugin, which hides columns if they don't fit?
+    // if not, a horizontal scrollbar will be shown instead
+    'responsive_table' => true
+```
+
+To turn off the responsive table behaviour for _just one CRUD panel_, you can use ```$this->crud->disableResponsiveTable()``` in your ```setupListOperation()``` method.
+
+<a name="persistent-query"></a>
+#### Persistent Table
+
+By default, ListEntries will NOT remember your filtering, search and pagination when you leave the page. If you want ListEntries to do that, you can enable a ListEntries feature we call ```persistent_table```. 
+
+**This will take the user back to the _filtered table_ after adding an item, previewing an item, creating an item or just browsing around**, preserving the table just like he/she left it - with the same filtering, pagination and search applied. It does so by saving the pagination, search and filtering for an arbitrary amount of time (by default: forever).
+
+To use ```persistent_table``` you can:
+- enable it for all CRUDs with the config option ```'persistent_table' => true``` in your ```config/backpack/crud.php```;
+- enable it inside a particular crud controller with ```$this->crud->enablePersistentTable();```
+- disable it inside a particular crud controller with ```$this->crud->disablePersistentTable();```
+
+> You can configure the persistent table duration in ``` config/backpack/crud.php ``` under `operations > list > persistentTableDuration`. False is forever. Set any amount of time you want in minutes. Note: you can configure it's expiring time on a per-crud basis using `$this->crud->setOperationSetting('persistentTableDuration', 120); in your setupListOperation()` for 2 hours persistency. The default is `false` which means forever. 
+
+<a name="how-to-overwrite"></a>
+## How to Overwrite
+
+The main route leads to ```EntityCrudController::index()```, which loads ```list.blade.php```. Inside that table view, we're using AJAX to fetch the entries and place them inside a DataTables. The AJAX points to the same controller, ```EntityCrudController::search()```.
+
+<a name="the-view"></a>
+### The View
+
+You can change how the ```list.blade.php``` file looks and works, by just placing a file with the same name in your ```resources/views/vendor/backpack/crud/list.blade.php```. To quickly do that, run:
+
+```zsh
+php artisan backpack:publish crud/list
+```
+
+Keep in mind that by publishing this file, you won't be getting any updates we'll be pushing to it.
+
+<a name="the-operation-logic"></a>
+### The Operation Logic
+
+Getting and showing the information is done inside the ```index()``` method. Take a look at the ```CrudController::index()``` method (your EntityCrudController is extending this CrudController) to see how it works.
+
+To overwrite it, just create an ```index()``` method in your ```EntityCrudController```.
+
+<a name="the-search-logic"></a>
+### The Search Logic
+
+An AJAX call is made to the ```search()``` method:
+- when entries are shown in the table;
+- when entries are filtered in the table;
+- when search is performed on the table;
+- when pagination is performed on the table;
+
+You can of course overwrite this ```search()``` method by just creating one with the same name in your ```EntityCrudController```. In addition, you can overwrite what a specific column is searching through (and how), by [using the searchLogic attribute](/docs/{{version}}/crud-columns#custom-search-logic) on columns.

--- a/5.x-dev/crud-operation-reorder.md
+++ b/5.x-dev/crud-operation-reorder.md
@@ -1,0 +1,82 @@
+# Reorder Operation
+
+---
+
+<a name="about"></a>
+## About
+
+This operation allows your admins to reorder & nest entries.
+
+![CRUD Reorder Operation](https://backpackforlaravel.com/uploads/docs-4-0/operations/reorder.png)
+
+<a name="requirements"></a>
+## Requirements
+
+Your model should have the following integer fields, with a default value of 0: ```parent_id```, ```lft```, ```rgt```, ```depth```.
+
+Additionally, the `parent_id` field has to be nullable.
+
+<a name="how-to-use"></a>
+## How to Use
+
+In order to enable this operation in your CrudController, you need to use the ```ReorderOperation``` trait, and have a ```setupReorderOperation()``` method that defines the ```label``` and ```max_level``` of allowed depth.
+
+```php
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+
+class ProductCrudController extends CrudController
+{
+    use \Backpack\CRUD\app\Http\Controllers\Operations\ReorderOperation;
+
+    protected function setupReorderOperation()
+    {
+    	// define which model attribute will be shown on draggable elements 
+        $this->crud->set('reorder.label', 'name');
+        // define how deep the admin is allowed to nest the items
+        // for infinite levels, set it to 0
+        $this->crud->set('reorder.max_level', 2);
+    }
+}
+```
+
+This will:
+- allow access to the Reorder operation;
+- make a "Reorder" button appear next to "Add entry" in the List view, if the List operation is enabled;
+- enable the routes needed by the Reorder operation;
+
+Where:
+- ```attribute_name``` should be the attribute you want shown on the draggable elements (ex: ```name```);
+- ```ALLOWED_DEPTH``` should be an integer, how many levels deep would you allow your admin to go when nesting; for infinite levels, you should set it to ```0```;
+
+<a name="how-it-works"></a>
+## How It Works
+
+The ```/reorder``` route points to a ```reorder()``` method in your ```EntityCrudController```.
+
+
+<a name="how-to-overwrite"></a>
+## How to Overwrite
+
+In case you need to change how this operation works, take a look at the ```ReorderOperation.php``` trait to understand how it works. You can easily overwrite the ```reorder()``` or the ```saveReorder()``` methods:
+
+```php
+use \Backpack\CRUD\app\Http\Controllers\Operations\ReorderOperation { reorder as traitReorder; }
+
+public function reorder()
+{
+    // your custom code here
+    
+    // call the method in the trait
+    return $this->traitReorder();
+}
+```
+
+You can also overwrite the reorder button by creating a file with the same name inside your ```resources/views/vendor/backpack/crud/buttons/```. You can easily publish the reorder button there to make changes using:
+
+```zsh
+php artisan backpack:publish crud/buttons/reorder
+```

--- a/5.x-dev/crud-operation-revisions.md
+++ b/5.x-dev/crud-operation-revisions.md
@@ -1,0 +1,71 @@
+# Revise Operation
+
+---
+
+<a name="about"></a>
+## About
+
+Revise allows your admins to store, see and undo changes to entries on an Eloquent model.
+
+The operation provides you with a simple interface to work with [venturecraft/revisionable](https://github.com/VentureCraft/revisionable#implementation), which is a great package that stores all changes in a separate table. It can work as an audit trail, a backup system and an accountability system for the admins.
+
+When enabled, ```Revise``` will show another button in the table view, between _Edit_ and _Delete_. On click, that button opens another page which will allow an admin to see all changes and who made them:
+
+
+![CRUD Revision Operation](https://backpackforlaravel.com/uploads/docs-4-0/operations/revisions.png)
+
+
+<a name="how-to-use"></a>
+## How to Use
+
+In order to enable this operation for a CrudController, you need to:
+
+**Step 1.** Install [the package](https://github.com/laravel-backpack/revise-operation) that provides this operation. This will also install venturecraft/revisionable if it's not already installed in your project.
+
+```bash
+composer require backpack/revise-operation
+```
+
+**Step 2.** Create the revisions table:
+
+```bash
+cp vendor/venturecraft/revisionable/src/migrations/2013_04_09_062329_create_revisions_table.php database/migrations/ && php artisan migrate
+```
+
+**Step 3.** Use [venturecraft/revisionable](https://github.com/VentureCraft/revisionable#implementation)'s trait on your model, and an ```identifiableName()``` method that returns an attribute on the model that the admin can use to distinguish between entries (ex: name, title, etc). If you are using another bootable trait be sure to override the boot method in your model.
+
+```php
+namespace App\Models;
+
+class Article extends Eloquent {
+    use \Backpack\CRUD\app\Models\Traits\CrudTrait, \Venturecraft\Revisionable\RevisionableTrait;
+    
+    public function identifiableName()
+    {
+        return $this->name;
+    }
+
+    // If you are using another bootable trait
+    // be sure to override the boot method in your model
+    public static function boot()
+    {
+        parent::boot();
+    }
+}
+```
+
+**Step 4.** In your CrudController, use the operation trait:
+
+```php
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+
+class ArticleCrudController extends CrudController
+{
+    use \Backpack\ReviseOperation\ReviseOperation;
+```
+
+For complex usage, head over to [VentureCraft/revisionable](https://github.com/VentureCraft/revisionable) to see the full documentation and configuration options.

--- a/5.x-dev/crud-operation-show.md
+++ b/5.x-dev/crud-operation-show.md
@@ -1,0 +1,114 @@
+# Show Operation
+
+--
+
+<a name="about"></a>
+## About
+
+This CRUD operation allows your admins to preview an entry. When enabled, it will add a "Preview" button in the ListEntries view, that points to a show page. By default, it will show all attributes for that model:
+
+![Backpack CRUD Show Operation](https://backpackforlaravel.com/uploads/docs-4-0/operations/show.png)
+
+In case your entity is translatable, it will show a multi-language dropdown, just like Edit.
+
+<a name="how-it-works"></a>
+## How it Works
+
+The ```/entity-name/{id}/show``` route points to the ```show()``` method in your EntityCrudController, which shows all columns that have been set up using [column types](/docs/{{version}}/crud-columns), by showing a ```show.blade.php``` blade file. 
+
+<a name="enabling"></a>
+## How to Use
+
+To enable this operation, you need to use the ```ShowOperation``` trait on your CrudController:
+
+```php
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+
+class ProductCrudController extends CrudController
+{
+    use \Backpack\CRUD\app\Http\Controllers\Operations\ShowOperation;
+}
+```
+
+This will:
+- make a Preview button appear inside the List view; 
+- allow access to the show view;
+
+By default, the operation tries to show all db columns in the database, but _remove_ any columns and buttons that it thinks you _wouldn't want_ shown. Which works great for simple Eloquent Models, it'll _just work_. But for more complex Models, it might be preferrable to define your own columns, using the same syntax you're using when defining the ListOperation.
+
+
+<a name="configuring"></a>
+## How to Configure
+
+### setupShowOperation()
+
+You can manually define columns inside the ```setupShowOperation()``` method - thereby stopping the default "guessing" and "removing" of columns - you'll start from a blank slate and be in complete control of what columns are shown. For example:
+
+```php
+    // if you just want to show the same columns as inside ListOperation
+    protected function setupShowOperation()
+    {
+        $this->setupListOperation();
+    }
+```
+
+But you can also do both - let Backpack guess columns, and do stuff before or after that guessing, by calling the `autoSetupShowOperation()` method wherever you want inside your `setupShowOperation()`:
+
+```php
+    // show whatever you want
+    protected function setupShowOperation()
+    {
+        // MAYBE: do stuff before the autosetup
+        
+        // automatically add the columns
+        $this->autoSetupShowOperation();
+    
+        // MAYBE: do stuff after the autosetup
+        
+        // for example, let's add some new columns
+        $this->crud->addColumn([
+            'name' => 'table',
+            'label' => 'Table',
+            'type' => 'table',
+            'columns' => [
+                'name'  => 'Name',
+                'desc'  => 'Description',
+                'price' => 'Price',
+            ]
+        ]);
+        $this->crud->addColumn([
+            'name' => 'fake_table',
+            'label' => 'Fake Table',
+            'type' => 'table',
+            'columns' => [
+                'name'  => 'Name',
+                'desc'  => 'Description',
+                'price' => 'Price',
+            ],
+        ]);
+        
+        // or maybe remove a column
+        $this->crud->removeColumn('text');
+    }
+```
+
+<a name="how-to-overwrite"></a>
+## How to Overwrite
+
+In case you need to modify the show logic in a meaningful way, you can create a ```show()``` method in your EntityCrudController. The route will then point to your method, instead of the one in the trait. For example:
+
+```php
+use \Backpack\CRUD\app\Http\Controllers\Operations\ShowOperation { show as traitShow; }
+
+public function show($id)
+{
+    // custom logic before
+    $content = $this->traitShow($id);
+    // cutom logic after
+    return $content;
+}
+```

--- a/5.x-dev/crud-operation-update.md
+++ b/5.x-dev/crud-operation-update.md
@@ -1,0 +1,371 @@
+# Update Operation
+
+---
+
+<a name="about"></a>
+## About
+
+This operation allows your admins to edit entries from the database.
+
+![CRUD Update Operation](https://backpackforlaravel.com/uploads/docs-4-2/operations/update.png)
+
+<a name="requirements"></a>
+## Requirements
+
+All editable attributes should be ```$fillable``` on your Model.
+
+<a name="how-to-use"></a>
+## How to Use
+
+**Step 0. Use the operation trait on your controller**:
+
+```php
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+
+class ProductCrudController extends CrudController
+{
+    use \Backpack\CRUD\app\Http\Controllers\Operations\UpdateOperation;
+
+    protected function setupUpdateOperation()
+    {
+        // $this->crud->setValidation(StoreRequest::class);
+        // $this->crud->addField()
+	
+        // or just do everything you've done for the Create Operation
+        // $this->crud->setupCreateOperation();
+	
+	// You can also do things depending on the current entry
+	// (the database item being edited or updated)
+	// if ($this->crud->getCurrentEntry()->smth == true) {}
+    }
+}
+```
+
+This will:
+- allow access to this operation;
+- make an Edit button appear in the ```line``` stack, next to each entry, in the List operation view;
+
+To use the Update operation, you must:
+
+**Step 1. Specify what field types** you'd like to show for each attribute, in your controller's ```setupUpdateOperation()``` method. You can do that using the [Fields API](/docs/{{version}}/crud-fields#fields-api). In short you can:
+
+```php
+// add a field only to the Update operation
+$this->crud->addField($field_definition_array);
+// add a field to both the Update and Update operations
+$this->crud->addField($field_definition_array);
+```
+
+**Step 2. Specify which FormRequest file to use for validation and authorization**, inside your ```setupUpdateOperation()``` method. You can pass the same FormRequest as you did for the Create operation if there are no differences. If you need separate validation for Create and Update [look here](#separate-validation).
+```php
+$this->crud->setValidation(StoreRequest::class);
+```
+
+For more on how to manipulate fields, please read the [Fields documentation page](/docs/{{version}}/crud-fields). For more on validation rules, check out [Laravel's validation docs](https://laravel.com/docs/master/validation#available-validation-rules).
+
+<a name="how-it-works"></a>
+## How It Works
+
+CrudController is a RESTful controller, so the ```Update``` operation uses two routes:
+- GET to ```/entity-name/{id}/edit``` - points to ```edit()``` which shows the Edit form (```edit.blade.php```);
+- POST to ```/entity-name/{id}/edit``` - points to ```update()``` which uses Eloquent to update the entry in the database;
+
+The ```edit()``` method will show all the fields you've defined for this operation using the [Fields API](/docs/{{version}}/crud-fields#fields-api), then upon Save the ```update()``` method will first check the validation from the typehinted FormRequest, then create the entry using the Eloquent model. Only attributes that have a field type added and are ```$fillable``` on the model will actually be updated in the database.
+
+
+<a name="advanced-features-and-techniques"></a>
+## Advanced Features and Techniques
+
+<a name="validation"></a>
+### Validation
+
+There are three ways you can define the [validation rules](https://laravel.com/docs/validation#available-validation-rules) for your fields:
+
+#### Validating fields using FormRequests
+
+When you generate a CrudController, you'll notice a [Laravel FormRequest](https://laravel.com/docs/validation#form-request-validation) has also been generated, and that FormRequest is mentioned as the source of your validation rules:
+```php
+protected function setupUpdateOperation()
+{
+    $this->crud->setValidation(StoreRequest::class);
+}
+```
+
+This works particularly well for bigger models, because you can mention a lot of rules, messages and attributes in your `FormRequest` and it will not increase the size of your `CrudController`.
+
+**Differences between the Create and Update validations?** Then create a separate request file for each operation and instruct your EntityCrudController to use those files:
+
+```php
+use App\Http\Requests\CreateTagRequest as StoreRequest;
+use App\Http\Requests\UpdateTagRequest as UpdateRequest;
+
+// ...
+
+public function setupCreateOperation()
+{
+    $this->crud->setValidation(CreateRequest::class);
+}
+
+public function setupUpdateOperation()
+{
+    $this->crud->setValidation(UpdateRequest::class);
+}
+```
+
+#### Validating fields using a rules array
+
+For smaller models (with just a few validation rules), creating an entire FormRequest file to hold them might be overkill. If you prefer, you can pass an array of [validation rules](https://laravel.com/docs/validation#available-validation-rules) to the same `setValidation()` method (with an optional second parameter for the validation messages):
+
+```php
+protected function setupUpdateOperation()
+{
+    $this->crud->setValidation([
+        'name' => 'required|min:2',
+    ]);
+
+    // or maybe
+    $rules = ['name' => 'required|min:2'];
+    $messages = [
+        'name.required' => 'You gotta give it a name, man.',
+        'name.min' => 'You came up short. Try more than 2 characters.',
+    ];
+    $this->crud->setValidation($rules, $messages);
+}
+```
+
+This is more convenient for small and medium models. Plus, it's very easy to read.
+
+#### Validating fields using field attributes
+
+Another good option for small & medium models is to define the [validation rules](https://laravel.com/docs/validation#available-validation-rules) directly on your fields:
+
+```php
+protected function setupUpdateOperation()
+{
+    $this->crud->addField([
+        'name' => 'content',
+        'label' => 'Content',
+        'type' => 'ckeditor',
+        'placeholder' => 'Your textarea text here',
+        'validationRules' => 'required|min:10',
+        'validationMessages' => [
+            'required' => 'You gotta write smth man.',
+            'min' => 'More than 10 characters, bro. Wtf... You can do this!',
+        ]
+    ]);
+    // CAREFUL! This MUST be called AFTER the fields are defined, NEVER BEFORE
+    $this->crud->setValidation();
+}
+```
+
+You must then call `setValidation()` without a parameter, and Backpack will go through all defined fields, get their `validationRules` and validate them. It is VERY IMPORTANT to call `setValidation()` _after_ you've defined the fields! Otherwise Backpack won't find any `validationRules`.
+
+<a name="callbacks"></a>
+### Callbacks
+
+Developers coming other CRUD systems (like GroceryCRUD) will be looking for callbacks to run "before_insert", "before_update", "after_insert", "after_update". **There are no callbacks in Backpack**, because... they're not needed. There are plenty of other ways to do things before/after an entry is updated.
+
+
+#### Use Events in your `setup()` method
+
+Laravel already triggers [multiple events](https://laravel.com/docs/master/eloquent#events) in an entry's lifecycle. Those also include:
+- `updating` and `updated`, which are triggered by the Update operation;
+- `saving` and `saved`, which are triggered by both the Create and the Update operations;
+
+So if you want to do something to a `Product` entry _before_ it's updated, you can easily do that:
+```php
+public function setupUpdateOperation()
+{
+
+    // ...
+
+    Product::updating(function($entry) {
+        $entry->last_edited_by = backpack_user()->id;
+    });
+}
+```
+
+Take a closer look at [Eloquent events](https://laravel.com/docs/master/eloquent#events) if you're not familiar with them, they're really _really_ powerful once you understand them. Please note that **these events will only get registered when the function gets called**, so if you define them in your `CrudController`, then:
+- they will NOT run when an entry is changed outside that CrudController;
+- if you want to expand the scope to cover both the `Create` and `Update` operations, you can easily do that, for example by using the `saving` and `saved` events, and moving the event-calling to your main `setup()` method;
+
+#### Use events in your field definition
+
+You can tell a field to do something to the entry when that field gets saved to the database. Rephrased, you can define standard [Eloquent events](https://laravel.com/docs/master/eloquent#events) directly on fields. For example:
+
+```php
+// FLUENT syntax - use the convenience method "on" to define just ONE event
+CRUD::field('name')->on('updating', function ($entry) {
+    $entry->last_edited_by = backpack_user()->id;
+});
+
+// FLUENT SYNTAX - you can define multiple events in one go
+CRUD::field('name')->events([
+    'updating' => function ($entry) {
+        $entry->last_edited_by = backpack_user()->id;
+    },
+    'saved' => function ($entry) {
+        // TODO: upload some file
+    },
+]);
+
+// using the ARRAY SYNTAX, define an array of events and closures
+CRUD::addField([
+    'name' => 'name',
+    'events' => [
+        'updating' => function ($entry) {
+            $entry->author_id = backpack_user()->id;
+        },
+    ],
+]);
+```
+
+#### Override the `update()` method
+
+The store code is inside a trait, so you can easily overwrite it:
+
+```php
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+
+class ProductCrudController extends CrudController
+{
+    use \Backpack\CRUD\app\Http\Controllers\Operations\UpdateOperation { update as traitUpdate; }
+
+    // ...
+    
+    public function update()
+    {
+        // do something before validation, before save, before everything; for example:
+        // $this->crud->addField(['type' => 'hidden', 'name' => 'author_id']);
+        // $this->crud->removeField('password_confirmation');
+	
+	// Note: By default Backpack ONLY saves the inputs that were added on page using Backpack fields.
+	// This is done by stripping the request of all inputs that do NOT match Backpack fields for this
+	// particular operation. This is an added security layer, to protect your database from malicious
+	// users who could theoretically add inputs using DeveloperTools or JavaScript. If you're not properly
+	// using $guarded or $fillable on your model, malicious inputs could get you into trouble.
+	
+	// However, if you know you have proper $guarded or $fillable on your model, and you want to manipulate 
+	// the request directly to add or remove request parameters, you can also do that.
+	// We have a config value you can set, either inside your operation in `config/backpack/crud.php` if
+	// you want it to apply to all CRUDs, or inside a particular CrudController:
+    	// $this->crud->setOperationSetting('saveAllInputsExcept', ['_token', '_method', 'http_referrer', 'current_tab', 'save_action']);
+	// The above will make Backpack store all inputs EXCEPT for the ones it uses for various features.
+	// So you can manipulate the request and add any request variable you'd like.
+	// $this->crud->getRequest()->request->add(['author_id'=> backpack_user()->id]);
+	// $this->crud->getRequest()->request->remove('password_confirmation');
+	// $this->crud->getRequest()->request->add(['author_id'=> backpack_user()->id]);
+	// $this->crud->getRequest()->request->remove('password_confirmation');
+	
+        $response = $this->traitUpdate();
+        // do something after save
+        return $response;
+    }
+}
+```
+
+>But before you do that, ask yourself - **_is this something that should be done when an entry is added/updated/deleted from the application, too_**? Not just the admin admin? If so, a better place for it would be the Model. Remember your Model is a pure Eloquent Model, so the cleanest way might be to use [Eloquent Event Observers](https://laravel.com/docs/5.5/eloquent#events) or [accessors and mutators](https://laravel.com/docs/master/eloquent-mutators#accessors-and-mutators).
+
+<a name="translatable-models"></a>
+### Translatable models and multi-language CRUDs
+
+![CRUD Update Operation](https://backpackforlaravel.com/uploads/docs-4-0/operations/update_translatable.png)
+
+For localized apps, you can let your admins edit multi-lingual entries. Translations are stored using [spatie/laravel-translatable](https://github.com/spatie/laravel-translatable).
+
+In order to make one of your Models translatable (localization), you need to:
+0. Be running MySQL 5.7+ (or a PostgreSQL with JSON column support);
+1. [Install spatie/laravel-translatable](https://github.com/spatie/laravel-translatable#installation);
+2. In your database, make all translatable columns either JSON or TEXT.
+3. Use Backpack's ```HasTranslations``` trait on your model (instead of using spatie's ```HasTranslations```) and define what fields are translatable, inside the ```$translatable``` property. For example:
+
+```php
+<?php
+
+namespace App\Models;
+
+use Backpack\CRUD\app\Models\Traits\CrudTrait;
+use Illuminate\Database\Eloquent\Model;
+use Backpack\CRUD\app\Models\Traits\SpatieTranslatable\HasTranslations;
+
+class Product extends Model
+{
+    use CrudTrait;
+    use HasTranslations;
+
+     /*
+  |--------------------------------------------------------------------------
+  | GLOBAL VARIABLES
+  |--------------------------------------------------------------------------
+  */
+
+    protected $table = 'products';
+    protected $primaryKey = 'id';
+    protected $fillable = ['name', 'category_id', 'options', 'price', 'tags'];
+    protected $translatable = ['name', 'options'];
+```
+
+> You DO NOT need to cast translatable string columns as array/json/object in the Eloquent model. From Eloquent's perspective they're strings. So:
+> - you _should NOT_ cast ```name```; it's a string in Eloquent, even though it's stored as JSON in the db by SpatieTranslatable;
+> - you _should_ cast ```extras``` to ```array```, if each translation stores an array of some sort;
+
+Change the languages available to translate to/from, in your crud config file (```config/backpack/crud.php```). By default there are quite a few enabled (English, French, German, Italian, Romanian).
+
+Additionally, if you have slugs (but only if you need translatable slugs), you'll need to use backpack's classes instead of the ones provided by cviebrock/eloquent-sluggable:
+
+```php
+<?php
+
+namespace Backpack\NewsCRUD\app\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Backpack\CRUD\app\Models\Traits\CrudTrait;
+use Backpack\CRUD\app\Models\Traits\SpatieTranslatable\Sluggable;
+use Backpack\CRUD\app\Models\Traits\SpatieTranslatable\SluggableScopeHelpers;
+use Backpack\CRUD\app\Models\Traits\SpatieTranslatable\HasTranslations;
+
+class Category extends Model
+{
+    use CrudTrait;
+    use Sluggable, SluggableScopeHelpers;
+    use HasTranslations;
+
+    /*
+    |--------------------------------------------------------------------------
+    | GLOBAL VARIABLES
+    |--------------------------------------------------------------------------
+    */
+
+    protected $table = 'categories';
+    protected $primaryKey = 'id';
+    // public $timestamps = false;
+    // protected $guarded = ['id'];
+    protected $fillable = ['name', 'parent_id'];
+    // protected $hidden = [];
+    // protected $dates = [];
+    protected $translatable = ['name', 'slug'];
+
+    /**
+     * Return the sluggable configuration array for this model.
+     *
+     * @return array
+     */
+    public function sluggable()
+    {
+        return [
+            'slug' => [
+                'source' => 'slug_or_name',
+            ],
+        ];
+    }
+}
+```
+> If your slugs are not translatable, use the ```cviebrock/eloquent-sluggable``` traits. The Backpack's ```Sluggable``` trait saves your slug as a JSON object, regardless of the ```slug``` field being defined inside the ```$translatable``` property.

--- a/5.x-dev/crud-operations.md
+++ b/5.x-dev/crud-operations.md
@@ -34,16 +34,16 @@ No operations are enabled by default.
 But Backpack does provide the logic for the most common operations admins perform on Eloquent model. You just need to use it (and maybe configure it) in your controller.
 
 Operations provided by Backpack:
-- [List](/docs/{{version}}/crud-operation-list-entries) - allows the admin to see all entries for an Eloquent model, with pagination, search, filters;
-- [Create](/docs/{{version}}/crud-operation-create) - allows the admin to add a new entry;
-- [Update](/docs/{{version}}/crud-operation-update) - allows the admin to edit an existing entry;
-- [Show](/docs/{{version}}/crud-operation-show) - allows the admin to preview an entry;
-- [Delete](/docs/{{version}}/crud-operation-delete) - allows the admin to remove and entry;
-- [BulkDelete](/docs/{{version}}/crud-operation-delete) - allows the admin to remove multiple entries in one go;
-- [Clone](/docs/{{version}}/crud-operation-clone) - allows the admin to make a copy of a database entry;
-- [BulkClone](/docs/{{version}}/crud-operation-clone) - allows the admin to make a copy of multiple database entries in one go;
-- [Reorder](/docs/{{version}}/crud-operation-reorder) - allows the admin to reorder & nest all entries of a model, in a hierarchy tree;
-- [Revisions](/docs/{{version}}/crud-operation-revisions) - shows an audit log of all changes to an entry, and allows the admin to undo modifications;
+- [List](/docs/{{version}}/crud-operation-list-entries) - allows the admin to see all entries for an Eloquent model, with pagination, search, filters; <span class="badge badge-pill badge-success">FREE</span>
+- [Create](/docs/{{version}}/crud-operation-create) - allows the admin to add a new entry; <span class="badge badge-pill badge-success">FREE</span>
+- [Update](/docs/{{version}}/crud-operation-update) - allows the admin to edit an existing entry; <span class="badge badge-pill badge-success">FREE</span>
+- [Show](/docs/{{version}}/crud-operation-show) - allows the admin to preview an entry; <span class="badge badge-pill badge-success">FREE</span>
+- [Delete](/docs/{{version}}/crud-operation-delete) - allows the admin to remove and entry; <span class="badge badge-pill badge-success">FREE</span>
+- [BulkDelete](/docs/{{version}}/crud-operation-delete) - allows the admin to remove multiple entries in one go; <span class="badge badge-pill badge-info">PRO</span>
+- [Clone](/docs/{{version}}/crud-operation-clone) - allows the admin to make a copy of a database entry; <span class="badge badge-pill badge-info">PRO</span>
+- [BulkClone](/docs/{{version}}/crud-operation-clone) - allows the admin to make a copy of multiple database entries in one go; <span class="badge badge-pill badge-info">PRO</span>
+- [Reorder](/docs/{{version}}/crud-operation-reorder) - allows the admin to reorder & nest all entries of a model, in a hierarchy tree; <span class="badge badge-pill badge-success">FREE</span>
+- [Revisions](/docs/{{version}}/crud-operation-revisions) - shows an audit log of all changes to an entry, and allows you to undo modifications; <span class="badge badge-pill badge-success">FREE</span>
 
 
 <a name="operation-actions"></a>

--- a/5.x-dev/crud-operations.md
+++ b/5.x-dev/crud-operations.md
@@ -1,0 +1,966 @@
+# Operations
+
+---
+
+When creating a CRUD Panel, your ```EntityCrudController``` (where Entity = your model name) is extending ```CrudController```. **By default, no operations are enabled.** No routes are registered.
+
+To use an operation, you need to use the operation trait on your controller. For example, to enable the List operation:
+
+```php
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+
+class ProductCrudController extends CrudController
+{
+    use \Backpack\CRUD\app\Http\Controllers\Operations\ListOperation;
+}
+```
+
+**Operations are traits that add functionality to that controller**. Most operations will have:
+- routes inside a ```setupOperationNameRoutes()```; this gets called in your ```routes/backpack/custom.php``` by the ```Route::crud('product', 'ProductCrudController``` macro, which determines which routes to register for that CrudController;
+- default setup inside a ```setupOperationNameDefaults()``` method, that gets called automatically by CrudController when you use that operation on a controller;
+- methods that return views, or perform certain operations;
+
+Of course, you can easily [add custom operations](/#creating-a-custom-operation).
+
+<a name="supported-operations"></a>
+## Standard Operations
+
+No operations are enabled by default.
+
+But Backpack does provide the logic for the most common operations admins perform on Eloquent model. You just need to use it (and maybe configure it) in your controller.
+
+Operations provided by Backpack:
+- [List](/docs/{{version}}/crud-operation-list-entries) - allows the admin to see all entries for an Eloquent model, with pagination, search, filters;
+- [Create](/docs/{{version}}/crud-operation-create) - allows the admin to add a new entry;
+- [Update](/docs/{{version}}/crud-operation-update) - allows the admin to edit an existing entry;
+- [Show](/docs/{{version}}/crud-operation-show) - allows the admin to preview an entry;
+- [Delete](/docs/{{version}}/crud-operation-delete) - allows the admin to remove and entry;
+- [BulkDelete](/docs/{{version}}/crud-operation-delete) - allows the admin to remove multiple entries in one go;
+- [Clone](/docs/{{version}}/crud-operation-clone) - allows the admin to make a copy of a database entry;
+- [BulkClone](/docs/{{version}}/crud-operation-clone) - allows the admin to make a copy of multiple database entries in one go;
+- [Reorder](/docs/{{version}}/crud-operation-reorder) - allows the admin to reorder & nest all entries of a model, in a hierarchy tree;
+- [Revisions](/docs/{{version}}/crud-operation-revisions) - shows an audit log of all changes to an entry, and allows the admin to undo modifications;
+
+
+<a name="operation-actions"></a>
+### Operation Actions
+
+Each Operation is actually _a trait_, which can be used on CrudControllers. This trait can contain one or more methods (or functions). Since Laravel calls each Controller method an _action_, that means each _Operation_ can have one or many _actions_. For example, we have the ```create``` operation and two actions: ```create()``` and ```store()```.
+
+```php
+trait CreateOperation
+{
+    public function create()
+    {
+        // ...
+    }
+
+    public function store()
+    {
+        // ...
+    }
+}
+```
+
+An action can do something with AJAX and return true/false, it can return a view, or whatever else you can do inside a controller method. Notice that it's a ```public``` method - which is a Laravel requirement, in order to point a route to it.
+
+You can check which action is currently being performed using the [standard Laravel Route API](https://laravel.com/api/8.x/Illuminate/Routing/Route.html):
+
+- ```\Route::getCurrentRoute()->getAction()``` or ```$this->crud->getRequest()->route()->getAction()```:
+```
+array:8 [▼
+  "middleware" => array:2 [▼
+    0 => "web"
+    1 => "admin"
+  ]
+  "as" => "crud.monster.index"
+  "uses" => "App\Http\Controllers\Admin\MonsterCrudController@index"
+  "operation" => "list"
+  "controller" => "App\Http\Controllers\Admin\MonsterCrudController@index"
+  "namespace" => "App\Http\Controllers\Admin"
+  "prefix" => "admin"
+  "where" => []
+]
+```
+- ```\Route::getCurrentRoute()->getActionName()``` or ```$this->crud->getRequest()->route()->getActionName()```:
+```
+App\Http\Controllers\Admin\MonsterCrudController@index
+```
+- ```\Route::getCurrentRoute()->getActionMethod()``` or ```$this->crud->getRequest()->route()->getActionMethod()```:
+```
+index
+```
+
+You can also use the shortcuts on the CrudPanel object:
+```php
+$this->crud->getActionMethod(); // returns the method on the controller that was called by the route; ex: create(), update(), edit() etc;
+$this->crud->actionIs('create'); // checks if the controller method given is the one called by the route
+```
+
+<a name="titles-heading-and-subheadings"></a>
+### Titles, Headings and Subheadings
+
+For standard CRUD operations, each _action_ that shows an interface uses some texts to show the user what page, operation or action he is currently performing:
+- **Title** - page title, shown in the browser's title bar;
+- **Heading** - biggest heading on page;
+- **Subheading** - short description of the current page, sits beside the heading;
+
+![CRUD Operation Headings](https://backpackforlaravel.com/uploads/docs-4-0/operations/headings.png)
+
+You can get and set the above using:
+```php
+// Getters
+$this->crud->getTitle('create'); // get the Title for the create action
+$this->crud->getHeading('create'); // get the Heading for the create action
+$this->crud->getSubheading('create'); // get the Subheading for the create action
+
+// Setters
+$this->crud->setTitle('some string', 'create'); // set the Title for the create action
+$this->crud->setHeading('some string', 'create'); // set the Heading for the create action
+$this->crud->setSubheading('some string', 'create'); // set the Subheading for the create action
+```
+
+These methods are usually useful inside actions, not in ```setup()```. Since action methods are called _after_ ```setup()```, any call to these getters and setters in ```setup()``` would get overwritten by the call in the action.
+
+<a name="access-to-operations"></a>
+### Handling Access to Operations
+
+Admins are allowed to do an operation or not using a very simple system: ```$crud->settings['operation_name']['access']``` will either be ```true``` or ```false```. When you enable a stock Backpack operation by doing ```use SomeOperation;``` on your controller, all operations will run ```$this->crud->allowAccess('operation_name');```, which will toggle that variable to ```true```.
+
+You can easily add or remove elements to this access array in your ```setup()``` method, or your custom methods, using:
+```php
+$this->crud->allowAccess('operation_name');
+$this->crud->allowAccess(['list', 'update', 'delete']);
+$this->crud->denyAccess('operation');
+$this->crud->denyAccess(['update', 'create', 'delete']);
+
+$this->crud->hasAccess('operation_name'); // returns true/false
+$this->crud->hasAccessOrFail('create'); // throws 403 error
+$this->crud->hasAccessToAll(['create', 'update']); // returns true/false
+$this->crud->hasAccessToAny(['create', 'update']); // returns true/false
+```
+
+<a name="operation-routes"></a>
+### Operation Routes
+
+Starting with Backpack 4.0, routes can be defined in the CrudController. Your ```routes/backpack/custom.php``` file will have calls like ```Route::crud('product', 'ProductCrudController');```. This ```Route::crud()``` is a macro that will go to that controller and run all the methods that look like ```setupXxxRoutes()```. That means each operation can have its own method to define the routes it needs. And they do - if you check out the code of any operation, you'll see every one of them has a ```setupOperationNameRoutes()``` method. 
+
+If you want to add a new route to your controller, there are two ways to do it:
+1. Add a route in your ```routes/backpack/custom.php```;
+2. Add a method following the ```setupXxxRoutes()``` convention to your controller;
+
+Inside a ```setupOperationNameRoutes()```, you'll notice that's also where we define the operation name:
+
+```php
+    protected function setupShowRoutes($segment, $routeName, $controller)
+    {
+        Route::get($segment.'/{id}/show', [
+            'as'        => $routeName.'.show',
+            'uses'      => $controller.'@show',
+            'operation' => 'show',
+        ]);
+    }
+```
+
+<a name="getting-and-setting-operation"></a>
+### Getting an Operation Name
+
+Once an operation name has been set using that route, you can do ```$crud->getOperation()``` inside your views and do things according to this.
+
+
+<a name="creating-a-custom-operation"></a>
+## Creating a Custom Operation
+
+<a name="create-operation-command"></a>
+### Command-line Tool
+
+If you've installed ```backpack/generators```, you can do ```php artisan backpack:crud-operation {OperationName}``` to generate an empty operation trait, that you can edit and use on your CrudControllers. For example:
+
+```bash
+php artisan backpack:crud-operation Comment
+```
+
+Will generate ```app/Http/Controllers/Admin/Operations/CommentOperation``` with the following contents:
+
+```php
+<?php
+
+namespace App\Http\Controllers\Admin\Operations;
+
+use Illuminate\Support\Facades\Route;
+
+trait CommentOperation
+{
+    /**
+     * Define which routes are needed for this operation.
+     *
+     * @param string $segment    Name of the current entity (singular). Used as the first URL segment.
+     * @param string $routeName  Prefix of the route name.
+     * @param string $controller Name of the current CrudController.
+     */
+    protected function setupCommentRoutes($segment, $routeName, $controller)
+    {
+        Route::get($segment.'/comment', [
+            'as'        => $routeName.'.comment',
+            'uses'      => $controller.'@comment',
+            'operation' => 'comment',
+        ]);
+    }
+
+    /**
+     * Add the default settings, buttons, etc that this operation needs.
+     */
+    protected function setupCommentDefaults()
+    {
+        $this->crud->allowAccess('comment');
+
+        $this->crud->operation('comment', function () {
+            $this->crud->loadDefaultOperationSettingsFromConfig();
+        });
+
+        $this->crud->operation('list', function () {
+            // $this->crud->addButton('top', 'comment', 'view', 'crud::buttons.comment');
+            // $this->crud->addButton('line', 'comment', 'view', 'crud::buttons.comment');
+        });
+    }
+
+    /**
+     * Show the view for performing the operation.
+     *
+     * @return Response
+     */
+    public function comment()
+    {
+        $this->crud->hasAccessOrFail('comment');
+
+        // prepare the fields you need to show
+        $this->data['crud'] = $this->crud;
+        $this->data['title'] = $this->crud->getTitle() ?? 'comment '.$this->crud->entity_name;
+
+        // load the view
+        return view("crud::operations.comment", $this->data);
+    }
+}
+```
+
+You'll notice the generated operation has:
+- a GET route (inside ```setupCommentRoutes()```);
+- a method that sets the defaults for this operation (```setupCommentDefaults()```);
+- a method to perform the operation, or show an interface (```comment()```);
+
+You can customize these to fit the operation you have in mind, then ```use \App\Http\Controllers\Admin\Operations\CommentOperation;``` inside the CrudControllers where you want the operation.
+
+<a name="contents-of-a-custom-operation"></a>
+### Contents of a Custom Operation
+
+Thanks to [Backpack's simple architecture](/docs/{{version}}/crud-basics#architecture), each CRUD panel uses a controller and a route, that are placed inside your project. That means you hold the keys to how this controller works.
+
+To add an operation to an ```EntityCrudController```, you can:
+- decide on your operation name; for example... "publish";
+- create a method that loads the routes inside your controller:
+```php
+    protected function setupPublishRoutes($segment, $routeName, $controller)
+    {
+        Route::get($segment.'/{id}/publish', [
+            'as'        => $routeName.'.publish',
+            'uses'      => $controller.'@publish',
+            'operation' => 'publish',
+        ]);
+    }
+```
+- create a method that performs the operation you want:
+```php
+    public function publish()
+    {
+        // do something
+        // return something
+    }
+```
+- [add a new button for this operation to the List view](/docs/{{version}}/crud-buttons#creating-a-custom-button), or enable access to it, inside a ```setupPublishDefaults()``` method:
+```php
+    protected function setupPublishDefaults()
+    {
+        $this->crud->allowAccess('publish');
+
+        $this->crud->operation('list', function () {
+            $this->crud->addButton('line', 'publish', 'view', 'buttons.publish', 'beginning');
+        });
+    }
+```
+
+Take a look at the examples below for a better picture and code examples.
+
+If you intend to reuse this operation across multiple controllers, you can group all the methods above in a trait, say ```PublishOperation.php``` and then just use that trait on the controllers where you need the operation:
+
+```php
+<?php
+
+namespace App\Http\Controllers\Admin\CustomOperations;
+
+use Illuminate\Support\Facades\Route;
+
+trait PublishOperation
+{
+    protected function setupPublishRoutes($segment, $routeName, $controller)
+    {
+        Route::get($segment.'/{id}/publish', [
+            'as'        => $routeName.'.publish',
+            'uses'      => $controller.'@publish',
+            'operation' => 'publish',
+        ]);
+    }
+
+    protected function setupPublishDefaults()
+    {
+        $this->crud->allowAccess('publish');
+
+        $this->crud->operation('list', function () {
+            $this->crud->addButton('line', 'publish', 'view', 'buttons.publish', 'beginning');
+        });
+    }
+
+    public function publish()
+    {
+        // do something
+        // return something
+    }
+}
+```
+
+In the example above, you could just do ```use \App\Http\Controllers\Admin\CustomOperations\PublishOperation;``` on any EntityCrudController, and your operation will be added - complete with routes, buttons, access, actions, everything.
+
+<a name="access-to-custom-operations"></a>
+### Access to Custom Operations
+
+Since you're creating a new operation, in terms of restricting access you can:
+1. allow access to this new operation depending on access to a default operation (usually if the admin can ```update```, he's ok to perform custom operations);
+2. customize access to this particular operation, by just using a different key than the default ones; for example, you can allow access by using ```$this->crud->allowAccess('publish')``` in your ```setup()``` method, then check for access to that operation using ```$this->crud->hasAccess('publish')```;
+
+<a name="operation-features"></a>
+### Adding Settings to the CrudPanel object
+
+#### Using the Settings API
+
+Anything an operation does to configure itself, or process information, should be stored inside ```$this->crud->settings``` . It's an associative array, and you can add/change things using the Settings API:
+
+```php
+// for the operation that is currently being performed
+$this->crud->setOperationSetting('show_title', true);
+$this->crud->getOperationSetting('show_title');
+$this->crud->hasOperationSetting('show_title');
+
+// for a particular operation, pass the operation name as a last parameter 
+$this->crud->setOperationSetting('show_title', true, 'create');
+$this->crud->getOperationSetting('show_title', 'create');
+$this->crud->hasOperationSetting('show_title', 'create');
+
+// alternatively, you could use the direct methods with no fallback to the current operation
+$this->crud->set('create.show_title', false);
+$this->crud->get('create.show_title');
+$this->crud->has('create.show_title');
+```
+
+#### Using the crud config file
+
+Additionally, operations can load default settings from the config file. You'll notice the ```config/backpack/crud.php``` file contains an array of operations, each with various settings. Those settings there are loaded by the operation as defaults, to allow users to change one setting in the config, and have that default changed across ALL of their CRUDs. If you take a look at the List operation you'll notice this:
+
+```php
+    /**
+     * Add the default settings, buttons, etc that this operation needs.
+     */
+    protected function setupListDefaults()
+    {
+        $this->crud->allowAccess('list');
+
+        $this->crud->operation('list', function () {
+            $this->crud->loadDefaultOperationSettingsFromConfig();
+        });
+    }
+```
+
+You can do the same in custom operations. Because this call happens in setupListDefaults(), inside an operation closure, the settings will only be added when that operation is being performed.
+
+
+<a name="adding-methods-to-the-crud-panel-object"></a>
+### Adding Methods to the CrudPanel Object
+
+You can add static methods to this ```$this->crud``` (which is a CrudPanel object) object with ```$this->crud->macro()```, because the object is [macroable](https://unnikked.ga/understanding-the-laravel-macroable-trait-dab051f09172). So you can do:
+
+```php
+class MonsterCrudController extends CrudController 
+{
+   public function setup() 
+   {
+       $this->crud->macro('doStuff', function($something) {
+            echo '<pre>'; var_dump($something); echo '</pre>';
+            dd($this);
+        });
+       $this->crud->macro('getColumnsInTheFormatIWant', function() {
+            $columns = $this->columns();
+            // ... do something to $columns;
+            return $columns;
+        });
+
+       // bla-bla-bla the actual setup code
+   }
+   public function sendEmail() 
+   {
+      // ...
+      $this->crud->doStuff();
+      dd($this->crud->getColumnsInTheFormatIWant());
+      // ...
+   }
+   public function markPending() 
+   {
+      // ...
+      $this->crud->doStuff();
+      dd($this->crud->getColumnsInTheFormatIWant());
+      // ...
+   }
+}
+```
+
+So if you define a custom operation that needs some static methods added to the ```CrudPanel``` object, you can add them. The best place to register your macros in a custom operation would probably be inside your ```setupXxxDefaults()``` method, inside an operation closure. That way, the static methods you add are only added when that operation is being performed. For example:
+
+```php
+protected function setupPrintDefaults()
+{
+    $this->crud->allowAccess('print');
+    
+    $this->crud->operation('print', function() {
+       $this->crud->macro('getColumnsInTheFormatIWant', function() {
+            $columns = $this->columns();
+            // ... do something to $columns;
+            return $columns;
+        });
+    });
+}
+```
+
+With the example above, you'll be able to use ```$this->crud->getColumnsInTheFormatIWant()``` inside your operation actions.
+
+<a name="using-a-feature-from-another-operation"></a>
+### Using a feature from another operation
+
+Anything an operation does to configure itself, or process information, is stored on the ```$this->crud->settings``` property. Operation features (ex: fields, columns, buttons, filters, etc) are created in such a way that all they do is add an entry in settings, for an operation, and manipulate it. That means there is nothing stopping you from using a feature from one operation in a different operation.
+
+If you create a Print operation, and want to use the ```columns``` feature that List and Show use, you can just go ahead and do ```$this->crud->addColumn()``` calls inside your operation. You'll notice the columns are stored inside ```$this->crud->settings['print.columns']```, so they're completely different from the ones in the List or Show operation. You'll need to actually do something with the columns you added, inside your operation methods or views - of course.
+
+
+<a name="examples"></a>
+### Examples
+
+<a name="creatig-a-new-operation-with-no-interface"></a>
+#### Creating a New Operation With No Interface
+
+Let's say we have a ```UserCrudController``` and we want to create a simple ```Clone``` operation, which would create another entry with the same info. So very similar to ```Delete```. What we need to do is:
+
+1. Create a route for this operation - as we've learned above we can do that in a ```setupXxxRoutes()``` method:
+
+```php
+    protected function setupPublishRoutes($segment, $routeName, $controller)
+    {
+        Route::get($segment.'/{id}/clone', [
+            'as'        => $routeName.'.clone',
+            'uses'      => $controller.'@clone',
+            'operation' => 'clone',
+        ]);
+    }
+```
+
+2. Add the method inside ```UserCrudController```:
+
+```php
+public function clone($id) 
+{
+    $this->crud->hasAccessOrFail('create');
+    $this->crud->setOperation('Clone');
+
+    $clonedEntry = $this->crud->model->findOrFail($id)->replicate();
+
+    return (string) $clonedEntry->push();
+}
+```
+
+3. Create a button for this method. Since our operation is similar to "Delete", lets start from that one and customize what we need. The button should clone the entry using an AJAX call. No need to load another page for an operation this simple. We'll create a ```resources\views\vendor\backpack\crud\buttons\clone.blade.php``` file:
+
+```php
+@if ($crud->hasAccess('create'))
+	<a href="javascript:void(0)" onclick="cloneEntry(this)" data-route="{{ url($crud->route.'/'.$entry->getKey().'/clone') }}" class="btn btn-xs btn-default" data-button-type="clone"><i class="fa fa-clone"></i> Clone</a>
+@endif
+
+{{-- Button Javascript --}}
+{{-- - used right away in AJAX operations (ex: List) --}}
+{{-- - pushed to the end of the page, after jQuery is loaded, for non-AJAX operations (ex: Show) --}}
+@push('after_scripts') @if (request()->ajax()) @endpush @endif
+<script>
+	if (typeof cloneEntry != 'function') {
+	  $("[data-button-type=clone]").unbind('click');
+
+	  function cloneEntry(button) {
+	      // ask for confirmation before deleting an item
+	      // e.preventDefault();
+	      var button = $(button);
+	      var route = button.attr('data-route');
+
+          $.ajax({
+              url: route,
+              type: 'POST',
+              success: function(result) {
+                  // Show an alert with the result
+                  new Noty({
+                    type: "success",
+                    text: "<strong>Entry cloned</strong><br>A new entry has been added, with the same information as this one."
+                  }).show();
+
+                  // Hide the modal, if any
+                  $('.modal').modal('hide');
+
+                  if (typeof crud !== 'undefined') {
+                    crud.table.ajax.reload();
+                  }
+              },
+              error: function(result) {
+                  // Show an alert with the result
+                  new Noty({
+                    type: "warning",
+                    text: "<strong>Cloning failed</strong><br>The new entry could not be created. Please try again."
+                  }).show();
+              }
+          });
+      }
+	}
+
+	// make it so that the function above is run after each DataTable draw event
+	// crud.addFunctionToDataTablesDrawEventQueue('cloneEntry');
+</script>
+@if (!request()->ajax()) @endpush @endif
+```
+
+4. We can now actually add this button to our ```UserCrudController::setupCloneOperation()``` method, or our ```setupCloneDefaults()``` method:
+
+```php
+protected function setupCloneDefaults() {
+  $this->crud->allowAccess('clone');
+
+  $this->crud->operation(['list', 'show'], function () {
+    $this->crud->addButtonFromView('line', 'clone', 'clone', 'beginning');
+  });
+}
+```
+
+>Of course, **if you plan to re-use this operation on another EntityCrudController**, it's a good idea to isolate the method inside a trait, then use that trait on each EntityCrudController where you want the operation to work.
+
+<a name="creating-a-new-operation-with-an-interface"></a>
+#### Creating a New Operation With An Interface
+
+Let's say we have a ```UserCrudController``` and we want to create a simple ```Moderate``` operation, where we show a form where the admin can add his observations and what not. In this respect, it should be similar to ```Update``` - the button should lead to a separate form, then that form will probably have a Save button. So when creating the methods, we should look at ```CrudController::edit()``` and ```CrudController::updateCrud()``` for working examples.
+
+What we need to do is:
+
+1. Create routes for this operation - we can do that using the ```setupOperationNameRoutes()``` convention inside a ```UserCrudController```:
+
+```php
+    protected function setupModerateRoutes($segment, $routeName, $controller)
+    {
+        Route::get($segment.'/{id}/moderate', [
+            'as'        => $routeName.'.getModerate',
+            'uses'      => $controller.'@getModerateForm',
+            'operation' => 'moderate',
+        ]);
+        Route::post($segment.'/{id}/moderate', [
+            'as'        => $routeName.'.postModerate',
+            'uses'      => $controller.'@postModerateForm',
+            'operation' => 'moderate',
+        ]);
+    }
+```
+
+2. Add the methods inside ```UserCrudController```:
+
+```php
+public function getModerateForm($id) 
+{
+    $this->crud->hasAccessOrFail('update');
+    $this->crud->setOperation('Moderate');
+
+    // get the info for that entry
+    $this->data['entry'] = $this->crud->getEntry($id);
+    $this->data['crud'] = $this->crud;
+    $this->data['title'] = 'Moderate '.$this->crud->entity_name;
+
+    return view('vendor.backpack.crud.moderate', $this->data);
+}
+
+public function postModerateForm(Request $request = null)
+{
+    $this->crud->hasAccessOrFail('update');
+
+    // TODO: do whatever logic you need here
+    // ...
+    // You can use 
+    // - $this->crud
+    // - $this->crud->getEntry($id)
+    // - $request
+    // ...
+
+    // show a success message
+    \Alert::success('Moderation saved for this entry.')->flash();
+
+    return \Redirect::to($this->crud->route);
+}
+```
+
+3. Create the ```/resources/views/vendor/backpack/crud/moderate.php``` blade file, which shows the moderate form and what not. Best to start from the ```edit.blade.php``` file and customize:
+
+```html
+@extends(backpack_view('layouts.top_left'))
+
+@php
+  $defaultBreadcrumbs = [
+    trans('backpack::crud.admin') => backpack_url('dashboard'),
+    $crud->entity_name_plural => url($crud->route),
+    'Moderate' => false,
+  ];
+
+  // if breadcrumbs aren't defined in the CrudController, use the default breadcrumbs
+  $breadcrumbs = $breadcrumbs ?? $defaultBreadcrumbs;
+@endphp
+
+@section('header')
+  <section class="container-fluid">
+    <h2>
+        <span class="text-capitalize">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
+        <small>{!! $crud->getSubheading() ?? 'Moderate '.$crud->entity_name !!}.</small>
+
+        @if ($crud->hasAccess('list'))
+          <small><a href="{{ url($crud->route) }}" class="hidden-print font-sm"><i class="fa fa-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>
+        @endif
+    </h2>
+  </section>
+@endsection
+
+@section('content')
+<div class="row">
+    <div class="col-md-8 col-md-offset-2">
+          <div class="card">
+            <div class="card-header">
+                <h3 class="card-title">Moderate</h3>
+            </div>
+            <div class="card-body row">
+              Something in the card body
+            </div><!-- /.card-body -->
+
+            <div class="card-footer">
+                Something in the box footer
+            </div><!-- /.card-footer-->
+          </div><!-- /.card -->
+          </form>
+    </div>
+</div>
+@endsection
+
+```
+
+4. Create a button for this operation. Since our operation is similar to "Update", lets start from that one and customize what we need. The button should just take the admin to the route that shows the Moderate form. Nothing fancy. We'll create a ```resources\views\vendor\backpack\crud\buttons\moderate.blade.php``` file:
+
+```php
+@if ($crud->hasAccess('moderate'))
+    <a href="{{ url($crud->route.'/'.$entry->getKey().'/moderate') }}" class="btn btn-sm btn-link"><i class="fa fa-list"></i> Moderate</a>
+@endif
+```
+
+4. We can now actually add this button to our ```UserCrudController::setup()```, to register that button inside the List operation:
+
+```php
+$this->crud->operation('list', function() {
+  $this->crud->addButtonFromView('line', 'moderate', 'moderate', 'beginning');  
+});
+```
+
+Or better yet, we can do this inside a ```setupModerateDefaults()``` method, which gets called automatically by CrudController when the ```moderate``` operation is being performed (thanks to the operation name set on the routes):
+
+```php
+protected function setupModerateDefaults()
+{
+  $this->crud->allowAccess('moderate');
+
+  $this->crud->operation('list', function() {
+    $this->crud->addButtonFromView('line', 'moderate', 'moderate', 'beginning');  
+  });
+}
+```
+
+>Of course, **if you plan to re-use this operation on another EntityCrudController**, it's a good idea to isolate the method inside a trait, then use that trait on each EntityCrudController where you want the operation to be enabled.
+
+```php
+<?php
+
+namespace App\Http\Controllers\Admin\CustomOperations;
+
+use Illuminate\Support\Facades\Route;
+
+trait ModerateOperation
+{
+    protected function setupModerateRoutes($segment, $routeName, $controller)
+    {
+        Route::get($segment.'/{id}/moderate', [
+            'as'        => $routeName.'.getModerate',
+            'uses'      => $controller.'@getModerateForm',
+            'operation' => 'moderate',
+        ]);
+        Route::post($segment.'/{id}/moderate', [
+            'as'        => $routeName.'.postModerate',
+            'uses'      => $controller.'@postModerateForm',
+            'operation' => 'moderate',
+        ]);
+    }
+
+    protected function setupmoderateDefaults()
+    {
+        $this->crud->allowAccess('moderate');
+
+        $this->crud->operation('list', function() {
+          $this->crud->addButtonFromView('line', 'moderate', 'moderate', 'beginning');  
+        });
+    }
+
+    public function getModerateForm($id) 
+    {
+        $this->crud->hasAccessOrFail('update');
+        $this->crud->setOperation('Moderate');
+
+        // get the info for that entry
+        $this->data['entry'] = $this->crud->getEntry($id);
+        $this->data['crud'] = $this->crud;
+        $this->data['title'] = 'Moderate '.$this->crud->entity_name;
+
+        return view('vendor.backpack.crud.moderate', $this->data);
+    }
+
+    public function postModerateForm(Request $request = null)
+    {
+        $this->crud->hasAccessOrFail('update');
+
+        // TODO: do whatever logic you need here
+        // ...
+        // You can use 
+        // - $this->crud
+        // - $this->crud->getEntry($id)
+        // - $request
+        // ...
+
+        // show a success message
+        \Alert::success('Moderation saved for this entry.')->flash();
+
+        return \Redirect::to($this->crud->route);
+    }
+}
+```
+
+<a name="creating-a-new-operation-with-bulk-action"></a>
+#### Creating a New Operation With a Bulk Action (No Interface)
+
+Say we want to create a ```BulkClone``` operation, with a button which clones multiple entries at the same time. So very similar to our ```BulkDelete```. What we need to do is:
+
+1. Create a new button:
+
+```html
+@if ($crud->hasAccess('bulkClone') && $crud->get('list.bulkActions'))
+  <a href="javascript:void(0)" onclick="bulkCloneEntries(this)" class="btn btn-sm btn-secondary bulk-button"><i class="fa fa-clone"></i> Clone</a>
+@endif
+
+@push('after_scripts')
+<script>
+  if (typeof bulkCloneEntries != 'function') {
+    function bulkCloneEntries(button) {
+
+        if (typeof crud.checkedItems === 'undefined' || crud.checkedItems.length == 0)
+        {
+            new Noty({
+            type: "warning",
+            text: "<strong>{{ trans('backpack::crud.bulk_no_entries_selected_title') }}</strong><br>{{ trans('backpack::crud.bulk_no_entries_selected_message') }}"
+          }).show();
+
+          return;
+        }
+
+        var message = "Are you sure you want to clone these :number entries?";
+        message = message.replace(":number", crud.checkedItems.length);
+
+        // show confirm message
+        swal({
+        title: "{{ trans('backpack::base.warning') }}",
+        text: message,
+        icon: "warning",
+        buttons: {
+          cancel: {
+          text: "{{ trans('backpack::crud.cancel') }}",
+          value: null,
+          visible: true,
+          className: "bg-secondary",
+          closeModal: true,
+        },
+          delete: {
+          text: "Clone",
+          value: true,
+          visible: true,
+          className: "bg-primary",
+        }
+        },
+      }).then((value) => {
+        if (value) {
+          var ajax_calls = [];
+              var clone_route = "{{ url($crud->route) }}/bulk-clone";
+
+          // submit an AJAX delete call
+          $.ajax({
+            url: clone_route,
+            type: 'POST',
+            data: { entries: crud.checkedItems },
+            success: function(result) {
+              // Show an alert with the result
+                    new Noty({
+                    type: "success",
+                    text: "<strong>Entries cloned</strong><br>"+crud.checkedItems.length+" new entries have been added."
+                  }).show();
+
+              crud.checkedItems = [];
+              crud.table.ajax.reload();
+            },
+            error: function(result) {
+              // Show an alert with the result
+                    new Noty({
+                    type: "danger",
+                    text: "<strong>Cloning failed</strong><br>One or more entries could not be created. Please try again."
+                  }).show();
+            }
+          });
+        }
+      });
+      }
+  }
+</script>
+@endpush
+```
+
+2. Create a method in your EntityCrudController (or in a trait, if you want to re-use it for multiple CRUDs):
+
+```php
+    public function bulkClone()
+    {
+        $this->crud->hasAccessOrFail('create');
+
+        $entries = $this->crud->getRequest()->input('entries');
+        $clonedEntries = [];
+
+        foreach ($entries as $key => $id) {
+            if ($entry = $this->crud->model->find($id)) {
+                $clonedEntries[] = $entry->replicate()->push();
+            }
+        }
+
+        return $clonedEntries;
+    }
+```
+
+3. Add a route to point to this new method:
+
+```php
+protected function setupBulkCloneRoutes($segment, $routeName, $controller)
+{
+    Route::post($segment.'/bulk-clone', [
+        'as'        => $routeName.'.bulkClone',
+        'uses'      => $controller.'@bulkClone',
+        'operation' => 'bulkClone',
+    ]);
+}
+```
+
+4. Setup the default features we need for the operation to work:
+
+```php
+protected function setupBulkCloneDefaults()
+{
+    $this->crud->allowAccess('bulkClone');
+
+    $this->crud->operation('list', function () {
+        $this->crud->enableBulkActions();
+        $this->crud->addButton('bottom', 'bulk_clone', 'view', 'bulk_clone', 'beginning');
+    });
+}
+```
+
+
+Now there's a Clone button on our List bottom stack, that works as expected for multiple entries.
+
+The button makes one call for all entries, and only triggers one notification. If you would rather make a call for each entry, you can use something like below:
+
+```html
+@if ($crud->hasAccess('create') && $crud->bulk_actions)
+  <a href="javascript:void(0)" onclick="bulkCloneEntries(this)" class="btn btn-sm btn-secondary bulk-button"><i class="fa fa-clone"></i> Clone</a>
+@endif
+
+@push('after_scripts')
+<script>
+  if (typeof bulkCloneEntries != 'function') {
+    function bulkCloneEntries(button) {
+
+        if (typeof crud.checkedItems === 'undefined' || crud.checkedItems.length == 0)
+        {
+          new PNotify({
+                title: "{{ trans('backpack::crud.bulk_no_entries_selected_title') }}",
+                text: "{{ trans('backpack::crud.bulk_no_entries_selected_message') }}",
+                type: "warning"
+            });
+
+          return;
+        }
+
+        var message = "Are you sure you want to clone these :number entries?";
+        message = message.replace(":number", crud.checkedItems.length);
+
+        // show confirm message
+        if (confirm(message) == true) {
+            var ajax_calls = [];
+
+            // for each crud.checkedItems
+            crud.checkedItems.forEach(function(item) {
+              var clone_route = "{{ url($crud->route) }}/"+item+"/clone";
+
+              // submit an AJAX delete call
+              ajax_calls.push($.ajax({
+                  url: clone_route,
+                  type: 'POST',
+                  success: function(result) {
+                      // Show an alert with the result
+                      new Noty({
+                        type: "success",
+                        text: "<strong>Entries cloned</strong><br>"+crud.checkedItems.length+" new entries have been added."
+                      }).show();
+                  },
+                  error: function(result) {
+                      // Show an alert with the result
+                      new Noty({
+                        type: "danger",
+                        text: "<strong>Cloning failed</strong><br>One or more entries could not be created. Please try again."
+                      }).show();
+                  }
+              }));
+
+          });
+
+          $.when.apply(this, ajax_calls).then(function ( ajax_calls ) {
+              crud.checkedItems = [];
+              crud.table.ajax.reload();
+        });
+        }
+      }
+  }
+</script>
+@endpush
+```

--- a/5.x-dev/crud-save-actions.md
+++ b/5.x-dev/crud-save-actions.md
@@ -1,0 +1,131 @@
+# Save Actions
+
+---
+
+<a name="about"></a>
+## About
+
+`Create` and `Update` forms end in a Save button with a drop menu. Every option in that dropdown is a SaveAction - they determine where the user is redirected after the saving is complete.
+
+<a name="defaults"></a>
+## Default Save Actions
+
+There are three save actions registered by Backpack by default. They are:
+  - ```save_and_back``` (Save your entity and go back to previous URL)
+  - ```save_and_edit``` (Save and edit the current entry)
+  - ```save_and_new``` (Save and go to create new entity page)
+
+<a name="save-actions-api"></a>
+## Save Actions API
+
+Inside your CrudController, inside your ```setupCreateOperation()``` or ```setupUpdateOperation()``` methods, you can change what save buttons are shown for each operation by using the methods below:
+
+#### addSaveAction(array $saveAction)
+
+Adds a new SaveAction to the "Save" button/dropdown.
+
+```php
+$this->crud->addSaveAction([
+    'name' => 'save_action_one',
+    'redirect' => function($crud, $request, $itemId) {
+        return $crud->route;
+    }, // what's the redirect URL, where the user will be taken after saving?
+
+    // OPTIONAL:
+    'button_text' => 'Custom save message', // override text appearing on the button
+    // You can also provide translatable texts, for example:
+    // 'button_text' => trans('backpack::crud.save_action_one'),
+    'visible' => function($crud) {
+        return true;
+    }, // customize when this save action is visible for the current operation
+    'referrer_url' => function($crud, $request, $itemId) {
+        return $crud->route;
+    }, // override http_referrer_url
+    'order' => 1, // change the order save actions are in
+]);
+```
+
+#### addSaveActions(array $saveActions)
+
+The same principle of `addSaveAction([])` but for adding multiple actions with only one crud call.
+
+```php
+$this->crud->addSaveActions([
+    [
+        'name' => 'save_action_one',
+        'visible' => function($crud) {
+            return true;
+        },
+        'redirect' => function($crud, $request, $itemId) {
+            return $crud->route;
+        },
+    ],
+    [
+        'name' => 'save_action_two',
+        'visible' => function($crud) {
+            return true;
+        },
+        'redirect' => function($crud, $request, $itemId) {
+            return $crud->route;
+        },
+    ],
+]);
+``` 
+
+#### replaceSaveActions(array $saveActions)
+
+This allows you to replace the current save actions with the ones provided in an array. 
+
+```php
+$this->crud->replaceSaveActions(
+    [
+        'name' => 'save_action_one',
+        'visible' => function($crud) {
+            return true;
+        },
+        'redirect' => function($crud, $request, $itemId) {
+            return $crud->route;
+        },
+    ],
+);
+``` 
+
+
+#### removeSaveAction(string $saveAction)
+
+This allows you to remove a specific save action from the save actions array. Provide the name of the save action that you would like to remove.
+```php
+$this->crud->removeSaveAction('save_action_one');
+```
+
+#### removeSaveActions(array $saveActions)
+
+The same principle as `removeSaveAction()` but to remove multiple actions at same time. You should provide an array with save action names.
+```php
+$this->crud->removeSaveActions(['save_action_one','save_action_two']);
+```
+
+#### orderSaveAction(string $saveAction, int $wantedOrder)
+
+You can specify a certain order for a certain save action.
+
+```php
+$this->crud->orderSaveAction('save_action_one', 1);
+```
+
+We will setup the save action in the desired order and try to re-order the other save actions accordingly. If you want more granular control over all save actions order, you can define ```order``` when creating the save action, or use ```orderSaveActions()```
+
+#### orderSaveActions(array $saveActions)
+
+Allows you to reorder multiple save actions at same time. You can use it by either specifying only the names of the save actions, in the order you want, or by specifying their order number too:
+
+```php
+// make save actions show up in this order
+$this->crud->orderSaveActions(['save_action_one','save_action_two']);
+// or
+$this->crud->orderSaveActions(['save_action_one' => 3,'save_action_two' => 2]);
+```
+
+#### setSaveActions(array $saveActions)
+
+Alias for ```replaceSaveActions(array $saveActions)```.

--- a/5.x-dev/crud-tutorial.md
+++ b/5.x-dev/crud-tutorial.md
@@ -1,0 +1,382 @@
+# CRUD Crash Course
+
+---
+
+What's the simplest entity you can think of? It will probably be something like ```Tag```, which only holds an ```id``` and a ```name```. Let's create this new entity in the database, the model for it, then create a CRUD Panel to let admins manage entries for this entity.
+
+We assume:
+- you've [installed Backpack](/docs/{{version}}/installation);
+- you don't already have a ```Tag``` model in your project;
+
+<a name="generate-files"></a>
+## Generate Files
+
+> **NEW!!!** Starting with Aug 2021, there's a much simpler way to generate everything 🎉 **Check out our new paid addon - [Backpack DevTools](https://backpackforlaravel.com/products/devtools).** It's a GUI that will help you generate Migrations, Models (complete with relationships), CRUDs from the browser 😱 It does cost extra, but it's well worth the price if you use Backpack regularly or your models are not dead-simple.
+
+Since we don't have an Eloquent model for it already, we're going to use [Jeffrey Way's Generators](https://github.com/laracasts/Laravel-5-Generators-Extended) package, which you've most likely installed along with Backpack, to generate the migration. 
+
+```zsh
+# install a 3rd party tool to generate migrations from the command line
+composer require --dev laracasts/generators
+
+# generate a migration and run it
+php artisan make:migration:schema create_tags_table --schema="name:string:unique"
+php artisan migrate
+```
+
+Now that we have the ```tags``` table in the database, let's generate the actual files we'll be using:
+
+```zsh
+php artisan backpack:crud tag #use singular, not plural
+```
+
+The code above will have generated:
+- a migration (```database/migrations/yyyy_mm_dd_xyz_create_tags_table.php```);
+- a database table (```tags``` with just two columns: ```id``` and ```name```);
+- a model (```app/Models/Tag.php```);
+- a controller (```app/Http/Controllers/Admin/TagCrudController.php```);
+- a request (```app/Http/Requests/TagCrudRequest.php```);
+- a resource route, as a line inside ```routes/backpack/custom.php```;
+- a new item in the sidebar menu, in ```resources/views/vendor/backpack/base/inc/sidebar_content.blade.php```;
+
+**Next up:** we'll need to go through the generated files, and customize for our needs.
+
+<a name="customize-generated-files"></a>
+## Customize Generated Files
+
+We'll skip the migration and database table, since there's nothing there specific to Backpack, nothing to customize, and we've already run the migration.
+
+<a name="the-model"></a>
+### The Model
+
+Let's take a look at the generated model:
+
+```php
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Backpack\CRUD\app\Models\Traits\CrudTrait;
+
+class Tag extends Model {
+
+  use CrudTrait;
+
+  /*
+  |--------------------------------------------------------------------------
+  | GLOBAL VARIABLES
+  |--------------------------------------------------------------------------
+  */
+
+  protected $table = 'tags';
+  // protected $primaryKey = 'id';
+  // public $timestamps = false;
+  protected $guarded = ['id'];
+  // protected $fillable = [];
+  // protected $hidden = [];
+  // protected $dates = [];
+
+  /*
+  |--------------------------------------------------------------------------
+  | FUNCTIONS
+  |--------------------------------------------------------------------------
+  */
+
+  /*
+  |--------------------------------------------------------------------------
+  | RELATIONS
+  |--------------------------------------------------------------------------
+  */
+
+  /*
+  |--------------------------------------------------------------------------
+  | SCOPES
+  |--------------------------------------------------------------------------
+  */
+
+  /*
+  |--------------------------------------------------------------------------
+  | ACCESSORS
+  |--------------------------------------------------------------------------
+  */
+
+  /*
+  |--------------------------------------------------------------------------
+  | MUTATORS
+  |--------------------------------------------------------------------------
+  */
+}
+```
+
+As we can see, this is a pretty standard Eloquent model. The only differences:
+- our new model uses a trait Backpack needs, ```CrudTrait```;
+- we have some comments to help us separate Eloquent logic in our Models;
+
+By default, the model uses ```$guarded``` to prevent people from editing certain attributes. But, as with all generated classes, it might not be exactly what you want. We should make sure:
+- ```$table``` contains the right table name (it does);
+- ```$guarded``` contains all the attributes we want the admin to NOT be able to change; alternatively, specify which fields the admin is _allowed_ to edit using ```$fillable```; 
+- relationships to other models are properly defined (no need for our ```Tag``` model);
+
+This is all _standard procedure_ for new Laravel models - nothing Backpack-specific here. In this particular case, where the entity is so simple and has no relationships, we don't need to make any changes to the generated model.
+
+We're now done configuring the model - because we didn't already have a valid Eloquent model to use for our CRUD Panel. If we _did have_ a working Eloquent model, we only needed to add ```use \Backpack\CRUD\app\Models\Traits\CrudTrait;```
+
+<a name="the-controller"></a>
+### The Controller
+
+Let's take a look at ```app/Http/Controllers/Admin/TagCrudController.php```. It should look something like this:
+
+```php
+<?php namespace App\Http\Controllers\Admin;
+
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+use App\Http\Requests\TagRequest;
+
+class TagCrudController extends CrudController {
+
+  use \Backpack\CRUD\app\Http\Controllers\Operations\ListOperation;
+  use \Backpack\CRUD\app\Http\Controllers\Operations\CreateOperation;
+  use \Backpack\CRUD\app\Http\Controllers\Operations\UpdateOperation;
+  use \Backpack\CRUD\app\Http\Controllers\Operations\DeleteOperation;
+  use \Backpack\CRUD\app\Http\Controllers\Operations\ShowOperation;
+
+  public function setup() 
+  {
+      $this->crud->setModel("App\Models\Tag");
+      $this->crud->setRoute("admin/tag");
+      $this->crud->setEntityNameStrings('tag', 'tags');
+  }
+  
+  protected function setupListOperation()
+  {
+      // TODO: remove setFromDb() and manually define Columns, maybe Filters
+      $this->crud->setFromDb();
+  }
+
+  protected function setupCreateOperation()
+  {
+      $this->crud->setValidation(TagRequest::class);
+
+      // TODO: remove setFromDb() and manually define Fields
+      $this->crud->setFromDb();
+  }
+
+  protected function setupUpdateOperation()
+  {
+      $this->setupCreateOperation();
+  }
+}
+```
+
+#### The Basics
+
+What we should notice inside this TagCrudController is that:
+- ```TagCrudController extends CrudController```;
+- ```TagCrudController``` has a ```setup()``` method, where can plug in the basics of our CRUD panel; everything we write here is applied on ALL operations;
+- All operations are enabled by using that operation's trait on the controller;
+- Each operation is set up inside a ```setupXxxOperation()``` method;
+
+As we can tell from the comments in our ```setupXxxOperation()``` methods, in most cases we _shouldn't_ use ```$this->crud->setFromDb()```, which automagically figures out which columns and fields to show. That's because for real models, in real projects, it would _never_ be able to 100% figure out which field types to use. Real projects are very custom - that's a fact. In real projects, models are complicated, use a bunch of field types and you'll want to customize things. Instead of using ```setFromDb()``` then gradually changing what you don't like, **we heavily recommend you manually define all fields and columns you need**.
+
+That being said, since our ```Tag``` model is so simple, we _can_ leave it like this - it will work perfectly, since we only need a ```text``` field and a ```text``` column. But let's not do that. Let's define our fields and columns manually, like big boys & girls. 
+
+#### Option 1. SetupXxxOperation Methods
+
+We can either define each operations inside its ```setupXxxOperation()``` method:
+
+```php
+  protected function setupListOperation()
+  {
+      $this->crud->addColumn(['name' => 'name', 'type' => 'text', 'label' => 'Name']);
+  }
+
+  protected function setupCreateOperation()
+  {
+      $this->crud->setValidation(TagRequest::class);
+      $this->crud->addField(['name' => 'name', 'type' => 'text', 'label' => 'Name']);
+  }
+
+  protected function setupUpdateOperation()
+  {
+      $this->setupCreateOperation(); // since this calls the methods above, no need to do anything here
+  }
+```
+
+This will:
+- disable the ```setFromDb()``` functionality (since we deleted that line);
+- add a simple ```text``` column for our ```name``` attribute for the List operation (the table view);
+- add a simple ```text``` field for our ```name``` attribute to the Create and Update forms;
+
+It's the exact same thing ```setFromDb()``` would have figured out, but done manually. This way, if we want to add [other columns](/docs/{{version}}/crud-columns)) or [other fields](/docs/{{version}}/crud-fields), we can easily do that. If we want to change the label of the ```name``` field from ```Name``` to ```Tag name```, we just make that small change. The benefits of _not_ using ```setFromDb()``` will be more obvious once you use Backpack on real models, we promise.
+
+#### Option 2. Operation Closures
+
+An alternative to defining operation inside ```setupXxxOperation()``` methods is to do it inside the ```setup()``` method. However, as we've mentioned before, everything you run in your ```setup()``` method is run for ALL operations. So you can easily end up bloating your operation with unnecessary operations. If you don't like having a method to configure each operation, and would like to define everything in ```setup()```, you should do so inside an ```operation()``` closure. Whatever's inside that closure will only be run for that operation. For example, everything we've done above would look like this if done inside operation closures:
+
+```php
+    public function setup()
+    {
+        $this->crud->setModel('App\Models\Tag');
+        $this->crud->setRoute(config('backpack.base.route_prefix') . '/tag');
+        $this->crud->setEntityNameStrings('tag', 'tags');
+
+        $this->crud->operation('list', function() {
+          $this->crud->addColumn(['name' => 'name', 'type' => 'text', 'label' => 'Name']);
+        });
+
+        $this->crud->operation(['create', 'update'], function() {
+          $this->crud->addValidation(TagCrudRequest::class);
+          $this->crud->addField(['name' => 'name', 'type' => 'text', 'label' => 'Name']);
+        });
+    }
+    
+    
+}
+```
+
+#### Other Calls
+
+Here, inside your ```setup()``` or ```setupXxxOperation``` methods, you can also do a lot of other things, like adding buttons, adding filters, customizing your query, etc. For a full list of the things you can do inside ```setup()``` check out our [cheat sheet](/docs/{{version}}/crud-cheat-sheet). 
+
+Next, let's continue to another generated file.
+
+<a name="the-request"></a>
+### The Request
+
+Backpack will also generate a [standard FormRequest file](https://laravel.com/docs/master/validation#form-request-validation), that you can use for validation of the Create and Update forms. There is nothing Backpack-specific in here, but let's take a look at the generated ```app/Http/Requests/TagRequest.php``` file:
+
+```php
+<?php
+
+namespace App\Http\Requests;
+
+use App\Http\Requests\Request;
+use Illuminate\Foundation\Http\FormRequest;
+
+class TagRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        // only allow updates if the user is logged in
+        return backpack_auth()->check();
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            // 'name' => 'required|min:5|max:255'
+        ];
+    }
+
+    /**
+     * Get the validation attributes that apply to the request.
+     *
+     * @return array
+     */
+    public function attributes()
+    {
+        return [
+            //
+        ];
+    }
+
+    /**
+     * Get the validation messages that apply to the request.
+     *
+     * @return array
+     */
+    public function messages()
+    {
+        return [
+            //
+        ];
+    }
+}
+
+```
+
+This file is a 100% pure FormRequest file - all Laravel, nothing particular to Backpack. In generated FormRequest files, no validation rules are imposed by default. But we do want ```name``` to be ```required``` and ```unique```, so let's do that, using the [standard Laravel validation rules](https://laravel.com/docs/master/validation#available-validation-rules):
+
+```diff
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+-            // 'name' => 'required|min:5|max:255'
++            'name' => 'required|min:5|max:255|unique:tags,name'
+        ];
+    }
+```
+
+> If your validation needs to be different between the Create and Update operations, [you can easily do that too](/docs/{{version}}/crud-operation-create#separate-requests-for-create-and-update), by specifying different FormRequest files for each operation.
+
+<a name="the-route"></a>
+### The Route
+
+We have already generated our CRUD route, and we don't need to do anything about it, but let's check our ```routes/backpack/custom.php```. It should look like this:
+
+```php
+<?php
+
+// --------------------------
+// Custom Backpack Routes
+// --------------------------
+// This route file is loaded automatically by Backpack\Base.
+// Routes you generate using Backpack\Generators will be placed here.
+
+Route::group([
+    'prefix'     => config('backpack.base.route_prefix', 'admin'),
+    'middleware' => ['web', config('backpack.base.middleware_key', 'admin')],
+    'namespace'  => 'App\Http\Controllers\Admin',
+], function () { // custom admin routes
+    // CRUD resources and other admin routes
+    Route::crud('tag', 'TagCrudController');
+}); // this should be the absolute last line of this file
+```
+
+Here, we can see that our routes have been placed:
+- under a prefix that we can change in ```config/backpack/base.php```;
+- under a middleware we can change in ```config/backpack/base.php```;
+- inside the ```App\Http\Controllers\Admin``` namespace, because that's where our custom CrudControllers will be generated;
+
+**It's generally a good idea to have the all admin routes in this separate file.** If you edit this file in the future, make sure you leave the last line intact, so that other routes can be automatically generated inside this file. And of course, add your routes inside this route group, so that:
+- you have a single prefix for your admin routes (ex: ```admin/tag```, ```admin/product```, ```admin/dashboard```);
+- all your admin panel functionality is protected by the same middleware;
+- all your admin panel controllers live in one place (```App\Http\Controllers\Admin```);
+
+<a name="the-menu-item"></a>
+### The Menu Item
+
+We've previously generated a menu item in the ```views/vendor/backpack/base/inc/sidebar_content.php``` file. You'll see this file is pure HTML. This will allow you to customize the menu as much as you want. The "active" state of the menu is done with JavaScript, based on the ```href``` attribute.
+
+This is the bit that has been generated for you:
+
+```php
+<li class='nav-item'><a class='nav-link' href='{{ backpack_url('tag') }}'><i class='nav-icon fa fa-tag'></i> Tags</a></li>
+```
+
+You can of course change anything here, if you want.
+
+<a name="the-result"></a>
+## The result
+
+You are now ready to go to ```your-app-name.domain/admin/tag``` and see your fully functional admin panel for ```Tags```. 
+
+**Congratulations, you should now have a good understanding of how Backpack\CRUD works!** This is a very very basic example, but the process will be identical for Models with 50+ attributes, complicated logic, etc.
+
+If you do have complex models, we _heavily_ recommend you go purchase [Backpack DevTools](https://backpackforlaravel.com/products/devtools) right now. It's the official paid GUI for generating all of the above. And while you're at it, you can [purchase a Backpack license](https://backpackforlaravel.com/pricing) too 😉

--- a/5.x-dev/demo.md
+++ b/5.x-dev/demo.md
@@ -8,23 +8,26 @@ We've put together a working Laravel app (backend-only), that you can install on
 - change stuff in code, to see how easy it is to customize Backpack; 
 
 In this [Demo repository](https://github.com/laravel-backpack/demo), we've:
-- installed Laravel 8;
-- installed Backpack\CRUD on top;
-- created a few demo models (Monsters, Icons, Products) and admin panels for them, using dozens of field types, column types, filters, etc - to show off most of Backpack's default features;
+- installed Laravel 9;
+- installed Backpack\CRUD; <span class="badge badge-pill badge-success">FREE</span>
+- installed Backpack\PRO; <span class="badge badge-pill badge-info">PRO</span>
+- created a few demo models and admin panels for them, using dozens of field types, column types, filters, etc - to show off most of Backpack CRUD + PRO features;
 - installed a few Backpack extensions: PermissionManager, PageManager, LogManager, BackupManager, Settings, MenuCRUD, NewsCRUD;
 
 
->**Don't use this demo to start your real projects.** Please use [the recommended installation procedure](/docs/{{version}}/installation). You don't want all the bogus entities we've created. You don't want all the packages we've used. And you _definitely_ don't want the default admin user. Start from scratch. 
+>**Don't use this demo to start your real projects.** Please use [the recommended installation procedure](/docs/{{version}}/installation). You don't want all the bogus entities we've created. You don't want all the packages we've used. And you _definitely_ don't want the default admin user. Start from scratch!
 
 <a name="preview"></a>
 ## Demo Preview
 
 ![https://user-images.githubusercontent.com/1032474/86720524-c5a1d480-c02d-11ea-87ed-d03b0197eb25.gif](https://user-images.githubusercontent.com/1032474/86720524-c5a1d480-c02d-11ea-87ed-d03b0197eb25.gif)
 
-If you just want to take a look at the Backpack interface and click around, you don't need to install the Demo. **Take a look at [demo.backpackforlaravel.com](https://demo.backpackforlaravel.com/admin) - we've installed for you.** The online demo is wiped and reinstalled every hour, on the hour.
+If you just want to take a look at the Backpack interface and click around, you don't have to install anything. **Take a look at [demo.backpackforlaravel.com](https://demo.backpackforlaravel.com/admin) - we've installed for you.** The online demo is wiped and reinstalled every hour, on the hour.
 
 <a name="installation"></a>
 ## Demo Installation
+
+If you _do_ want to install the Demo and play around, it's easy to do so. But because the demo uses [Backpack/PRO](https://backpackforlaravel.com/products/pro), you need to [purchase that addon first](https://backpackforlaravel.com/products/pro). If you don't like it, we'll happily give you a refund.
 
 1) In your ```Projects``` or ```www``` directory, wherever you host your apps:
 
@@ -34,13 +37,19 @@ git clone https://github.com/Laravel-Backpack/demo.git backpack-demo
 
 2) Set your database information in your ```.env``` file (use ```.env.example``` as an example);
 
-3) Install all the requirements:
+3) Authenticate and install the requirements:
 ``` zsh
 cd backpack-demo
+
+# Tell Composer how to connet to the private Backpack repo.
+# You'll need to replace these with your real token and password:
+composer config http-basic.backpackforlaravel.com [your-token-username] [your-token-password]
+
+# Install all dependencies
 composer install
 ```
 
-4) Populate the database and stuff:
+4) Populate the database:
 ```zsh
 php artisan key:generate
 php artisan migrate
@@ -57,8 +66,8 @@ Once everything's installed, and your database has been set up:
 - Login with email ```admin@example.com```, password ```admin```
 - You can register a different account, to check out the process and see your gravatar inside the admin panel. 
 - By default, registration is open only in your local environment. Check out ```config/backpack/base.php``` to change this and other preferences.
-- Check out the Monsters admin panel - it features over 40 field types.
-- The magic of Backpack is not in its standard functionality, but in how easy it is to code your own, or customize every little bit of it. Our recommendation:
+- Check out the Monsters admin panel - it features over 50 field types.
+- Devs love Backpack not just for its standard functionality, but also for how easy it is to code your own, or customize every little bit of it. Our recommendation:
     - Go through the [CRUD Tutorial](/docs/{{version}}/crud-tutorial) to understand it;
     - Create a new CRUD panel for an entity, using the faster procedure outlined at the end of that page; say... ```car```;
 

--- a/5.x-dev/demo.md
+++ b/5.x-dev/demo.md
@@ -1,0 +1,68 @@
+# Demo
+
+---
+
+We've put together a working Laravel app (backend-only), that you can install on your machine. This should make it easier to:
+- see how it looks & feels;
+- see how it works;
+- change stuff in code, to see how easy it is to customize Backpack; 
+
+In this [Demo repository](https://github.com/laravel-backpack/demo), we've:
+- installed Laravel 8;
+- installed Backpack\CRUD on top;
+- created a few demo models (Monsters, Icons, Products) and admin panels for them, using dozens of field types, column types, filters, etc - to show off most of Backpack's default features;
+- installed a few Backpack extensions: PermissionManager, PageManager, LogManager, BackupManager, Settings, MenuCRUD, NewsCRUD;
+
+
+>**Don't use this demo to start your real projects.** Please use [the recommended installation procedure](/docs/{{version}}/installation). You don't want all the bogus entities we've created. You don't want all the packages we've used. And you _definitely_ don't want the default admin user. Start from scratch. 
+
+<a name="preview"></a>
+## Demo Preview
+
+![https://user-images.githubusercontent.com/1032474/86720524-c5a1d480-c02d-11ea-87ed-d03b0197eb25.gif](https://user-images.githubusercontent.com/1032474/86720524-c5a1d480-c02d-11ea-87ed-d03b0197eb25.gif)
+
+If you just want to take a look at the Backpack interface and click around, you don't need to install the Demo. **Take a look at [demo.backpackforlaravel.com](https://demo.backpackforlaravel.com/admin) - we've installed for you.** The online demo is wiped and reinstalled every hour, on the hour.
+
+<a name="installation"></a>
+## Demo Installation
+
+1) In your ```Projects``` or ```www``` directory, wherever you host your apps:
+
+```zsh
+git clone https://github.com/Laravel-Backpack/demo.git backpack-demo
+```
+
+2) Set your database information in your ```.env``` file (use ```.env.example``` as an example);
+
+3) Install all the requirements:
+``` zsh
+cd backpack-demo
+composer install
+```
+
+4) Populate the database and stuff:
+```zsh
+php artisan key:generate
+php artisan migrate
+php artisan db:seed --class="Backpack\Settings\database\seeds\SettingsTableSeeder"
+php artisan db:seed
+```
+
+<a name="usage"></a>
+## Demo Usage 
+
+Once everything's installed, and your database has been set up:
+
+- Your admin panel is available at http://localhost/backpack-demo/admin
+- Login with email ```admin@example.com```, password ```admin```
+- You can register a different account, to check out the process and see your gravatar inside the admin panel. 
+- By default, registration is open only in your local environment. Check out ```config/backpack/base.php``` to change this and other preferences.
+- Check out the Monsters admin panel - it features over 40 field types.
+- The magic of Backpack is not in its standard functionality, but in how easy it is to code your own, or customize every little bit of it. Our recommendation:
+    - Go through the [CRUD Tutorial](/docs/{{version}}/crud-tutorial) to understand it;
+    - Create a new CRUD panel for an entity, using the faster procedure outlined at the end of that page; say... ```car```;
+
+
+>**vhost configurations**
+>
+>Depending on your vhost configuration you might need to access the application via a different url, for example if you're using ```artisan serve``` you can access it on http://127.0.0.1:8000/admin - if you're using Laravel Valet, then it may look like http://backpack-demo.test/admin - you will need to access the url which matches your systems configuration. If you do not understand how to configure your virtual hosts, we suggest [watching Laracasts Episode #1](https://laracasts.com/series/laravel-from-scratch/episodes/1) to quickly get started.

--- a/5.x-dev/faq.md
+++ b/5.x-dev/faq.md
@@ -1,0 +1,100 @@
+# Frequently Asked Questions
+
+---
+
+
+<a name="licensing"></a>
+## Licensing
+
+<a name="no-license-needed-on-localhost"></a>
+### Do I need a license to test Backpack?
+
+You don't need a license code AT ALL, if you're just installing Backpack on localhost. Just go ahead and install Backpack, you'll have zero limitations until you go to production.
+
+
+<a name="licese-for-stagind-domain"></a>
+### Do I need a license to put a project on a testing domain?
+
+Yes, you do need a license code. But not a _separate_ license code. If you've already purchased a license code, you should use the same code for both your staging and production instances - even if the domains are different.
+
+If you're interested in a license code to test your project online, _before_ you purchase a Backpack license - take note that we don't do that. We do not issue licenses for testing an already built app on a staging domain. If you've reached a point where you put your project on a staging server, that should mean Backpack has already helped you or your company save dozens or hundreds of hours of work - so that qualifies as commercial use. We recommend you purchase a license code - you can use the same license code on both your staging and production domain.
+
+An alternative to be able to test a project online, without paying anything, would be to put your project online and bear the annoying notification bubbles. If you don't mind the notification bubbles, you can get a general idea of what's working and what's not. It's not ideal, but it's free.
+
+
+<a name="backpack-license-for-open-source-projects"></a>
+### Do I need a license to create an open-source project?
+
+No, you do not. But there's a huge catch. 
+
+Because Backpack requires a license code to work in production, all users of _your open-source project_ will require a Backpack license code for their apps to work in production. So yes, your project will be open-source, but developers _will_ need to pay for a Backpack license if their project is commercial, or apply for a free non-commercial license on our website. This makes it a bit inconvenient to use Backpack for open-source work, we know that. 
+
+To rephrase and clarify - _you_ don't need a license code to develop an open-source project that uses Backpack. But _your users_ will. And no, if you purchase a Backpack license, your open-source users are not covered by your license, only you are. Even if you do have a Backpack license code, that is for you alone, and you should never _ever_ make that code public, or share it with anybody outside your company. 
+
+We plan to address this inconvenience in Backpack v5, by having a "Backpack Lite" package under MIT License, with limited features. Then you could easily build things on top of that, instead of the main Backpack package. But until then, I'm afraid the problem remains - and the only solution is to clearly state in your README file that your package is open-source, but one of your dependencies requires payment for commercial use. Feel free to email hello@tabacitu.ro with details about your project, for more information.
+
+
+
+<a name="how-do-i-use-a-backpack-license-key"></a>
+### How do I use the Backpack license key I purchased/received? 
+
+There are two places where you can put your Backpack license code:
+
+- (A) inside your .ENV file, ona a new line, as `BACKPACK_LICENSE=xxx`
+- (B) inside your `config/backpack/base.php`, at the bottom, you'll find `'license_code' => env('BACKPACK_LICENSE', false)` - you can replace `false` with your license code (wrapped by single quotes)
+
+Option (A) is the recommended one, because there's no point in saving the license code within the code base (in git), and exposing it to whoever has access to the source code. The Backpack license code is only needed in production, so the best way is to add an environment variable there, in on your production server.
+
+
+<a name="miscellaneous"></a>
+## Miscellaneous
+
+
+<a name="how-do-i-update-backpack"></a>
+### How do I update Backpack to the latest non-breaking version? 
+
+First of all, **run `composer update` on your project**. That will pull in the latest supported version of all your Backpack packages.
+
+Then you should **re-publish the JS and CSS assets**. There are two ways to do that:
+
+(A) Run `php artisan vendor:publish --provider="Backpack\CRUD\BackpackServiceProvider" --tag=public --force`. Please note this will overwrite anything that's already there. This B solution has a downside: _unused files are not removed_. A few files Backpack no longer uses will still be in your public/packages folder, even though they're no longer used.
+
+(B) If you have NOT touched you `public/packages` folder, or placed anything custom inside it:
+- delete the public/packages directory and all its contents;
+- run `php artisan vendor:publish --provider="Backpack\CRUD\BackpackServiceProvider" --tag=public`
+- if you use elFinder, also delete `resources/views/vendor/elfinder` and run `php artisan backpack:filemanager:install`
+
+
+<a name="how-do-i-uninstall-backpack"></a>
+### How do I uninstall Backpack from my project? 
+
+You can remove Backpack from your project pretty easily, if you decide to stop using it. You just have to do the opposite of the installation process:
+
+```bash
+# delete the files Backpack has placed inside your application
+rm -rf app/Http/Middleware/CheckIfAdmin.php
+rm -rf config/backpack
+rm -rf config/gravatar.php
+rm -rf public/packages
+rm -rf resources/views/errors
+rm -rf resources/views/vendor/backpack
+rm -rf routes/backpack
+
+# delete any CrudControllers you've created, so MAYBE:
+rm -rf app/Http/Controllers/Admin
+
+# delete any Requests you've created for your CrudControllers.
+# MAKE SURE YOU DON'T NEED ANYTHING IN THIS DIRECTORY ANYMORE.
+# You might have OTHER requests that are not Backpack-related.
+rm -rf app/Http/Requests 
+
+# (maybe) remove other Backpack dev tools you've used
+composer remove --dev laracasts/generators
+
+# remove Backpack from your composer.json requirements
+composer remove --dev backpack/generators
+composer remove backpack/crud
+
+```
+
+That's it! If you've decided NOT to use Backpack, we'd be super-grateful if you could <a href="mailto:hello@backpackforlaravel.com?subject=Why%20I%20decided%20against%20using%20Backpack&body=Hey%20there%20Backpack%20team%2C%0D%0A%0D%0AHopefully%20my%20experience%20will%20help%20you%20take%20Backpack%20in%20a%20direction%20where%20it'll%20be%20a%20better%20fit%20for%20me%20in%20the%20future.%0D%0A%0D%0AI've%20decided%20to%20NOT%20use%20Backpack%20in%20my%20project%20because...">send us an email</a> telling us WHY you didn't like Backpack, or it didn't fit your project. It might help us take Backpack in a different direction, one where you might want to use it. Thank you 🙏

--- a/5.x-dev/getting-started-advanced-features.md
+++ b/5.x-dev/getting-started-advanced-features.md
@@ -10,29 +10,29 @@ Here are some other cool things Backpack makes easy for you. We recommend going 
 
 <a name="other-operations"></a>
 ## Other Operations
-- [Show](/docs/{{version}}/crud-operation-show) Operation - you can let your admins preview an entry
-- [Reorder](/docs/{{version}}/crud-operation-reorder) Operation - you can reorder and nesting entries (hierarchy tree)
-- [Revisions](/docs/{{version}}/crud-operation-revisions) Operation - you can keep a record of all modifications to an entry, and let your admin revert changes
-- [Clone](/docs/{{version}}/crud-operation-clone) Operation - you can make a copy of an entry;
-- [BulkDelete](/docs/{{version}}/crud-operation-delete) Operation - you can delete multiple items in one go;
-- [BulkClone](/docs/{{version}}/crud-operation-clone) Operation - you can clone multiple items in one go;
+- [Show](/docs/{{version}}/crud-operation-show) Operation - you can let your admins preview an entry <span class="badge badge-pill badge-success">FREE</span>
+- [Reorder](/docs/{{version}}/crud-operation-reorder) Operation - you can reorder and nesting entries (hierarchy tree) <span class="badge badge-pill badge-success">FREE</span>
+- [Revisions](/docs/{{version}}/crud-operation-revisions) Operation - you can keep a record of all modifications to an entry, and let your admin revert changes <span class="badge badge-pill badge-success">FREE</span>
+- [Clone](/docs/{{version}}/crud-operation-clone) Operation - you can make a copy of an entry; <span class="badge badge-pill badge-info">PRO</span>
+- [BulkDelete](/docs/{{version}}/crud-operation-delete) Operation - you can delete multiple items in one go; <span class="badge badge-pill badge-info">PRO</span>
+- [BulkClone](/docs/{{version}}/crud-operation-clone) Operation - you can clone multiple items in one go; <span class="badge badge-pill badge-info">PRO</span>
 
 ---
 
 <a name="other-features"></a>
 ## Other Features
 - **Create & Update**
-    - [Manage files on disk](/docs/{{version}}/crud-how-to#use-the-media-library-file-manager) (media library)
-    - [Fake fields](/docs/{{version}}/crud-fields#optional-fake-field-attributes-stores-fake-attributes-as-json-in)
-    - Translatable models and [multi-language CRUDs](/docs/{{version}}/crud-operation-update#translatable-models)
-    - [Tabs in create/update forms](/docs/{{version}}/crud-fields#split-fields-into-tabs)
+    - [Manage files on disk](/docs/{{version}}/crud-how-to#use-the-media-library-file-manager) (media library) <span class="badge badge-pill badge-success">FREE</span>
+    - [Fake fields](/docs/{{version}}/crud-fields#optional-fake-field-attributes-stores-fake-attributes-as-json-in) <span class="badge badge-pill badge-success">FREE</span>
+    - Translatable models and [multi-language CRUDs](/docs/{{version}}/crud-operation-update#translatable-models) <span class="badge badge-pill badge-success">FREE</span>
+    - [Tabs in create/update forms](/docs/{{version}}/crud-fields#split-fields-into-tabs) <span class="badge badge-pill badge-success">FREE</span>
 
 --
 
 - **ListEntries**
-    - you can add a "+" button next to each entry, to allow the admin to easily preview some quick information that was too big to fit inside a columns - we call it [details row](/docs/{{version}}/crud-operation-list-entries#details-row)
-    - export all visible items in the table by adding [export buttons](/docs/{{version}}/crud-operation-list-entries#export-buttons)
-    - [custom search logic](/docs/{{version}}/crud-columns#custom-search-logic) for the columns in the list view
+    - you can add a "+" button next to each entry, to allow the admin to easily preview some quick information that was too big to fit inside a columns - we call it [details row](/docs/{{version}}/crud-operation-list-entries#details-row) <span class="badge badge-pill badge-success">FREE</span>
+    - export all visible items in the table by adding [export buttons](/docs/{{version}}/crud-operation-list-entries#export-buttons) <span class="badge badge-pill badge-success">FREE</span>
+    - [custom search logic](/docs/{{version}}/crud-columns#custom-search-logic) for the columns in the list view <span class="badge badge-pill badge-success">FREE</span>
 
 
 Additionally, here are a few more ways you can customize your CRUDs:

--- a/5.x-dev/getting-started-advanced-features.md
+++ b/5.x-dev/getting-started-advanced-features.md
@@ -1,0 +1,49 @@
+# 3. Advanced Features
+
+---
+
+**Duration:** 5 min
+
+Here are some other cool things Backpack makes easy for you. We recommend going through them one by one, just browsing. You might not need the feature _right now_, but when _you do_, you'll know how to find it.
+
+---
+
+<a name="other-operations"></a>
+## Other Operations
+- [Show](/docs/{{version}}/crud-operation-show) Operation - you can let your admins preview an entry
+- [Reorder](/docs/{{version}}/crud-operation-reorder) Operation - you can reorder and nesting entries (hierarchy tree)
+- [Revisions](/docs/{{version}}/crud-operation-revisions) Operation - you can keep a record of all modifications to an entry, and let your admin revert changes
+- [Clone](/docs/{{version}}/crud-operation-clone) Operation - you can make a copy of an entry;
+- [BulkDelete](/docs/{{version}}/crud-operation-delete) Operation - you can delete multiple items in one go;
+- [BulkClone](/docs/{{version}}/crud-operation-clone) Operation - you can clone multiple items in one go;
+
+---
+
+<a name="other-features"></a>
+## Other Features
+- **Create & Update**
+    - [Manage files on disk](/docs/{{version}}/crud-how-to#use-the-media-library-file-manager) (media library)
+    - [Fake fields](/docs/{{version}}/crud-fields#optional-fake-field-attributes-stores-fake-attributes-as-json-in)
+    - Translatable models and [multi-language CRUDs](/docs/{{version}}/crud-operation-update#translatable-models)
+    - [Tabs in create/update forms](/docs/{{version}}/crud-fields#split-fields-into-tabs)
+
+--
+
+- **ListEntries**
+    - you can add a "+" button next to each entry, to allow the admin to easily preview some quick information that was too big to fit inside a columns - we call it [details row](/docs/{{version}}/crud-operation-list-entries#details-row)
+    - export all visible items in the table by adding [export buttons](/docs/{{version}}/crud-operation-list-entries#export-buttons)
+    - [custom search logic](/docs/{{version}}/crud-columns#custom-search-logic) for the columns in the list view
+
+
+Additionally, here are a few more ways you can customize your CRUDs:
+- [Custom Views for each CRUD](/docs/{{version}}/crud-how-to#customize-views-for-each-crud-panel)
+- [Custom Content Class for each CRUD](/docs/{{version}}/crud-how-to#resize-the-content-wrapper-for-an-operation)
+- [Custom CSS or JS](/docs/{{version}}/crud-how-to#customize-css-and-js-for-default-crud-operations) for each CRUD Operation
+
+**That's it for today!** Told you we're done with long lessons :-) Hopefully some of the above have peaked your interest and you've clicked to see what Backpack can do. In the [next lesson](/docs/{{version}}/getting-started-license-and-support) we'll go through a few other Backpack packages that cover some recurring use cases.
+
+
+<br>
+<a href="/docs/{{version}}/getting-started-license-and-support" class="btn btn-outline-info shadow">
+  Next  &#xFFEB;
+</a>

--- a/5.x-dev/getting-started-basics.md
+++ b/5.x-dev/getting-started-basics.md
@@ -1,0 +1,163 @@
+# 1. Basics
+
+---
+
+**Duration:** 5 minutes
+
+> **Are you already comfortable with Laravel?** In order to understand this series and make use of Backpack, you'll need to have a decent understanding of the Laravel framework. If you don't, please go ahead and [watch this excellent intro series on Laracasts](https://laracasts.com/series/laravel-from-scratch-2018) and accommodate yourself with Laravel first.
+
+
+<a name="what-is-backpack"></a>
+## What is Backpack?
+A software that helps Laravel professionals build administration panels - secure areas where administrators login and create, read, update and delete application information. It is *not* a CMS, it is more a framework that lets you *build your own* CMS. You can install it in your existing project or in a totally new project. 
+
+It's designed to be flexible enough to allow you to **build admin panels for everything from simple presentation websites to CRMs, ERPs, eCommerce, eLearning, etc**. We can vouch for that, because we have built all that stuff using Backpack already.
+
+<a name="how-to-use-backpack"></a>
+## What's a CRUD?
+
+A **CRUD** is what we call a section of your admin panel that lets the admin _Create, Read, Update or Delete_ entries of a certain entity (or Model). So you can have a CRUD for Products, a CRUD for Articles, a CRUD for Categories, or whatever else you might want to create, read, update or delete.
+
+For the purpose of this series, we'll show examples on the ```Tag``` entity. This is what a Tag CRUD could look like:
+
+![Tag CRUD - List Entries Operation](https://backpackforlaravel.com/uploads/docs-4-0/getting_started/tag_crud_list_entries.png)
+
+But Backpack is prepared for feature-packed CRUDs - since it's a good tool for very complex projects too. Here's what a CRUD that uses all of Backpack's features could look like:
+
+![Monsters CRUD - List Entries Operation](https://backpackforlaravel.com/uploads/docs-4-0/getting_started/monster_crud_list_entries.png)
+
+Mind that you will _almost never_ use all of Backpack's features in one CRUD. But if you do... it still looks good, and it'll be intuitive to use.
+
+<a name="core-packages"></a>
+## Main Features
+
+<a name="backpack-design"></a>
+### Front-End Design
+
+Backpack installs the [CoreUI](https://coreui.io) HTML theme, and our own design on top - [Backstrap](https://backstrap.net). It uses Bootstrap 4, and has many HTML blocks ready for you to use. When you're building a custom page in your admin panel, it's easy to just copy-paste the HTML from our [Backstrap demo](https://backstrap.net), or from the [CoreUI documentation](https://coreui.io/docs/getting-started/introduction/) and it will look good, without you having to design anything.
+
+It also installs Noty for triggering JS notification bubbles, and SweetAlerts. So you can easily use these across your admin panel. You can [trigger notification bubbles in PHP](/docs/{{version}}/base-about#triggering-notification-bubbles-in-php) or [trigger notification bubbles in JavaScript](/docs/{{version}}/base-about#triggering-notification-bubbles-in-javascript).
+
+
+<a name="backpack-authentication"></a>
+### Authentication
+
+Backpack comes with a basic authentication system that's separate from Laravel's. This way, you can have different login screens for users & admins, if you need. If not, you can choose to use only one authentication - either Laravel's, or Backpack's.
+
+![Backpack 3.5 Authentication Screens](https://backpackforlaravel.com/uploads/docs-4-0/getting_started/auth_screens.png)
+
+After you [install Backpack](/docs/{{version}}/installation) (don't do it now), you'll be able to log into your admin panel at ```http://yourapp/admin```. You can change the URL prefix from ```admin``` to something else in your ```config/backpack/base.php``` file, along with a bunch of other configuration options. [Click here](https://github.com/Laravel-Backpack/CRUD/blob/master/src/config/backpack/base.php) to browse the configuration file and see what it can do for you.
+
+
+<a name="backpack-crud"></a>
+### CRUDs
+
+This is where it gets interesting. As soon as you [install Backpack](/docs/{{version}}/installation) in your project, you can create **CRUDs** for your admins to easily manipulate DB information. Let's browse through a simple example, of creating a CRUD administration panel for a Tag entity.
+
+You can generate everything a CRUD needs using one of the methods below:
+
+---
+
+**Option A) PAID - using our GUI, [Backpack DevTools](https://backpackforlaravel.com/products/devtools)**
+
+Just install DevTools, fill in a web form with the columns for your entity, and it'll generate all needed files. It's that simple. Check out [the images here](https://backpackforlaravel.com/products/devtools) for how it works. It's especially useful for more complex entities. It is a paid tool though, and you might not be ready to purchase yet, so let's explore a free option too.
+
+**Option B) FREE - using the command-line interface**
+
+You can use anything you want to generate the Migration and Model, so in this case we're going to use [laracasts/generators](https://github.com/laracasts/Laravel-5-Generators-Extended):
+
+```zsh
+# STEP 0. install a 3d party tool to generate migrations
+composer require --dev laracasts/generators
+
+# STEP 1. create a migration
+php artisan make:migration:schema create_tags_table --model=0 --schema="name:string:unique,slug:string:unique"
+php artisan migrate
+
+# STEP 2. create a CRUD for it
+php artisan backpack:crud tag #use singular, not plural
+```
+
+---
+
+In both cases, what we're getting is a simple CRUD panel, which you should now be able to see in the Sidebar.
+
+For a simple entry like this, the generated CRUD panel will even work "as is", no need for customizations. But don't expect this for more complex entities. They will usually have particularities and need customization. That's where Backpack shines - modifying anything in the CRUD Panel is easy and intuitive, once you understand how it works.
+
+The methods above will generate:
+- a **migration** file
+- a **model** (```app\Models\Tag.php```)
+- a **request** file, for form validation (```app\Http\Requests\TagCrudRequest.php```)
+- a **controller** file, where you can customize how the CrudPanel looks and feels (```app\Http\Controllers\Admin\TagCrudController.php```)
+- a **route**, as a line inside ```routes/backpack/custom.php```
+
+It will also add:
+- a route inside ```routes/backpack/custom.php```, pointing to that controller;
+- a sidebar item inside ```resources/views/vendor/backpack/base/inc/sidebar_content.blade.php```;
+
+You might have noticed that **no views** are generated. That's because in most cases you _don't need_ custom views with Backpack. All your custom code is in the controller, model or request, so the default views are loaded, from the package. If you do, however, need to customize a view, it is [ridiculously easy](/docs/{{version}}/crud-how-to#customize-views-for-each-crud-panel).
+
+Also, we won't be covering the **migration**, **model** and **request** files here, as they are in no way custom. The only thing you need to make sure is that the Model is properly configured (db table, relationships, ```$fillable``` or ```$guarded``` properties, etc) and that it uses our ```CrudTrait```. What we _will_ be covering is ```TagCrudController``` - which is where most of your logic will reside. Here's a copy of a simple one you might use to achieve the above:
+
+```php
+<?php namespace App\Http\Controllers\Admin;
+
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+use App\Http\Requests\TagCrudRequest;
+
+class TagCrudController extends CrudController {
+
+  use \Backpack\CRUD\app\Http\Controllers\Operations\ListOperation;
+  use \Backpack\CRUD\app\Http\Controllers\Operations\ShowOperation;
+  use \Backpack\CRUD\app\Http\Controllers\Operations\CreateOperation;
+  use \Backpack\CRUD\app\Http\Controllers\Operations\UpdateOperation;
+  use \Backpack\CRUD\app\Http\Controllers\Operations\DeleteOperation;
+
+  public function setup() 
+  {
+      $this->crud->setModel("App\Models\Tag");
+      $this->crud->setRoute("admin/tag");
+      $this->crud->setEntityNameStrings('tag', 'tags');
+  }
+
+  public function setupListOperation()
+  {
+      $this->crud->setColumns(['name', 'slug']);
+  }
+
+  public function setupCreateOperation()
+  {
+      $this->crud->setValidation(TagCrudRequest::class);
+
+      $this->crud->addField([
+        'name' => 'name',
+        'type' => 'text',
+        'label' => "Tag name"
+      ]);
+      $this->crud->addField([
+        'name' => 'slug',
+        'type' => 'text',
+        'label' => "URL Segment (slug)"
+      ]);
+  }
+
+  public function setupUpdateOperation()
+  {
+      $this->setupCreateOperation();
+  }
+}
+```
+
+You should notice:
+- It uses basic inheritance (```TagCrudController extends CrudController```); so if you want to modify a behaviour (save, update, reorder, etc), you can easily do that by overwriting the corresponding method in your ```TagCrudController```;
+- All operations are enabled by using that operation's trait on the controller;
+- The ```setup()``` method defines the basics of the CRUD panel;
+- Each operation is set up inside a ```setupXxxOperation()``` method;
+
+**That's all for today!** If you want to learn more, go ahead and [read the next lesson](/docs/{{version}}/getting-started-crud-operations) of this series.
+
+
+<br>
+<a href="/docs/{{version}}/getting-started-crud-operations" class="btn btn-outline-info shadow">
+  Next  &#xFFEB;
+</a>

--- a/5.x-dev/getting-started-crud-operations.md
+++ b/5.x-dev/getting-started-crud-operations.md
@@ -1,0 +1,254 @@
+# 2. CRUD Operations
+
+---
+
+**Duration:** 10 minutes
+
+Let's bring back the example in our first lesson. The Tags CRUD:
+
+![Tag CRUD - List Entries Operation](https://backpackforlaravel.com/uploads/docs-4-0/getting_started/tag_crud_list_entries.png)
+
+With its ```TagCrudController```:
+
+```php
+<?php namespace App\Http\Controllers\Admin;
+
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+use App\Http\Requests\TagCrudRequest;
+
+class TagCrudController extends CrudController {
+
+  use \Backpack\CRUD\app\Http\Controllers\Operations\ListOperation;
+  use \Backpack\CRUD\app\Http\Controllers\Operations\ShowOperation;
+  use \Backpack\CRUD\app\Http\Controllers\Operations\CreateOperation;
+  use \Backpack\CRUD\app\Http\Controllers\Operations\UpdateOperation;
+  use \Backpack\CRUD\app\Http\Controllers\Operations\DeleteOperation;
+
+  public function setup() 
+  {
+      $this->crud->setModel("App\Models\Tag");
+      $this->crud->setRoute("admin/tag");
+      $this->crud->setEntityNameStrings('tag', 'tags');
+  }
+
+  public function setupListOperation()
+  {
+      $this->crud->setColumns(['name', 'slug']);
+  }
+
+  public function setupCreateOperation()
+  {
+      $this->crud->setValidation(TagCrudRequest::class);
+
+      $this->crud->addField([
+        'name' => 'name',
+        'type' => 'text',
+        'label' => "Tag name"
+      ]);
+      $this->crud->addField([
+        'name' => 'slug',
+        'type' => 'text',
+        'label' => "URL Segment (slug)"
+      ]);
+  }
+
+  public function setupUpdateOperation()
+  {
+      $this->setupCreateOperation();
+  }
+}
+```
+
+In the example above, we've enabled the most common operations:
+- **Create** - using a create form (aka "*add form*")
+- **List** - using AJAX DataTables (aka "*list view*", aka "*table view*")
+- **Update** - using an update form (aka "*edit form*")
+- **Delete** - using a *button* in the *list view* 
+- **Show** - using a *button* in the *list view* 
+
+These are the basic operations an admin can execute on an Eloquent model, thanks to Backpack. We do have additional operations (Reorder, Revisions, Clone, BulkDelete, BulkClone), and you can easily _create a custom operation_, but let's not get ahead of ourselves. Baby steps. **Let's go through the most important features of the operations you'll be using _all the time_: ListEntries, Create and Update**.
+
+<a name="create-and-update-operations"></a>
+## Create & Update Operations
+
+![Tag CRUD - Edit Operation](https://backpackforlaravel.com/uploads/docs-4-0/getting_started/tag_crud_edit.png)
+
+<a name="fields"></a>
+### Fields
+
+Inside your Controller's ```setupCreateOperation()``` or ```setupUpdateOperation()``` method, you'll be able to define what fields you want the admin to see, when creating/updating entries. In the example above, we only have two fields, both using the ```text``` field type. So that's what's shown to the admin. When the admin presses _Save_, assuming your model has those two attributes as ```$fillable```, Backpack will save the entry and take you back to the ListEntries view. Keep in mind we're using a _pure_ Eloquent model. So of course, inside the model you could use accessors, mutators, events, etc.
+
+
+But a lot of times, you won't just need text inputs. You'll need datepickers, upload buttons, 1-n relationship, n-n relationships, textareas, etc. For each field, you only need to define it properly in the Controller. Here are the most used methods to manipulate fields:
+
+```php
+$this->crud->addField($field_definition_array);
+$this->crud->addFields([$field_definition_array_1, $field_definition_array_2]);
+$this->crud->removeField('name');
+$this->crud->removeFields(['name_1', 'name_2']);
+
+// pro tip:
+// a quick way to add simple fields: let the CRUD decide what field type it is
+$this->crud->addField('db_column_name'); 
+```
+
+A typical *field definition array* will need at least three things:
+- ```name``` - the attribute (column in the database), which will also become the name of the input;
+- ```type``` - the kind of field we'd like to use (text, number, select2, etc);
+- ```label``` - the human-readable label for the input (will be generated from ```name``` if not given);
+
+
+You can use [one of the 44+ field types we've provided](/docs/{{version}}/crud-fields#default-field-types), or easily [create a custom field type](/docs/{{version}}/crud-fields#creating-a-custom-field-type) if you have some super-specific need that we haven't covered yet, or even [overwrite how a field type works](#overwriting-default-field-types). Take a few minutes and [browse the 44+ field types](/docs/{{version}}/crud-fields#default-field-types), to understand how the definition array differs from one to another and how many use cases you have already covered.
+
+Let's take another example, slightly more complicated than the ```text``` fields we used above. Something you'll encounter all the time is relationship fields. So let's say the ```Tag``` model has an **n-n relationship** with an Article model:
+
+```php
+    public function articles()
+    {
+        return $this->belongsToMany('App\Models\Article', 'article_tag');
+    }
+```
+
+We could use the code below to add a ```select2_multiple``` field to the Tag update forms:
+
+```php
+$this->crud->addField([
+    'type' => 'select2_multiple',
+    'name' => 'articles', // the relationship name in your Model
+    'entity' => 'articles', // the relationship name in your Model
+    'attribute' => 'title', // attribute on Article that is shown to admin
+    'pivot' => true, // on create&update, do you need to add/delete pivot table entries?
+]);
+```
+
+**Notes:**
+- If we call this inside ```setupUpdateOperation()``` it will only be added on that operation;
+- Because we haven't specified a ```label```, Backpack will take the "_articles_" name and turn it into a label: "_Articles_";
+
+If we had an Articles CRUD, and the reverse relationship defined on the ```Article``` model too, we could also add a ```select2_multiple``` field in the Article CRUD, to allow the admin to choose which tags apply to each article. This actually makes more sense than the above :-)
+
+```php
+$this->crud->addField([
+    'label' => "Tags",
+    'type' => 'select2_multiple',
+    'name' => 'tags', // the method that defines the relationship in your Model
+    'entity' => 'tags', // the method that defines the relationship in your Model
+    'attribute' => 'name', // foreign key attribute that is shown to user
+    'pivot' => true, // on create&update, do you need to add/delete pivot table entries?
+]);
+```
+
+> When generating a CrudController, you might be using the ```$this->crud->setFromDb();``` method by default, which tries to figure out what fields you might need in your create/update forms and what columns in your list view, but - as you'd expect - it only works for the simple field types. You can:
+> 
+> (1) choose to keep using ```setFromDb()``` and add/remove/change additional fields
+> 
+>   or 
+> 
+> (2) delete ```setFromDb()``` and manually define each field and column;
+> 
+> **Our recommendation**, for anything but the simplest CRUDs, **is to manually define each field** - much easier to understand and customize, for your future self and any other developer that comes after you.
+
+<a name="callbacks"></a>
+### Callbacks
+
+Developers coming from GroceryCRUD on CodeIgniter or other CRUD systems will be looking for callbacks to run ```before_insert```, ```before_update```, ```after_insert```, ```after_update```. **There are no callbacks in Backpack**. The ```store()``` and ```update()``` code is inside a trait, so you can easily overwrite that method, and call it inside your new method. For example, here's how we can do things before/after an item is saved in the Create operation:
+
+```php
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+
+class ProductCrudController extends CrudController
+{
+    use \Backpack\CRUD\app\Http\Controllers\Operations\CreateOperation { store as traitStore; }
+
+    // ...
+    
+    public function store()
+    {
+      // do something before validation, before save, before everything
+      $response = $this->traitStore();
+      // do something after save
+      return $response;
+    }
+}
+```
+
+>But before you do that, ask yourself - **_is this something that should be done when an entry is added/updated/deleted from the application, too_**? Not just the admin panel? If so, a better place for it would be the Model. Remember your Model is a pure Eloquent Model, so the cleanest way might be to use [Eloquent Event Observers](https://laravel.com/docs/6.0/eloquent#events) or [accessors and mutators](https://laravel.com/docs/master/eloquent-mutators#accessors-and-mutators).
+
+<a name="list-entries-operation"></a>
+## List Operation
+
+List shows the admin a table with all entries. On the front-end, the information is pulled using AJAX calls, and shown using DataTables. It's the most feature-packed operation in Backpack, but right now we're just going through the most important features you need to know about: columns, filters and buttons. 
+
+You should configure the List operation inside the ```setupListOperation()``` method.
+
+<a name="columns"></a>
+### Columns
+
+Columns help you specify *which* attributes are shown in the table and *in which order*. **Their syntax is super-similar to fields**:
+
+```php
+$this->crud->addColumn($column_definition_array); // add a single column, at the end of the table
+$this->crud->addColumns([$column_definition_array_1, $column_definition_array_2]); // add multiple columns, at the end of the table
+$this->crud->removeColumn('column_name'); // remove a column from the table
+$this->crud->removeColumns(['column_name_1', 'column_name_2']); // remove an array of columns from the table
+$this->crud->setColumnDetails('column_name', ['attribute' => 'value']);
+$this->crud->setColumnsDetails(['column_1', 'column_2'], ['attribute' => 'value']);
+
+$this->crud->setColumns([$column_definition_array_1, $column_definition_array_2]); // make these the only columns in the table
+```
+
+You can use one of the [14+ column types](/docs/{{version}}/crud-columns#default-column-types) to show information to the user in the table, or easily [create a custom column type](/docs/{{version}}/crud-columns#creating-a-custom-column-type), if you have a super-specific need. Here's an example of using the methods above:
+
+```php
+$this->crud->addColumn([
+    'name' => 'published_at',
+    'type' => 'date',
+    'label' => 'Publish_date',
+]);
+
+// PRO TIP: to quickly add a text column, just pass the name string instead of an array
+$this->crud->addColumn('text'); // adds a text column, at the end of the stack
+```
+
+<a name="filters"></a>
+### Filters
+
+![Monster CRUD - List Entries Filters](https://backpackforlaravel.com/uploads/docs-4-0/getting_started/backpack_filters.png)
+
+Filters provide an easy way for the admin to well… _filter_ the ListEntries table. The syntax is very similar to Fields and Columns and you can use one of the [existing 8 filter types](/docs/{{version}}/crud-filters) or easily [create a custom filter](/docs/{{version}}/crud-filters#creating-custom-filters). 
+
+```php
+$this->crud->addFilter($options, $values, $filter_logic);
+$this->crud->removeFilter($name);
+$this->crud->removeAllFilters();
+```
+
+For more on this, check out the [filters documentation page](/docs/{{version}}/crud-filters), when you need them.
+
+<a name="buttons"></a>
+### Buttons
+
+![Tag CRUD - List Entries Buttons](https://backpackforlaravel.com/uploads/docs-4-0/getting_started/backpack_buttons.png)
+
+If you want to add a custom button to an entry, you can do that. If you want to remove a button, you can also do that. Look for the [buttons documentation](/docs/{{version}}/crud-buttons) when you need it.  
+
+```php
+// positions: 'beginning' and 'end'
+// stacks: 'line', 'top', 'bottom'
+// types: view, model_function
+$this->crud->addButton($stack, $name, $type, $content, $position);
+$this->crud->removeButton($name);
+$this->crud->removeButtonFromStack($name, $stack);
+```
+
+**That's it for today!** Thanks for sticking with us this long. This has been the most important and longest lesson. You can go ahead and [install Backpack](/docs/{{version}}/installation) now, as you've already gone through the most important features. Or [read the next lesson](/docs/{{version}}/getting-started-advanced-features), about advanced features.
+
+
+<br>
+<a href="/docs/{{version}}/getting-started-advanced-features" class="btn btn-outline-info shadow">
+  Next  &#xFFEB;
+</a>

--- a/5.x-dev/getting-started-license-and-support.md
+++ b/5.x-dev/getting-started-license-and-support.md
@@ -1,0 +1,56 @@
+# 4. Add-ons, License & Support
+
+---
+
+**Duration:** 3 minutes
+
+<a name="add-ons"></a>
+## Add-ons
+
+In addition to our core packages (Base and CRUD), we have quite a few packages you can install or download, that treat common use cases. Some have been developed by our core team, some by our wonderful community. For example, we have plug&play interfaces to manage [site-wide settings](https://github.com/Laravel-Backpack/Settings), [the default Laravel users table](https://github.com/eduardoarandah/UserManager), [users, groups & permissions](https://github.com/Laravel-Backpack/PermissionManager), [content for custom pages, using page templates](https://github.com/Laravel-Backpack/PageManager), [news articles, categories and tags](https://github.com/Laravel-Backpack/NewsCRUD), etc.
+
+Take a look at:
+- [all official add-ons](/docs/{{version}}/add-ons-official)
+- [all community add-ons](/docs/{{version}}/add-ons-community)
+
+<a name="license"></a>
+## License
+
+Backpack is **free for non-commercial use**, but needs a license code in order to prevent "_unlicensed use_" notification bubbles and interruption of service. You can get a license code for your project:
+- ```free```, if you're using it for non-commercial purposes; [apply here](https://backpackforlaravel.com/pricing);
+- ```free```, if you've contributed to Backpack on Github; [apply here](https://backpackforlaravel.com/pricing);
+- ```€69 EUR/project```, if you're making money using it for a project; [buy here](https://backpackforlaravel.com/pricing);
+- ```€399 EUR for unlimited projects```, if you use Backpack a lot; [buy here](https://backpackforlaravel.com/pricing);
+
+**Freelancers** or companies **who make money using Backpack** - for themselves, their employers or their clients, **should [purchase a commercial license here](https://backpackforlaravel.com/pricing)**.
+
+
+>**You don't need a license code on LOCALHOST.** If you're just trying Backpack on your own machine, you don't need a license code. You only need a license code when you take your application to production.
+
+<a name="support"></a>
+## Support
+
+With thousands of developers using Backpack, a lot of them non-commercial, and such a small price, **we can't offer official support for the packages**. We've been doing this since 2016, we actively maintain the packages, we try to squash any bugs ASAP and add new features all the time, but we unfortunately can't spend time on back-and-forth on implementation issues in your project. But. We do have good documentation and have been blessed with a **great community**, where people help each other out. If Backpack becomes your tool of preference, I highly recommend you join our gang. Help others get started, create cool stuff, or even influence the direction of Backpack: 
+
+- **[StackOverflow tag](https://stackoverflow.com/questions/tagged/backpack-for-laravel) for support requests** (If you need help creating something using Backpack, post your question on StackOverflow using the ```backpack-for-laravel``` tag. We've been blessed with a great community that is happy to help. Who doesn't like getting StackOverflow points?)
+- **[Gitter Chatroom](https://gitter.im/BackpackForLaravel/Lobby) for quick questions** (If you have an urgent matter that won't take much time to answer, use our 24/7 Gitter chatroom. Be considerate, everyone's probably working on their own project right now.)
+- **[Github Issues](https://github.com/laravel-backpack/) for bugs** (Found a bug? Great! Please search for it on Github first - someone might have already found it. If not, open an issue, we're happy to learn about it and make Backpack better. )
+- **[/r/BackpackForLaravel subreddit](https://www.reddit.com/r/BackpackForLaravel/) for showing off your work, asking for opinions on implementation, sharing tips, packages, etc.**
+ 
+Thank you for sticking up with us for so long. This is the last Backpack lesson we can give you. **Now you have absolutely no excuse not to start your first Backpack project :-)** Here are a few links for if you still don't think you're ready:
+
+- [Go through the demo](/docs/{{version}}/demo) and play around
+- Read this [CRUD Crash Course](/docs/{{version}}/crud-tutorial) and do the steps yourself
+- Take a look at the [CrudController API Cheat Sheet](/docs/{{version}}/crud-cheat-sheet)
+
+
+<br>
+<a href="/docs/{{version}}/crud-tutorial" class="btn btn-info shadow">
+  CRUD Crash Course
+</a>
+<a href="/docs/{{version}}/demo" class="btn btn-outline-info shadow">
+  Demo
+</a>
+<a href="/docs/{{version}}/crud-cheat-sheet" class="btn btn-outline-info shadow">
+  Cheat Sheet
+</a>

--- a/5.x-dev/getting-started-license-and-support.md
+++ b/5.x-dev/getting-started-license-and-support.md
@@ -16,16 +16,16 @@ Take a look at:
 <a name="license"></a>
 ## License
 
-Backpack is **free for non-commercial use**, but needs a license code in order to prevent "_unlicensed use_" notification bubbles and interruption of service. You can get a license code for your project:
-- ```free```, if you're using it for non-commercial purposes; [apply here](https://backpackforlaravel.com/pricing);
-- ```free```, if you've contributed to Backpack on Github; [apply here](https://backpackforlaravel.com/pricing);
-- ```€69 EUR/project```, if you're making money using it for a project; [buy here](https://backpackforlaravel.com/pricing);
-- ```€399 EUR for unlimited projects```, if you use Backpack a lot; [buy here](https://backpackforlaravel.com/pricing);
 
-**Freelancers** or companies **who make money using Backpack** - for themselves, their employers or their clients, **should [purchase a commercial license here](https://backpackforlaravel.com/pricing)**.
+Starting with v5, Backpack has become open-core. The main features are now split into two packages:
 
+- [Backpack\CRUD](https://github.com/laravel-backpack/crud) is the core, released under the [MIT License](https://github.com/Laravel-Backpack/CRUD/blob/master/LICENSE.md) (free, open-source); <span class="badge badge-pill badge-success">FREE</span>
+- [Backpack\PRO](https://backpackforlaravel.com/products/pro) is a Backpack add-on, released under our [EULA](https://backpackforlaravel.com/eula) (paid, closed-source); <span class="badge badge-pill badge-info">PRO</span>
 
->**You don't need a license code on LOCALHOST.** If you're just trying Backpack on your own machine, you don't need a license code. You only need a license code when you take your application to production.
+Backpack\CRUD is perfect if you're building a simple admin panel - it's packed with features! It's also perfect if you're building an open-source project, the permissive license allows you to do whatever you want.
+
+When your admin panel grows and your needs become more complex, you can purchase our [Backpack\PRO](https://backpackforlaravel.com/products/pro) add-on, which adds A LOT of features for complex use-cases (see [list here]([Backpack\Pro](https://backpackforlaravel.com/products/pro))). Our documentation includes instructions on how to use both Backpack\CRUD and Backpack\PRO, with all the PRO features clearly labeled <span class="badge badge-pill badge-info">PRO</span>
+
 
 <a name="support"></a>
 ## Support

--- a/5.x-dev/getting-started-videos.md
+++ b/5.x-dev/getting-started-videos.md
@@ -1,0 +1,118 @@
+# Getting Started Videos
+
+---
+
+**Total Duration:** 31 minutes
+
+
+<a name="intro"></a>
+<h2 class="mb-7">Intro</h2>
+
+
+Meet your teacher, [Cristian Tabacitu](https://twitter.com/tabacitu), the founder of Backpack for Laravel.
+
+<div class='mx-sm-n5 mx-md-n6 mx-lg-n7 mt-7 embed-container'><iframe src='https://player.vimeo.com/video/424693910' frameborder='0' webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe></div>
+
+<br>
+Mentioned in this video:
+- [Laravel](https://laravel.com)
+- ["Laravel from Scratch" series on Laracasts](https://laravelfromscratch.com/)
+- [Backpack's docs repo on Github](https://github.com/laravel-backpack/docs)
+
+----
+
+<a name="the-admin-interface"></a>
+<h2 class="mb-7">The Admin Interface</h2>
+
+Before we go deep into the PHP features offered by Backpack, it's important to understand the HTML & CSS it uses, and how that can make your life easier when building admin panels. This is often an afterthought in admin panels, but Backpack makes it really really easy to create admin pages that are 100% custom.
+
+<div class='mx-sm-n5 mx-md-n6 mx-lg-n7 mt-7 embed-container'><iframe src='https://player.vimeo.com/video/424698837' frameborder='0' webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe></div>
+
+<br>
+Mentioned in this video:
+- [Laravel docs - installation](https://laravel.com/docs/7.x)
+- [Backpack docs - installation](/docs/{{version}}/installation)
+- [Backpack docs - how to customize the user interface](/docs/{{version}}/base-how-to#customizing-the-design-of-the-menu-sidebar-footer)
+- [Backpack docs - widgets](/docs/{{version}}/base-widgets)
+- [Backpack docs - add-ons](/addons)
+- [Bootstrap 4 docs](https://getbootstrap.com/)
+- [Backstrap.net - the default HTML template & UI blocks](https://backstrap.net/)
+
+----
+
+<a name="generating-and-understanding-cruds"></a>
+<h2 class="mb-7">Generating and Understanding CRUDs</h2>
+
+Let's generate a few Backpack CRUDs - places where the admin can Create, Read, Update or Delete entries. CRUDs will make it easy for you to build admin panels, 10x faster than before.
+
+<div class='mx-sm-n5 mx-md-n6 mx-lg-n7 mt-7 embed-container mb-4'><iframe src='https://player.vimeo.com/video/424701595' frameborder='0' webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe></div>
+
+
+> **NEW!!!** Starting with Aug 2021, there's a much simpler way to generate everything 🎉 Instead of using Blueprint,
+ **check out our new paid addon - [Backpack DevTools](https://backpackforlaravel.com/products/devtools).** It's a GUI that will help you generate Migrations, Models (complete with relationships), CRUDs from the browser 😱 It does cost extra, but it's well worth the price if you use Backpack regularly or your models are not dead-simple.
+
+<br>
+Mentioned in this video:
+- [Backpack's online demo](https://demo.backpackforlaravel.com/admin/login)
+- [laravel-shift/blueprint](https://blueprint.laravelshift.com/) - CLI tool to generate Eloquent models
+- [Laravel docs - migrations](https://laravel.com/docs/7.x/migrations#introduction)
+- [backpack/generators - CLI tool to generate CRUDs](https://github.com/laravel-backpack/generators)
+- [Fork - Git client for Mac OS & Windows](https://git-fork.com/)
+- [Backpack's List Operation](/docs/{{version}}/crud-operation-list-entries) - features [columns](/docs/{{version}}/crud-columns), [filters](/docs/{{version}}/crud-filters), [buttons](/docs/{{version}}/crud-buttons), [widgets](/docs/{{version}}/base-widgets), [other features](/docs/{{version}}/crud-operation-list-entries#other-features)
+- [Backpack's Create Operation](/docs/{{version}}/crud-operation-create) - features [fields](/docs/{{version}}/crud-fields), [widgets](/docs/{{version}}/base-widgets), [save actions](/docs/{{version}}/crud-save-actions), [split fields into tabs](/docs/{{version}}/crud-fields#split-fields-into-tabs), [add custom HTML between the fields](/docs/{{version}}/crud-fields#custom-html)
+- [Backpack's Update Operation](/docs/{{version}}/crud-operation-update)
+- [Backpack's Delete Operation](/docs/{{version}}/crud-operation-delete)
+
+Not mentioned in this video, but heavily recommended:
+- [Backpack DevTools](https://backpackforlaravel.com/products/devtools)
+
+----
+
+<a name="using-operations-and-features-in-cruds"></a>
+<h2 class="mb-7">Using Operations and Features in CRUDs</h2>
+
+I'd argue the best part of Backpack is not how easy it is to generate CRUDs, but how easy it is to customize them. In this video, we'll be taking a look at the default Operations that Backpack offers, and changing things around to fit our purpose. In the process, you'll understand how they work, and just how easy it is to use, customize or overwrite Operations like Create, Update, List, Delete, Reorder, Clone, BulkClone and BulkDelete.
+
+<div class='mx-sm-n5 mx-md-n6 mx-lg-n7 mt-7 embed-container'><iframe src='https://player.vimeo.com/video/424703257' frameborder='0' webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe></div>
+
+<br>
+Mentioned in this video:
+- [Backpack operations](/docs/{{version}}/crud-operations)
+- Laravel docs - [validation using Laravel Form Requests](https://laravel.com/docs/7.x/validation#form-request-validation)
+- Laravel docs - [validation rules](https://laravel.com/docs/7.x/validation#available-validation-rules)
+- [Reorder Operation](/docs/{{version}}/crud-operation-reorder)
+- [Clone & BulkClone Operations](/docs/{{version}}/crud-operation-clone)
+- Columns - [the 20+ column types](/docs/{{version}}/crud-columns#default-column-types), [columns API](/docs/{{version}}/crud-columns#columns-api), [fluent syntax](/docs/{{version}}/crud-fluent-syntax#fluent-columns), [array syntax](/docs/{{version}}/crud-columns#about), [overwriting a column type](/docs/{{version}}/crud-columns#overwriting-default-column-types), [creating a custom column type](/docs/{{version}}/crud-columns#creating-a-custom-column-type)
+- Fields - [the 50+ field types](/docs/{{version}}/crud-fields#default-field-types), [fluent syntax](/docs/{{version}}/crud-fluent-syntax#fluent-fields-api), [array syntax](/docs/{{version}}/crud-fields#about), [overwriting a field type](/docs/{{version}}/crud-fields#overwriting-default-field-types), [custom field types](/docs/{{version}}/crud-fields#creating-a-custom-field-type)
+- [the contents of an Operation - sidebar item, routes, controller](/docs/{{version}}/crud-operations#contents-of-a-custom-operation)
+
+----
+
+
+Thank you for dedicating these 31 minutes to learning Backpack. **You should now be able to build your first admin panel.** But if you feel like you're _not quite ready yet_, here are a few more things you can do:
+
+- [Go through the demo](/docs/{{version}}/demo) and play around, browse the features (pay special attention to the Monsters CRUD)
+- Read this [CRUD Crash Course](/docs/{{version}}/crud-tutorial) and do the steps yourself
+- Take a look at the [CrudController API Cheat Sheet](/docs/{{version}}/crud-cheat-sheet)
+- Read our [Getting Started Text Course](/docs/{{version}}/getting-started-basics)
+- Purchase and install [Backpack DevTools](https://backpackforlaravel.com/products/devtools) which will generate the minimum stuff for you
+
+
+<style>
+  .embed-container { 
+    position: relative; 
+    padding-bottom: 56.25%; 
+    height: 0; 
+    overflow: hidden; 
+    max-width: 100%; 
+  } 
+  .embed-container iframe, 
+  .embed-container object, 
+  .embed-container embed { 
+    position: absolute; 
+    top: 0; 
+    left: 0; 
+    width: 100%; 
+    height: 100%; 
+  }
+</style>

--- a/5.x-dev/index.md
+++ b/5.x-dev/index.md
@@ -1,0 +1,58 @@
+#### About
+
+- [Introduction](/docs/{{version}}/introduction)
+- [Demo](/docs/{{version}}/demo)
+- [Installation](/docs/{{version}}/installation)
+- [Release Notes](/docs/{{version}}/release-notes)
+- [Upgrade Guide](/docs/{{version}}/upgrade-guide)
+- [FAQ](/docs/{{version}}/faq)
+
+#### Getting Started
+- [Video Course](/docs/{{version}}/getting-started-videos)
+- [Text Course](/docs/{{version}}/getting-started-basics)
+    - [1. Basics](/docs/{{version}}/getting-started-basics)
+    - [2. CRUD Operations](/docs/{{version}}/getting-started-crud-operations)
+    - [3. Advanced Features](/docs/{{version}}/getting-started-advanced-features)
+    - [4. Add-ons, License & Support](/docs/{{version}}/getting-started-license-and-support)
+
+#### Admin UI
+
+- [About](/docs/{{version}}/base-about)
+- [Alerts](/docs/{{version}}/base-alerts)
+- [Breadcrumbs](/docs/{{version}}/base-breadcrumbs)
+- [Widgets](/docs/{{version}}/base-widgets)
+- [FAQ](/docs/{{version}}/base-how-to)
+
+#### CRUD Panels
+
+- [Basics](/docs/{{version}}/crud-basics)
+- [Crash Course](/docs/{{version}}/crud-tutorial)
+- [Operations](/docs/{{version}}/crud-operations)
+    + [List](/docs/{{version}}/crud-operation-list-entries)
+        + [Columns](/docs/{{version}}/crud-columns)
+        + [Buttons](/docs/{{version}}/crud-buttons)
+        + [Filters](/docs/{{version}}/crud-filters)
+    + [Create](/docs/{{version}}/crud-operation-create) & [Update](/docs/{{version}}/crud-operation-update)
+        + [Fields](/docs/{{version}}/crud-fields)
+        + [Save Actions](/docs/{{version}}/crud-save-actions)
+    + [Delete](/docs/{{version}}/crud-operation-delete)
+    + [Show](/docs/{{version}}/crud-operation-show)
+        + [Columns](/docs/{{version}}/crud-columns)
+- [Additional Operations](/docs/{{version}}/crud-operations)
+    + [Clone](/docs/{{version}}/crud-operation-clone)
+    + [Reorder](/docs/{{version}}/crud-operation-reorder)
+    + [Revise](/docs/{{version}}/crud-operation-revisions)
+    + [Fetch](/docs/{{version}}/crud-operation-fetch)
+    + [InlineCreate](/docs/{{version}}/crud-operation-inline-create)
+- [API](/docs/{{version}}/crud-cheat-sheet)
+    + [Cheat Sheet](/docs/{{version}}/crud-cheat-sheet)
+    + [Crud API](/docs/{{version}}/crud-api)
+    + [Fluent API](/docs/{{version}}/crud-fluent-syntax)
+- [FAQ](/docs/{{version}}/crud-how-to)
+
+
+#### Add-ons
+
+- [Official Add-ons](/docs/{{version}}/add-ons-official)
+- [Community Add-ons](https://backpackforlaravel.com/addons)
+- [How to Create an Add-on](/docs/{{version}}/add-ons-tutorial-using-the-addon-skeleton)

--- a/5.x-dev/install-optionals.md
+++ b/5.x-dev/install-optionals.md
@@ -1,0 +1,167 @@
+# Install Optional Packages
+
+---
+
+Each Backpack package has its own installation instructions in its readme file. We duplicate them here for easy access.
+
+Everything else is optional. Your project might use them or it might not. Only do each of the following steps if you need the functionality that package provides.
+
+<a name="backup-manager"></a>
+## BackupManager
+
+[>> See screenshots and installation](https://github.com/Laravel-Backpack/BackupManager)
+
+1) In your terminal
+
+```bash
+# Install the package
+composer require backpack/backupmanager
+
+# Publish the config file and lang files:
+php artisan vendor:publish --provider="Backpack\BackupManager\BackupManagerServiceProvider"
+
+# [optional] Add a sidebar_content item for it
+php artisan backpack:add-sidebar-content "<li class='nav-item'><a class='nav-link' href='{{ backpack_url('backup') }}'><i class='nav-icon la la-hdd-o'></i> Backups</a></li>"
+```
+
+2) Add a new "disk" to config/filesystems.php:
+
+```php
+// used for Backpack/BackupManager
+'backups' => [
+    'driver' => 'local',
+    'root'   => storage_path('backups'), // that's where your backups are stored by default: storage/backups
+],
+```
+This is where you choose a different driver if you want your backups to be stored somewhere else (S3, Dropbox, Google Drive, Box, etc).
+
+3) [optional] Modify your backup options in config/backup.php
+
+4) [optional] Instruct Laravel to run the backups automatically in your console kernel:
+
+```php
+// app/Console/Kernel.php
+
+protected function schedule(Schedule $schedule)
+{
+   $schedule->command('backup:clean')->daily()->at('04:00');
+   $schedule->command('backup:run')->daily()->at('05:00');
+}
+```
+
+5) [optional] If you need to change the path to the mysql_dump command, you can do that in your config/database.php file. For MAMP on Mac OS, add these to your mysql connection:
+```php
+'dump' => [
+    'dump_binary_path' => '/Applications/MAMP/Library/bin/', // only the path, so without `mysqldump` or `pg_dump`
+    'use_single_transaction',
+    'timeout' => 60 * 5, // 5 minute timeout
+]
+```
+
+<a name="log-manager"></a>
+## LogManager
+
+[>> See screenshots and installation](https://github.com/Laravel-Backpack/logmanager)
+
+
+1) Install via composer:
+
+```bash
+composer require backpack/logmanager
+```
+
+2) Add a "storage" filesystem disk in config/filesystems.php:
+
+```php
+// used for Backpack/LogManager
+'storage' => [
+    'driver' => 'local',
+    'root'   => storage_path(),
+],
+```
+
+3) Configure Laravel to create a new log file for every day, in your .ENV file, if it's not already. Otherwise there will only be one file at all times.
+
+```
+APP_LOG=daily
+```
+
+or directly in your config/app.php file:
+```php
+'log' => env('APP_LOG', 'daily'),
+```
+
+4) [optional] Add a menu item for it in resources/views/vendor/backpack/base/inc/sidebar_content.blade.php or menu.blade.php:
+
+```bash
+php artisan backpack:add-sidebar-content "<li class='nav-item'><a class='nav-link' href='{{ backpack_url('log') }}'><i class='nav-icon la la-terminal'></i> Logs</a></li>"
+```
+<a name="settings-manager"></a>
+## Settings
+
+An interface for the administrator to easily change application settings. Uses Laravel Backpack. 
+
+[>> See screenshots and installation](https://github.com/Laravel-Backpack/settings)
+
+Installation:
+
+```bash
+# install the package
+composer require backpack/settings
+
+# run the migration
+php artisan vendor:publish --provider="Backpack\Settings\SettingsServiceProvider"
+php artisan migrate
+
+# [optional] add a menu item for it to the sidebar_content file
+php artisan backpack:add-sidebar-content "<li class='nav-item'><a class='nav-link' href='{{ backpack_url('setting') }}'><i class='nav-icon fa fa-cog'></i> Settings</a></li>"
+
+# [optional] insert some example dummy data to the database
+php artisan db:seed --class="Backpack\Settings\database\seeds\SettingsTableSeeder"
+```
+
+<a name="page-manager"></a>
+## PageManager
+
+An admin panel where you, as a developer, can define templates with different fields, and the admin can choose between those templates to create/edit pages with content.
+
+[>> See screenshots and installation](https://github.com/Laravel-Backpack/pagemanager)
+
+<a name="permission-manager"></a>
+## PermissionManager
+
+An admin panel for user authentication on Laravel 5, using Backpack\CRUD. Add, edit, delete users, roles and permission.
+
+[>> See screenshots and installation](https://github.com/Laravel-Backpack/PermissionManager)
+
+<a name="menu-crud"></a>
+## MenuCrud
+
+An admin panel for menu items on Laravel 5, using Backpack\CRUD. Add, edit, reorder, nest, rename menu items and link them to Backpack\PageManager pages, external link or custom internal link.
+
+[>> Github](https://github.com/Laravel-Backpack/MenuCRUD)
+
+<a name="news-crud"></a>
+## NewsCrud
+
+Since NewsCRUD does not provide any extra functionality other than Backpack\CRUD, it is not a package. It's just a tutorial to show you how this can be achieved. In the future, CRUD examples like this one will be easily installed from the command line, from a central repository. Until then, you will need to manually create the files.
+
+[>> Github](https://github.com/Laravel-Backpack/NewsCRUD)
+
+
+<a name="file-manager"></a>
+## FileManager
+
+Backpack admin interface for files and folders, using [barryvdh/laravel-elfinder](https://github.com/barryvdh/laravel-elfinder).
+
+[>> See screenshots and installation](https://github.com/Laravel-Backpack/FileManager)
+
+Installation:
+
+```bash
+composer require backpack/filemanager
+```
+
+```bash
+php artisan backpack:filemanager:install
+```

--- a/5.x-dev/installation.md
+++ b/5.x-dev/installation.md
@@ -29,7 +29,7 @@ cd your-laravel-project-name
 
 ``` bash
 # require Backpack using Composer
-composer require backpack/crud:"4.2.x-dev as 4.1.99"
+composer require backpack/crud:"5.x.x-dev as 4.1.99"
 composer require --dev backpack/generators
 
 # run the installation command
@@ -38,7 +38,7 @@ php artisan backpack:install
 
 > Backpack install is interactive and will ask questions during instalation, if you don't want that add the `--no-interaction` argument to the install command.
 
-2) [optional] Backpack assumes you already have your Eloquent Models properly set up. If you don't, **consider using something to quickly generate Migrations & Models**. You can use anything you want, but here are the options we recommend:
+Backpack assumes you already have your Eloquent Models properly set up. If you don't, **consider using something to quickly generate Migrations & Models**. You can use anything you want, but here are the options we recommend:
 
 - a) Generate from a **web interface** - [Backpack Devtools](https://backpackforlaravel.com/products/devtools) - premium product, paid separately. A simple GUI to quickly generate Migrations, Models, Factories, Seeders and CRUDs, right from your browser. Works well for entities of all sizes.
 
@@ -46,12 +46,12 @@ php artisan backpack:install
 
 - c) Generate from a **YAML file** - [LaravelShift's Blueprint](https://blueprint.laravelshift.com/) - free & open-source. Enables you to create a `draft.yml` file in your repo, where you can specify the column using their custom YAML syntax. Works well for small & medium entities.
 
-3) Take note that:
+Take note that:
 - By default all users are considered admins; If that's not what you want in your application (you have both users and admins), please:
     - Change ```app/Http/Middleware/CheckIfAdmin.php```, particularly ```checkIfUserIsAdmin($user)```, to make sure you only allow admins to access the admin panel;
-    - Change ```app/Providers/RouteServiceProvider::HOME```, which will send logged in (but not admin) users to `/home`, to something that works for your app; This is only needed in Laravel 7+; 
-- Change configuration values in ```config/backpack/base.php``` to make the admin panel your own. Backpack is white label, so you can change everything: menu color, project name, developer name etc.
-- If your User model has been moved (it is not ```App\User.php```), please change ```config/backpack/base.php``` to use the correct user model using the ```user_model_fqn``` config key. If you are using Laravel 8 and up, you need to change this. Because by default Laravel 8 and up save the ```User``` model inside the ```Models``` directory.
+    - Change ```app/Providers/RouteServiceProvider::HOME```, which will send logged in (but not admin) users to `/home`, to something that works for your app;
+- You should the configuration values in ```config/backpack/base.php``` to make the admin panel your own. Backpack is white label, so you can change everything: menu color, project name, developer name etc.
+- If your User model has been moved (it is not ```App\Models\User.php```), please change ```config/backpack/base.php``` to use the correct user model using the ```user_model_fqn``` config key.
 
 That's it. If you already know how to use Backpack, next up you'll probably want to [create CRUD Panels](/docs/{{version}}/crud-tutorial#generate-files).
 

--- a/5.x-dev/installation.md
+++ b/5.x-dev/installation.md
@@ -1,0 +1,73 @@
+# Installation
+
+---
+
+<a name="requirements"></a>
+## Requirements
+
+If you can run Laravel 8 or 9, you can install Backpack. Backpack does _not_ have additional requirements. For the following process, we assume:
+
+- you have a [working installation of Laravel](https://laravel.com/docs/9.x#installation) (an existing project is fine, you don't need a *fresh* Laravel install);
+
+- you have configured your .ENV file with your database and mail information;
+
+- you can run the ```composer``` command from any directory (you have ```composer``` registered as a global command); if you need to run ```php composer.phar``` or reference another directory, please remember to adapt the commands below to your configuration;
+
+<a name="installation"></a>
+## Installation
+
+<a name="install-core-packages"></a>
+### Install Core Packages
+
+0) Open your project folder in your terminal:
+
+```bash
+cd your-laravel-project-name
+```
+
+1) In your project's main directory:
+
+``` bash
+# require Backpack using Composer
+composer require backpack/crud:"4.2.x-dev as 4.1.99"
+composer require --dev backpack/generators
+
+# run the installation command
+php artisan backpack:install
+```
+
+> Backpack install is interactive and will ask questions during instalation, if you don't want that add the `--no-interaction` argument to the install command.
+
+2) [optional] Backpack assumes you already have your Eloquent Models properly set up. If you don't, **consider using something to quickly generate Migrations & Models**. You can use anything you want, but here are the options we recommend:
+
+- a) Generate from a **web interface** - [Backpack Devtools](https://backpackforlaravel.com/products/devtools) - premium product, paid separately. A simple GUI to quickly generate Migrations, Models, Factories, Seeders and CRUDs, right from your browser. Works well for entities of all sizes.
+
+- b) Generate from the **command-line** - [Laracasts Generators](https://github.com/laracasts/Laravel-5-Generators-Extended) - free & open-source. Adds a new artisan command so that you can do `php artisan make:migration:schema create_users_table --schema="username:string, email:string:unique"`. Works well for smaller entities.
+
+- c) Generate from a **YAML file** - [LaravelShift's Blueprint](https://blueprint.laravelshift.com/) - free & open-source. Enables you to create a `draft.yml` file in your repo, where you can specify the column using their custom YAML syntax. Works well for small & medium entities.
+
+3) Take note that:
+- By default all users are considered admins; If that's not what you want in your application (you have both users and admins), please:
+    - Change ```app/Http/Middleware/CheckIfAdmin.php```, particularly ```checkIfUserIsAdmin($user)```, to make sure you only allow admins to access the admin panel;
+    - Change ```app/Providers/RouteServiceProvider::HOME```, which will send logged in (but not admin) users to `/home`, to something that works for your app; This is only needed in Laravel 7+; 
+- Change configuration values in ```config/backpack/base.php``` to make the admin panel your own. Backpack is white label, so you can change everything: menu color, project name, developer name etc.
+- If your User model has been moved (it is not ```App\User.php```), please change ```config/backpack/base.php``` to use the correct user model using the ```user_model_fqn``` config key. If you are using Laravel 8 and up, you need to change this. Because by default Laravel 8 and up save the ```User``` model inside the ```Models``` directory.
+
+That's it. If you already know how to use Backpack, next up you'll probably want to [create CRUD Panels](/docs/{{version}}/crud-tutorial#generate-files).
+
+> If it's your first time installing Backpack, it is **highly recommended** that you go through our [Getting Started series](/docs/{{version}}/getting-started-basics), to understand how Backpack works. That's why we created it - to help you learn how to use this admin panel framework. In ~23 minutes we'll teach you 80% of what you can do, and how.
+
+
+<a name="install-add-ons"></a>
+### Install Add-ons
+
+In case you want to add extra functionality that's already been built, check out [the installation steps for the add-ons we've developed](/docs/{{version}}/install-optionals).
+
+<a name="frequently-asked-questions"></a>
+## Frequently Asked Questions
+
+- **Error: The process X exceeded the timeout of 60 seconds.** It might mean Github or Packagist is unavailable at the moment. This usually doesn't last for more than a few minutes, so you can run ```php artisan backpack:install --timeout=600``` to increase the timeout to 10 minutes. If this doesn't work either, take a look behind the scenes with ```php artisan backpack:install --timeout=600 --debug```;
+
+- **Error: SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key was too long**. Your MySQL version might be a bit old. Please [apply this quick fix](https://laravel-news.com/laravel-5-4-key-too-long-error), then run ```php artisan migrate:fresh```.
+
+- **Any other installation error?** If you can't install Backpack because of a different error, you can [try the manual installation process](/docs/{{version}}/crud-how-to#manually-install-backpack), which you can tweak to your needs.

--- a/5.x-dev/introduction.md
+++ b/5.x-dev/introduction.md
@@ -1,0 +1,102 @@
+# Introduction
+
+---
+
+Backpack is a collection of Laravel packages that help you **build custom administration panels**, for anything from presentation websites to complex web applications. You can install them on top of existing Laravel installations _or_ fresh projects.
+
+In a nutshell:
+
+- Backpack will provide you with a _visual interface_ for the admin panel (the HTML, the CSS, the JS); it pulls in the excellent [CoreUI](https://coreui.io/) theme, with our own design called [Backstrap](https://backstrap.net), adds authentication functionality & bubble notifications; when you decide to build a custom feature for your admin panel, you already have the HTML blocks for the UI, and it will look good;
+- Backpack will help you build _sections where your admins can manipulate entries for Eloquent models_; we call them _CRUD Panels_ after the most basic operations: Create/Read/Update/Delete; after [understanding Backpack](/docs/{{version}}/getting-started-basics), you'll be able to create a CRUD panel for each entity in about 10 minutes / model:
+
+```bash
+# STEP 0. create migration (in case you're starting from scratch)
+composer require --dev laracasts/generators
+php artisan make:migration:schema create_tags_table --model=0 --schema="name:string:unique"
+php artisan migrate
+
+# STEP 1. create a Model, Request, Controller, Route and sidebar item for the admin panel
+php artisan backpack:crud tag #use singular, not plural
+
+# STEP 2. go through the generated files, customize according to your needs
+```
+
+Better yet, if you purchase our brand-new [Backpack DevTools](https://backpackforlaravel.com/products/devtools) (premium addon, paid extra) you can generate better Migrations, Models, Seeders, Factories and CRUDs... from the comfort of your browser window 🤯 It's never been this easy:
+
+![](https://user-images.githubusercontent.com/1032474/128379216-72ae55fa-fcff-4747-8c35-42c733923c94.gif)
+
+---
+
+<a name="how-to-start"></a>
+## How to Start
+
+We heavily recommend you spend a little time to understand Backpack, and only afterwards install and use it. Fortunately it's super-simple to get started. Using any of the options below will get you to a point where you can use Backpack in your projects:
+- **[Video Course](/docs/{{version}}/getting-started-videos)** - 31 minutes
+- **[Text Course](/docs/{{version}}/getting-started-basics)** - 20 minutes
+- **[Email Course](https://backpackforlaravel.com/getting-started-emails)** - 1 email per day, for 4 days, 5 minutes each
+
+
+<br>
+<a href="/docs/{{version}}/getting-started-videos" class="btn btn-outline-info btn-sm shadow"><i class="fe fe-video"></i> Video Course</a>
+<a href="/docs/{{version}}/getting-started-basics" class="btn btn-outline-info btn-sm shadow"><i class="fe fe-file-text"></i> Text Course</a>
+<a href="https://backpackforlaravel.com/getting-started-emails" class="btn btn-outline-info btn-sm shadow"><i class="fe fe-inbox"></i> Email Course</a>
+
+---
+
+<a name="need-to-know"></a>
+## Need to Know
+
+<a name="requirements"></a>
+### Requirements
+
+  - Laravel 9.x or 8.x
+  - MySQL (recommended) / PostgreSQL / SQLite / SQL Server
+
+<a name="how-does-it-look"></a>
+### How does it look?
+
+- Take a look at [our homepage](https://backpackforlaravel.com/).
+- Play around in our [live demo](https://demo.backpackforlaravel.com/admin/login).
+- [Install the demo](/docs/{{version}}/demo) and fiddle with the code.
+
+<a name="security"></a>
+### Security
+
+Backpack has never had a critical vulnerability/hack. But there _have_ been important security updates for dependencies (including Laravel). Please [login with Github](/auth/github) or  [subscribe to our security newsletter](https://backpackforlaravel.com/newsletter), so we can reach you in case anything bad happens. No spam, no marketing emails, we promise. We only send about 2 emails per year, when there's a problem you should know about or we introduce major Backpack upgrades.
+
+<a name="maintenance"></a>
+### Maintenance
+
+Backpack v5 is the current version, and is being actively maintained by the Backpack team, with the help of a wonderful community of Backpack veterans. [See all contributors](https://github.com/Laravel-Backpack/CRUD/graphs/contributors).
+
+<a name="license"></a>
+### License
+
+Starting with v5, Backpack has become open-core. The main features are now split into two packages:
+
+- [Backpack\CRUD](https://github.com/laravel-backpack/crud) is the core, released under the [MIT License](https://github.com/Laravel-Backpack/CRUD/blob/master/LICENSE.md) (free, open-source); <span class="badge badge-pill badge-success">FREE</span>
+- [Backpack\PRO](https://backpackforlaravel.com/products/pro) is a Backpack add-on, released under our [EULA](https://backpackforlaravel.com/eula) (paid, closed-source); <span class="badge badge-pill badge-info">PRO</span>
+
+Backpack\CRUD is perfect if you're building a simple admin panel - it's packed with features! It's also perfect if you're building an open-source project, the permissive license allows you to do whatever you want.
+
+When your admin panel grows and your needs become more complex, you can purchase our [Backpack\PRO](https://backpackforlaravel.com/products/pro) add-on, which adds A LOT of features for complex use-cases (see [list here]([Backpack\Pro](https://backpackforlaravel.com/products/pro))). Our documentation includes instructions on how to use both Backpack\CRUD and Backpack\PRO, with all the PRO features clearly labeled <span class="badge badge-pill badge-info">PRO</span>
+
+
+<a name="versioning"></a>
+### Versioning, Updates and Upgrades
+
+Starting with Backpack v5, all our packages follow [semantic versioning](https://semver.org/). Here's what `major.minor.patch` (eg. `5.0.1`) means for Backpack\CRUD:
+- `major` - breaking changes, major new features, complete rewrites; released **once a year**, in February; it adds features that were previously impossible and upgrades our dependencies; upgrading is done by following our clear and detailed upgrade guides;
+- `minor` - new features, released in backwards-compatible ways; **every few months**; update takes seconds;
+- `patch` - bug fixes & small non-breaking changes; historically **every week**; update takes seconds;
+
+When we release a new Backpack\CRUD version, all paid addons receive support for it the same day. And because (1) we release a new version every year and (2) when you buy a Backpack addon, you get access to not only _updates_, but also _upgrades_ (for 12mo), that means that... **any time you buy a Backpack addon, it is very likely that you're not only buying the _current_ version** (`v5` at the moment), **but also the upgrade to the _next version_** (`v6` for example).
+
+<a name="add-ons"></a>
+### Add-ons
+
+In addition to our core CRUD package, there are a few additional packages you might want to take a look at, that treat common use cases. Some have been developed by our core team, some by our wonderful community. You can just install interfaces to manage [site-wide settings](https://github.com/Laravel-Backpack/Settings), [the default Laravel users table](https://github.com/eduardoarandah/UserManager), [users, groups & permissions](https://github.com/Laravel-Backpack/PermissionManager), [content for custom pages, using page templates](https://github.com/Laravel-Backpack/PageManager), [news articles, categories and tags](https://github.com/Laravel-Backpack/NewsCRUD), etc.
+
+For more information, please see:
+- [all official add-ons](/docs/{{version}}/add-ons-official)
+- [all community add-ons](/docs/{{version}}/add-ons-community)

--- a/5.x-dev/release-notes.md
+++ b/5.x-dev/release-notes.md
@@ -1,0 +1,228 @@
+# Release Notes
+
+---
+
+**Launch date:** (expected) end of Jan, 2022
+
+Anybody with a 4.0 or 4.1 license can install and use 4.2, but in order to get the new features in a project that currently runs 4.1, you need to [follow the upgrade guide](/docs/{{version}}/upgrade-guide). Don't get fooled by the fact that we kept the 4.x.x prefix - that's just to show that **Backpack 4.2 is a FREE upgrade from 4.1**. But **Backpack 4.2 is a MAJOR new version**, with 12 months of work put into it, and major improvements under-the-hood. It is the current and recommended version of Backpack and it's got so many cool new things that we couldn't fit them all inside this page.
+
+But what Backpack 4.2 brings to the table and why you should upgrade from [Backpack 4.1](/docs/4.1) to 4.2:
+
+
+<a name="added"></a>
+## Added
+
+### Operations
+
+#### Warning before leaving the Create or Update form
+
+For large forms, it's often smart to ask the user if they really want to lose their form changes, before they leave the page. That's exactly what `CRUD::set('warnBeforeLeaving', true)` will do, just call it in your `setupCreateOperation()` or `setupUpdateOperation()`.
+
+
+#### Quickly validate forms inside CrudController, no FormRequest needed
+
+Previously, you could validate the Create & Update forms in one way - by telling Backpack which FormRequest holds the validation rules: `CRUD::setValidation(TagRequest::class)`. Which works very well for large models. But for very simple models... like Tags... do you really _need_ a `TagRequest` to say the name is required? If you've found that inconvenient, we have good news:
+
+```php
+protected function setupCreateOperation()
+{
+    // instead of these (which still work, btw)
+    $this->crud->setValidation(TagRequest::class);
+    $this->crud->setValidation('App\Http\Requests\TagRequest');
+
+    // you can now also do this
+    $this->crud->setValidation([
+        'name' => 'required|min:2',
+    ]);
+
+    // you even define custom validation messages, using the second parameter
+    $rules = ['name' => 'required|min:2'];
+    $messages = [
+        'name.required' => 'You gotta give it a name, man.',
+        'name.min' => 'You came up short. Try more than 2 characters.',
+    ];
+    $this->crud->setValidation($rules, $messages);
+}
+```
+
+#### Use Model Events inside CrudControllers
+
+You can now define closures to be run when Model Events get triggered, right inside your CrudController:
+
+```php
+public function setup() {
+    // this will get run for all operations that trigger the "deleting" model event
+    // by default, that's the Delete operation
+    Monster::deleting(function ($entry) {
+        // TODO: delete that entry's files from the disk
+    });
+
+    // this will get run on all operations that trigger the "saving" model event
+    // by default, that's the Create and Update operations
+    Monster::saving(function ($entry) {
+        // TODO: change one value to another or something
+    });
+}
+
+public function setupCreateOperation()
+{
+    // this will only get triggered inside the Create operation because
+    // that's where we've defined it
+    Monster::creating(function ($entry) {
+        // TODO: something to the entry
+    });
+}
+```
+
+This is particularly useful if you've ever overriden your `create()` or `store()` methods in your CrudController. Now... you don't really have to do that any more, you can do stuff directy on the model, upon an event. But it's not limited to that use case, since it supports [all Eloquent events](https://laravel.com/docs/master/eloquent#events).
+
+<hr>
+
+### Fields
+
+#### Define validation rules directly on fields
+
+In addition to the array validation above... Backpack 4.2 has one more trick up its sleeve. You can now also define the validation rules and vlidation messages right when you define the field. No more `FormRequest`, no more defining the validation rules separately:
+
+```php
+protected function setupCreateOperation()
+{
+    $this->crud->addField([
+        'name' => 'content',
+        'label' => 'Content',
+        'type' => 'ckeditor',
+        'placeholder' => 'Your text here',
+        'validationRules' => 'required|min:10',
+        'validationMessages' => [
+            'required' => 'You gotta write smth man.',
+            'min' => 'More than 10 characters, bro. Wtf... You can do this!',
+        ]
+    ]);
+    // This MUST be called AFTER the fields are defined, never before.
+    $this->crud->setValidation();
+}
+```
+
+In short, just call `CRUD::setValidation()` without passing anything and it will validate all the fields that have `validationRules` defined. But be careful - you have to call `setValidation()` _after_ you've defined your fields.
+
+
+#### Define Model Events directly on fields
+
+Previously, if you wanted to change the value of a field when retrieving it or storing in the database, Backpack encouraged you to use Accessors and Mutators. You can still do that, they're stock Laravel features and they'll work fine. But sometimes... you might not want to change the Model itself.
+
+Now, you can define closures to run when standard Eloquent events are triggered, right on your fields:
+
+```php
+// using the ARRAY SYNTAX, define an array of events and closures
+CRUD::addField([
+    'name' => 'name',
+    'events' => [
+        'saving' => function ($entry) {
+            $entry->name = strtoupper($entry->name);
+        },
+    ],
+]);
+
+// using the FLUENT SYNTAX, you can define the same array
+CRUD::field('name')->events([
+    'saving' => function ($entry) {
+        $entry->name = strtoupper($entry->name);
+    },
+]);
+
+// BUT you can also use the convenience method "on" to define just ONE event
+CRUD::field('name')->on('saving', function ($entry) {
+    $entry->name = strtoupper($entry->name);
+});
+```
+
+It supports [all Eloquent events](https://laravel.com/docs/master/eloquent#events), but... the ones that make sense are just: ~~`retrieved`~~, `creating`, `created`, `updating`, `updated`, `saving`, `saved`, ~~`deleting`~~, ~~`deleted`~~, ~~`restoring`~~, ~~`restored`~~, and ~~`replicating`~~, because those are the events that actually take place inside the Create and Update operations.
+
+We think you'll find this particularly useful for the `image`, `upload` and `upload_multiple` fields. Previously, they required you to create Mutators for them to work. Which meant you had to go to the Model to do that. But now... you can just do that in your CrudController:
+
+```php
+CRUD::field('attachment')->on('saving', function ($entry) {
+    $value = request()->file('upload');
+
+    if (!is_null($value)) {
+        $entry->uploadFileToDisk($value, 'upload', 'public', 'uploads/monsters/upload_field');
+    }
+});
+```
+
+#### Simple validation for `repeatable` entries
+
+Previously, in order to validate the contents of a subfield in `repeatable`, you had to write your own custom validation, which could take you quite some time. Now, you can just do `'testimonial.*.name' => 'required|min:5|max:256'` and use [Laravel's nested array validation](https://laravel.com/docs/8.x/validation#validating-nested-array-input).
+
+
+#### Better than ever `relationship` field, now with `subfields` too
+
+We've spent _months_ building up and polishing the `relationship` field. It's now a one-stop-shop for all your needs, when creating/editing a relationship. Because it supports all common Eloquent relationships:
+- ✅ `hasOne` (1-1) - shows subform if you define `subfields`
+- ✅ `belongsTo` (n-1) - shows a select2 (single)
+- ✅ `hasMany` (1-n) - shows a select2_multiple OR a subform if you define `subfields`
+- ✅ `belongsToMany` (n-n) - shows a select2_multiple OR a subform if you define `subfields` for pivot extras
+- ✅ `morphOne` (1-1) - shows a subform if you define `subfields`
+- ✅ `morphMany` (1-n) - shows a select2_multiple OR a subform if you define `subfields`
+- ✅ `morphToMany` (n-n) - shows a select2_multiple OR a subform if you define `subfields` for pivot extras
+
+One HUGE addition we've made in 4.2 is... 🥁🥁🥁 subfields. For complex relationship, you just need to define `subfields` and the select2 will be turned into a subform, allowing your admin to define extra attributes. This will save you _hours_ or even _days_ when you have complex relationships. Because right in the current form, your admin can now easily:
+- [create/update/delete a related 1-1 entry](/docs/{{version}}/crud-how-to#hasone-1-1-relationship) (`hasOne` and `morphOne`, eg. User and UserDetail)
+- [create/update/delete related 1-n entries](/docs/{{version}}/crud-fields#manage-related-entries-in-the-same-form-create-update-delete) (`hasMany` and `morphMany`, eg. Invoice and InvoiceItem)
+- [edit columns on the pivot table of n-n relationships](/docs/{{version}}/crud-fields#save-additional-data-to-pivot-table) (`belongsToMany` and `morphToMany`, eg. 'position' on company_user)
+
+Check out the links above for more info, but in short, `subfields` will look and work just as you'd expect, like a `repeatable` field (because, under the hood, that's what it uses):
+
+![](https://backpackforlaravel.com/uploads/docs-4-2/fields/repeatable_hasMany_entries.png)
+
+<hr>
+
+### Widgets
+
+#### New widget - `script`
+
+You can now easily "push" a JS file to any page you want, straight from a Controller or view. This is particularly useful when you want something custom done inside a CRUD Operation. See [the `script` widget docs](/docs/{{version}}/base-widgets#script-1) for more details.
+
+#### New widget - `style`
+
+You can now easily "push" a CSS file to any page you want, straight from a Controller or view. This is particularly useful when you want something custom done inside a CRUD Operation. See [the `script` widget docs](/docs/{{version}}/base-widgets#style-1) for more details.
+
+<hr>
+
+### Developer Experience
+
+#### Easily Debug AJAX Errors using the Error Frame Modal
+
+Did your AJAX request error? No need to dig into your Chrome Devtools and read that awful output. When you have your APP_DEBUG to `true`, Backpack will show that error in a modal. This seems like a small thing, but it makes it _much_ easier to work with some complex Backpack features, like [ListOperation](https://backpackforlaravel.com/docs/4.1/crud-operation-list-entries), [InlineCreateOperation](https://backpackforlaravel.com/docs/4.1/crud-operation-inline-create), [filters](https://backpackforlaravel.com/docs/4.1/crud-filters), [`select2_from_ajax`](https://backpackforlaravel.com/docs/4.1/crud-fields#select2_from_ajax) field, [`relationship`](https://backpackforlaravel.com/docs/4.1/crud-fields#relationship-1) field. During development, if something goes wrong, Backpack will show it to you - it's that simple:
+
+![image](https://user-images.githubusercontent.com/1838187/141500871-039ef53f-4207-4018-ac93-c41b547b62a5.png)
+
+<hr>
+
+
+<a name="changed"></a>
+## Changed
+
+#### Easily Include CSS and JS Assets Only Once Per Page
+
+Backpack now ships with a new `@loadOnce()` directive, which makes sure that piece of JS/CSS/code is only loaded once per pageload. You can see [more info about it here](https://github.com/digitallyhappy/assets) (and why it's more than `@once`).
+
+Of course, Backpack now uses this directive in all views that could get repeatedly loaded, so for example if you're loading in a single form a `select2`, a `select2_multiple` and a `select2_from_ajax`... you won't be getting the assets three times... but once.
+
+#### Increased Default Security
+
+Starting with v4.2, Backpack will throttle password request attempts. This will prevent malicious actors from using the "reset password" functionality of your admin panel to send unsolicited emails.
+
+In addition, most column types now escape the output by default. This will better prevent your admins from XSS attacks, in case where you do not trust the information in the database to not contain javascript payloads.
+
+<a name="removed"></a>
+## Removed
+
+- Support for Laravel 6;
+- Support for Laravel 7;
+- Support for PHP lower than 7.3 (since Laravel 8 does not support them);
+- `simplemde` field, in favor of `easymde`;
+
+---
+
+In order to get all of the features above (and a few more hidden gems), please [follow the upgrade guide](/docs/{{version}}/upgrade-guide), to get from Backpack 4.1 to Backpack 4.2.

--- a/5.x-dev/release-notes.md
+++ b/5.x-dev/release-notes.md
@@ -2,11 +2,51 @@
 
 ---
 
-**Launch date:** (expected) end of Jan, 2022
+**Launch date:** (expected) Feb 9th, 2022
 
-Anybody with a 4.0 or 4.1 license can install and use 4.2, but in order to get the new features in a project that currently runs 4.1, you need to [follow the upgrade guide](/docs/{{version}}/upgrade-guide). Don't get fooled by the fact that we kept the 4.x.x prefix - that's just to show that **Backpack 4.2 is a FREE upgrade from 4.1**. But **Backpack 4.2 is a MAJOR new version**, with 12 months of work put into it, and major improvements under-the-hood. It is the current and recommended version of Backpack and it's got so many cool new things that we couldn't fit them all inside this page.
+Backpack v5 is a major release, but NOT a huge upgrade. Think of it as a "4.2" release, that we've had to name "v5", because we've also changed our pricing. We have added new features and major improvements, but also kept the upgrading process as easy as possible. Plus...
 
-But what Backpack 4.2 brings to the table and why you should upgrade from [Backpack 4.1](/docs/4.1) to 4.2:
+> 🎉 &nbsp; 🎉 &nbsp; 🎉 &nbsp; **Backpack v5 is a FREE upgrade, for everybody who's purchased a Backpack v4 license after 9 Feb 2021.** Please read on to understand why.  &nbsp;  🎉 &nbsp; 🎉 &nbsp; 🎉
+
+
+But yes, **Backpack v5 is a MAJOR new version**, with 8+ months of work put into it, and major improvements under-the-hood. It is the current and recommended version of Backpack and it's got so many cool new things... that we couldn't fit them all inside this page. Here's what Backpack v5 brings to the table and why you should upgrade from [Backpack 4.1](/docs/4.1) to v5:
+
+<a name="new-pricing"></a>
+## New Pricing
+
+**The good news** - if you've purchased Backpack v4 after 9 Feb 2021:
+- you have access to all v5.x.x updates for 12 months from your purchase date;
+- if we release a v6 in those 12 months, you'll also have access to the v6 upgrade;
+- even after those 12 months go buy, you'll still have access to those versions, for ever;
+- you can [generate a token & password for v5 automatically, in your Backpack acount](https://backpackforlaravel.com/user/tokens);
+
+Basically, if you expected your updates to end soon... they don't. We've made sure that you receive at least 12 months of updates & upgrades, even though you purchased towards the end of Backpack's release cycle. We believe that's the _fair_ thing to do - give you guarantees that whenever you buy Backpack, you'll receive updates for a reasonable amount of time. It's one of the reasons we changed our pricing.
+
+**The bad news**... it's a little more difficult to understand WHY we've done that. Please read on, it makes perfect sense, we promise.
+
+### Backpack is now open-core
+
+We try not to make a big fuss out of this, but this is HUGE - we consider it a _bug fix_. A _licensing bug fix_.
+
+Previously, when you were buying a Backpack v4 license, you didn't know how many updates you're getting. Depending on _when_ you purchased, you could get 2 years of updates or 2 days. You'd then have to purchase the next version (using the limited-time discount we always give when launching). We consider that a stressful experience, both for you and us, so we've found a way to eliminate that stress too.
+
+**Starting with v5, the features that were previously in "Backpack\CRUD" are now split between two packages:**
+- **[Backpack\CRUD](https://github.com/laravel-backpack/crud) is the free & open-source core**, released under the [MIT License](https://github.com/Laravel-Backpack/CRUD/blob/master/LICENSE.md); <span class="badge badge-pill badge-success">FREE</span>
+- **[Backpack\PRO](https://backpackforlaravel.com/products/pro) is a paid closed-source Backpack add-on**, released under our [EULA](https://backpackforlaravel.com/eula); <span class="badge badge-pill badge-info">PRO</span>
+
+Since `backpack/pro` is released under the same terms of our `backpack/devtools` package:
+- you get 12 months of updates _and upgrades_, guaranteed;
+- after those 12 months you still have access to all versions you purchased;
+
+We're very happy with this new pricing, because we believe it is _fair to everyone_:
+- Open-source devs - you can now use Backpack for open-source projects;
+- Devs with low/no budget - you can now use Backpack\CRUD: no strings attached, no application form;
+- Professionals - when you buy `backpack/pro`, you get 12 months of updates and upgrades, _guaranteed_; no more worries about where we are in the release cycle; it's _always_ a good time to buy Backpack;
+- Maintainers - only people who purchase `backpack/pro` can now use the most complex features we've built and maintain; we hope that'll mean less piracy _and_ fewer reported issues;
+
+You can read more about this on [our pricing page](https://backpackforlaravel.com/pricing). We hope now you understand _why_ we're giving free access to v5 to everyone who purchased after 9 Feb 2021. We consider it _a bug fix_. We think it's only _fair_ for devs who have bought in 2021 to the same a dev that buys in 2022 gets (12 months of updates & upgrades).
+
+**After this open-core split, we no longer offer non-commercial licenses for free. We've disabled our application form.** But... if you've previously received a free non-commercial Backpack v4 license, we've got your back. Reach out by email, we'll give you access to `backpack/pro` if your project is still non-commercial.
 
 
 <a name="added"></a>
@@ -82,7 +122,7 @@ This is particularly useful if you've ever overriden your `create()` or `store()
 
 #### Define validation rules directly on fields
 
-In addition to the array validation above... Backpack 4.2 has one more trick up its sleeve. You can now also define the validation rules and vlidation messages right when you define the field. No more `FormRequest`, no more defining the validation rules separately:
+In addition to the array validation above... Backpack v5 has one more trick up its sleeve. You can now also define the validation rules and vlidation messages right when you define the field. No more `FormRequest`, no more defining the validation rules separately:
 
 ```php
 protected function setupCreateOperation()
@@ -166,7 +206,7 @@ We've spent _months_ building up and polishing the `relationship` field. It's no
 - ✅ `morphMany` (1-n) - shows a select2_multiple OR a subform if you define `subfields`
 - ✅ `morphToMany` (n-n) - shows a select2_multiple OR a subform if you define `subfields` for pivot extras
 
-One HUGE addition we've made in 4.2 is... 🥁🥁🥁 subfields. For complex relationship, you just need to define `subfields` and the select2 will be turned into a subform, allowing your admin to define extra attributes. This will save you _hours_ or even _days_ when you have complex relationships. Because right in the current form, your admin can now easily:
+One HUGE addition we've made in v5 is... 🥁🥁🥁 subfields. For complex relationship, you just need to define `subfields` and the select2 will be turned into a subform, allowing your admin to define extra attributes. This will save you _hours_ or even _days_ when you have complex relationships. Because right in the current form, your admin can now easily:
 - [create/update/delete a related 1-1 entry](/docs/{{version}}/crud-how-to#hasone-1-1-relationship) (`hasOne` and `morphOne`, eg. User and UserDetail)
 - [create/update/delete related 1-n entries](/docs/{{version}}/crud-fields#manage-related-entries-in-the-same-form-create-update-delete) (`hasMany` and `morphMany`, eg. Invoice and InvoiceItem)
 - [edit columns on the pivot table of n-n relationships](/docs/{{version}}/crud-fields#save-additional-data-to-pivot-table) (`belongsToMany` and `morphToMany`, eg. 'position' on company_user)
@@ -211,7 +251,7 @@ Of course, Backpack now uses this directive in all views that could get repeated
 
 #### Increased Default Security
 
-Starting with v4.2, Backpack will throttle password request attempts. This will prevent malicious actors from using the "reset password" functionality of your admin panel to send unsolicited emails.
+Starting with v5, Backpack will throttle password request attempts. This will prevent malicious actors from using the "reset password" functionality of your admin panel to send unsolicited emails.
 
 In addition, most column types now escape the output by default. This will better prevent your admins from XSS attacks, in case where you do not trust the information in the database to not contain javascript payloads.
 
@@ -225,4 +265,4 @@ In addition, most column types now escape the output by default. This will bette
 
 ---
 
-In order to get all of the features above (and a few more hidden gems), please [follow the upgrade guide](/docs/{{version}}/upgrade-guide), to get from Backpack 4.1 to Backpack 4.2.
+In order to get all of the features above (and a few more hidden gems), please [follow the upgrade guide](/docs/{{version}}/upgrade-guide), to get from Backpack 4.1 to Backpack v5.

--- a/5.x-dev/upgrade-guide.md
+++ b/5.x-dev/upgrade-guide.md
@@ -1,0 +1,302 @@
+# Upgrade Guide
+
+---
+
+This will guide you to upgrade from Backpack 4.1 to 4.2. The steps are color-coded by the probability that you will need it for your application: <span class="badge badge-info text-white" style="text-decoration: none;">High</span>, <span class="badge badge-warning text-white" style="text-decoration: none;">Medium</span> and <span class="badge badge-secondary-soft" style="text-decoration: none;">Low</span>.
+
+<a name="requirements"></a>
+## Requirements
+
+Please make sure your project respects the requirements below, before you start the upgrade process. You can check with ```php artisan backpack:version```:
+
+- PHP 8.x, 7.4.x or 7.3.x
+- Laravel 8.x
+- Backpack\CRUD 4.1.x
+- ~10 minutes (for most projects)
+
+**If you're running Backpack version 3.x or 4.0, please follow ALL the minor upgrade guides first, to incrementally get to use Backpack 4.1**. Test that your app works well with each version, after each upgrade. Only _afterwards_ can you follow this guide, to upgrade from 4.0 to 4.1. Previous upgrade guides:
+- [upgrade from 4.0 to 4.1](https://backpackforlaravel.com/docs/4.1/upgrade-guide);
+- [upgrade from 3.6 to 4.0](https://backpackforlaravel.com/docs/4.0/upgrade-guide); this is a major upgrade, and requires a v4 license code; if you've purchased a Backpack v3 license, but don't have a Backpack v4 license yet, [read the 4.0 Release Notes here](/docs/4.0/release-notes#backpack-v3-buyers).
+- [upgrade from 3.5 to 3.6](https://backpackforlaravel.com/docs/3.6/upgrade-guide);
+- [upgrade from 3.4 to 3.5](https://backpackforlaravel.com/docs/3.5/upgrade-guide);
+- [upgrade from 3.3 to 3.4](https://backpackforlaravel.com/docs/3.4/upgrade-guide);
+
+<a name="upgraade-steps"></a>
+## Upgrade Steps
+
+The upgrade guide might seem long and intimidating, but really, it's an easy upgrade. But **most projects will only be affected by a few of the 22 breaking changes outlined below**. And when there are changes needed, they're pretty small.
+
+Please **go thorough all steps**, to ensure a smooth upgrade process. The steps are color-coded by how likely we think that step is needed for your project: <span class="badge badge-info text-white" style="text-decoration: none;">High</span>, <span class="badge badge-warning text-white" style="text-decoration: none;">Medium</span> and <span class="badge badge-secondary-soft" style="text-decoration: none;">Low</span>.
+
+<br>
+
+
+<a name="step-0" href="#step-0" class="badge badge-info" style="text-decoration: none;">Step 0.</a> **[Upgrade to Laravel 8](https://laravel.com/docs/8.x/upgrade)**, then test to confirm your app is working fine with Laravel 8 + Backpack 4.1.
+
+<a name="composer"></a>
+### Composer
+
+<a name="step-1" href="#step-1" class="badge badge-info text-white" style="text-decoration: none;">Step 1.</a> Update your ```composer.json``` file to require ```"backpack/crud": "4.2.*"```
+
+<a name="step-2" href="#step-2" class="badge badge-warning text-white" style="text-decoration: none;">Step 2.</a> If you have a lot of Backpack add-ons installed (and their dependencies), here are their latest versions, that support Backpack 4.2. You can copy-paste the versions of the packages you're using:
+
+// TODO
+
+```
+        "backpack/logmanager": "^4.0.0",
+        "backpack/settings": "^3.0.0",
+        "backpack/pagemanager": "^3.0.0",
+        "backpack/menucrud": "^2.0.0",
+        "backpack/newscrud": "^4.0.0",
+        "backpack/permissionmanager": "^6.0.0",
+        "backpack/backupmanager": "^2.0.0",
+        "spatie/laravel-translatable": "^4.0",
+        "backpack/langfilemanager": "^3.0.0",
+
+        /* and in require-dev */
+
+        "backpack/generators": "^3.0",
+        "laracasts/generators": "^1.0"
+```
+
+<a name="step-3" href="#step-3" class="badge badge-info text-white" style="text-decoration: none;">Step 3.</a> Run ```composer update``` in the command line.
+
+<a name="models"></a>
+### Models
+
+<a name="step-4" href="#step-4" class="badge badge-warning text-white" style="text-decoration: none;">Step 4.</a> The `repeatable` field has been completely rewritten, in order to work with values as a nested PHP array, not a JSON. This has HUGE benefits, but presents some small breaking changes. **If you've used the `repeatable` field in your CRUDs**
+- please make sure that db column is casted as `array` or `json` (eg. add `protected $casts = ['testimonials' => 'array'];` to your model);
+- a data syntax bug has been fixed - previously, if inside `repeatable` you used a subfield with multiple values (`select_multiple` or `select2_multiple` etc.), it would not store `'categories': [1, 2]` like you'd expect, but `'categories[]': [1, 2]`; those brackets were not intentional, but we could not fix them without telling you about  it; when upgrading to 4.2:
+    - if you've coded a workaround to strip those brackets, you can now remove the workaround;
+    - if you use the attribute with brackets anywhere, please expect it to be either _with_ or _without_ brackets; Backpack will NOT strip all the brackets automatically, it will only strip them upon saving, when an admin edits that particular entry;
+
+<a name="form-requests"></a>
+### Form Requests
+
+<a name="step-5" href="#step-5" class="badge badge-warning text-white" style="text-decoration: none;">Step 5.</a> **For `repeatable` fields, you no longer have to create custom validation logic. You can now use Laravel's [nested array validation](https://laravel.com/docs/validation#validating-nested-array-input).** If you've used a `repeatable` in your CRUDs and validated it in your FormRequest:
+- you can keep your custom validation logic, but make sure you no longer `json_decode()` the value in the input; if you've used our validation example, that means instead of `$fieldGroups = json_decode($value);` you should do `$fieldGroups = is_array($value) ? $value : [];`;
+- you can rewrite that validation in a cleaner and more concise way, using [Laravel's nested array input validation rules](https://laravel.com/docs/validation#validating-nested-array-input); for example, you can do `'testimonial.*.name' => 'required|min:5|max:256'` to validate all `name` subfields inside a repeatable `testimonial`;
+
+<a name="routes"></a>
+### Routes
+
+No changes needed.
+
+<a name="config"></a>
+### Config
+
+<a name="step-6" href="#step-6" class="badge badge-secondary-soft" style="text-decoration: none;">Step 6.</a> Security improvement: Starting with v4.2, Backpack will throttle password request attempts, so that a malicious actor cannot use the "reset password" functionality to send unsolicited emails. We recommend you add this configuration entry to your `config/backpack/base.php` (before "_Authentication_"). See [#3862](https://github.com/Laravel-Backpack/CRUD/pull/3862) for details.
+
+```php
+    /*
+    |--------------------------------------------------------------------------
+    | Security
+    |--------------------------------------------------------------------------
+    */
+
+    // Backpack will prevent visitors from requesting password recovery too many times
+    // for a certain email, to make sure they cannot be spammed that way.
+    // How many seconds should a visitor wait, after they've requested a
+    // password reset, before they can try again for the same email?
+    'password_recovery_throttle_notifications' => 600, // time in seconds
+
+    // Backpack will prevent an IP from trying to reset the password too many times,
+    // so that a malicious actor cannot try too many emails, too see if they have
+    // accounts or to increase the AWS/SendGrid/etc bill.
+    //
+    // How many times in any given time period should the user be allowed to
+    // attempt a password reset? Take into account that user might wrongly
+    // type an email at first, so at least allow one more try.
+    // Defaults to 3,10 - 3 times in 10 minutes.
+    'password_recovery_throttle_access' => '3,10',
+```
+
+----
+
+
+<a name="step-7" href="#step-7" class="badge badge-info text-white" style="text-decoration: none;">Step 7.</a> Operation configurations have been moved from `config/backpack/crud.php`, each to its own file. That way, if an operation config value isn't present, it will fall back to Backpack's default value. To upgrade, please:
+- run `php artisan vendor:publish --provider="Backpack\CRUD\BackpackServiceProvider" --tag=config` - this will publish a new config file for each operation (eg. `config/backpack/operations/create.php`, `update.php` etc.);
+- if you've changed things inside your `config/backpack/crud.php`, then make the same changes inside the config files you've published above;
+- in your `config/backpack/crud.php` delete the `operations` array entirely;
+
+----
+
+<a name="step-8" href="#step-8" class="badge badge-secondary-soft" style="text-decoration: none;">Step 8.</a> Inside `config/backpack/crud.php`, you were previously able to change what inputs are stripped from the request before saving, by configuring `saveAllInputsExcept` for the Create and Update operations. We have moved the configuration to `config/backpack/operations/create.php` & `config/backpack/operations/update.php`, then:
+- renamed it to `strippedRequest`;
+- given you the possibility to do whatever you want to the request, by using a `closure` instead of `array`;
+- kept the default behaviour; if `strippedRequest` is undefined or false, Backpack will strip all inputs that don't have fields, which we consider is the safest approach;
+
+**If in your `config/backpack/operations/create.php` or `config/backpack/operations/update.php` you've copied `saveAllInputsExcept` as `null` or `false`, you don't have to do anything.**
+
+However, **if you have an array for your `saveAllInputsExcept`**, you can now achieve the same thing by stripping the request yourself in a closure. Basically:
+```diff
+-    'saveAllInputsExcept' => ['_token', '_method', 'http_referrer', 'current_tab', 'save_action'],
++    'strippedRequest' => (function ($request) {
++        return $request->except('_token', '_method', '_http_referrer', '_current_tab', '_save_action');
++    }),
+```
+But you can also do a lot more, because you have the `$request` in that closure. See more info in PR #[3987](https://github.com/Laravel-Backpack/CRUD/pull/3987). In addition, please notice that all hidden parameters are now prefixed by an underscore. Starting with 4.2, if it starts with an underscore, you know it's not an actual database column.
+
+
+----
+
+
+<a name="step-9" href="#step-9" class="badge badge-secondary-soft" style="text-decoration: none;">Step 9.</a> The **Show operation** will now show `created_at`, `updated_at` columns by default, if they exist. In most cases, this is what you want - show as many things as possible inside the Show operation - and `created_at` and `updated_at` provide some useful information about the entry. So it should NOT negatively affect you. But if you _don't_ want to show those columns, you can turn off this new default behavior in your `config/backpack/operations/show.php`, by defining `'timestamps' => false,`. You can also do `'softDeletes' => true,` if you want to show that column, by the way.
+
+<a name="controllers"></a>
+### CrudControllers
+
+<a name="step-10" href="#step-10" class="badge badge-secondary-soft" style="text-decoration: none;">Step 10.</a> We've improved the guessing of column types, by also taking into consideration your Model casts ([PR here](https://github.com/Laravel-Backpack/CRUD/pull/3618)). If you have places in your CrudControllers where you have NOT defined a column type (and just assumed it'll probably be `text`), but that item is cast as `date`, `json`, `array` etc... Backpack will now try to show a more appropriate column type for it, instead of `text`. This is unlikely to affect you negatively, but... it's not a terrible idea to go through all your ListOperation and ShowOperation views, to make sure you're happy with what's displayed.
+
+----
+
+<a name="step-11" href="#step-11" class="badge badge-secondary-soft" style="text-decoration: none;">Step 11.</a> There have been some changes in how the `repeatable` field works by default:
+- it now shows `0` rows when empty (previously it was showing `1`); we believe that provides a better UX for most projects, but if you don't like it, please define `'min_rows' => 1`;
+- we're renamed the `fields` attribute to `subfields` for more clarity (but both will work);
+- if you have subfields that do NOT have their type defined, Backpack will now assume you wanted a `text` field;
+
+----
+
+<a name="step-12" href="#step-12" class="badge badge-info text-white" style="text-decoration: none;">Step 12.</a> We have removed the **`simplemde` field**, since the JS library hasn't received any updates since 2016. However, there is a drop-in replacement called `easymde` which is well maintained. If you're using the `simplemde` field type anywhere in your project, please use `easymde` instead. A simple find & replace in your Controllers should do.
+
+----
+
+<a name="step-13" href="#step-13" class="badge badge-secondary-soft" style="text-decoration: none;">Step 13.</a> If you're using the **Reorder operation** _and_ have overriden some of its functionality, please take note that the information is now passed as JSON. Replicate the [small changes here](https://github.com/Laravel-Backpack/CRUD/pull/3808/files) in your custom code too.
+
+----
+
+<a name="step-14" href="#step-14" class="badge badge-info text-white" style="text-decoration: none;">Step 14.</a> When setting up your **Show operation** in Backpack 4.1, whatever you did inside `setupShowOperation()` was called _before_ the opration added all columns. That made it pretty difficult to delete auto-added columns. You might have used a workaround for this.
+
+Starting with Backpack 4.2, the operation will do its "_automatic setup_" inside an `autoSetupShowOperation()` method. If you define `setupShowOperation()`, that method will no longer be called, you have to call it inside you `setupShowOperation()` if you want what it does. To upgrade:
+- if you _do not_ have a `setupShowOperation()` in your CrudControllers, you are not affected by this - don't worry;
+- if you _do_ have a `setupShowOperation()` method in your CrudControllers, just the fact that you have it defined will remove all guessing of columns, so that you have complete control over what columns are shown;
+    - **to keep the same behaviour as before (guess columns), please run `$this->autoSetupShowOperation();` wherever you want inside your `setupShowOperation()`;** add it to the end of your `setupShowOperation()` to keep the same behaviour as before;
+    - if you have any workarounds for the problem mentioned above (difficult to delete columns in `setupShowOperation()`), call `$this->autoSetupShowOperation();` at the start of your `setupShowOperation()` call and eliminate your workarounds, it should now "_just work_";
+
+----
+
+<a name="step-15" href="#step-15" class="badge badge-warning text-white" style="text-decoration: none;">Step 15.</a> The **Create and Update operations** no longer save the `request()`, they save your `ProductFormRequest` (the one that contains the validation). If you have NOT modified the `request()` or `CRUD::getRequest()` in any of your CrudControllers, you will not be affected by this, move on.
+
+However, if you _have_ modified the request (most likely to add or remove inputs), those changes will never reach the db. To give you an example, if you've over overridden the `store()` or `update()` methods to add an input, it might look something like this:
+```php
+use \Backpack\CRUD\app\Http\Controllers\Operations\CreateOperation { store as traitStore; }
+
+public function store()
+{
+    $this->crud->setOperationSetting('saveAllInputsExcept', ['save_action', 'token', 'http_referrer']);
+    $this->crud->getRequest()->request->add(['updated_by' => backpack_user()->id]);     
+        
+    return $this->traitStore();
+}
+```
+
+That will no longer work, because Backpack won't save the `request()` or `$this->crud->getRequest()` any more, but your `ProductRequest`. But there are now more ways than ever to achieve the same thing. Please read all solutions below and decide which one is best for you:
+
+**Solution (A)**
+
+That actually means it's easier to change the request now inside a CrudController, but you need to do it inside the `strippedRequest` closure:
+
+```php
+public function store()
+{
+    $this->crud->set('strippedRequest', function($request) {
+        $request->add([ 'updated_by' => backpack_user()->id ]);
+        return $request->except(['_save_action', '_token', '_http_referrer']);
+    });
+        
+    return $this->traitStore();
+}
+```
+
+**Solution (B)**
+
+If you feel overriding the `store()` or `update()` methods was messy... you're not alone. We have good news for you, you can now move that logic to your `ProductRequest`, for example inside the lesser-known `prepareForValidation()` method:
+```php
+// app/Http/Requests/ProductRequest.php
+
+    protected function prepareForValidation()
+    {
+        \CRUD::setOperationSetting('strippedRequest', function ($request) {
+            $input = $request->only(\CRUD::getAllFieldNames());
+            $input['updated_by'] = backpack_user()->id;
+            
+            return $input;
+        });
+    }
+```
+
+**Solution (C)**
+
+Alternatively... if you absolutely _hate_ this new behaviour and want your previous code to continue working, you can now easily tell Backpack to save the `CRUD::getRequest()`, for all CRUDs, in your `config/backpack/operations/create.php` and `config/backpack/operations/update.php`. That way, you can keep your old CrudController overrides:
+```php
+    'strippedRequest' => (function ($request) {
+        return CRUD::getRequest()->request->except('_token', '_method', '_http_referrer', '_current_tab', '_save_action');
+    }),
+```
+
+
+----
+
+<a name="step-16" href="#step-16" class="badge badge-secondary-soft" style="text-decoration: none;">Step 16.</a> If you've customized the saving process of the Create or Update operations (read: you've overriden the `store()` or `update()` methods), please take into consideration that starting with Backpack 4.2, **when a select multiple is emptied, it will still be part of the request, as `null`**. Whereas previously (if emptied) it was missing entirely. This applies to all `select` and `select2` fields when used as `multiple`. You might need to change your saving logic accordingly, instead of expecting them to be missing, to expect them to be `null`.
+
+----
+
+
+<a name="step-17" href="#step-17" class="badge badge-secondary-soft" style="text-decoration: none;">Step 17.</a> The `page_or_link` field has been moved from `backpack/crud` to `backpack/menucrud` because it made little sense outside it. If you've used the `page_or_link` field anywhere in your CrudControllers:
+- if you have `MenuCRUD` installed: 
+    - bump the MenuCRUD version in your `composer.json` (`"backpack/menucrud": "^3.0.0"`)
+    - anywhere you've used the `page_or_link` field, make sure to specify its view_namespace (`'view_namespace' => 'menucrud::fields'`);
+- if you DO NOT have `MenuCRUD` installed;
+    -  tell us that this has affected you, in [this PR](https://github.com/Laravel-Backpack/CRUD/pull/3459);
+    -  you can create a new file in your `resources/views/vendor/backpack/fields/page_or_link.blade.php` and paste [the content from here](https://raw.githubusercontent.com/Laravel-Backpack/MenuCRUD/e0afc7960d5513017ef847480f50591400bd4a6b/src/resources/views/fields/page_or_link.blade.php);
+
+
+<a href="assets"></a>
+### CSS & JS Assets
+
+<a name="step-18" href="#step-18" class="badge badge-info text-white" style="text-decoration: none;">Step 18.</a> We've updated most CSS & JS dependencies to their latest versions. There are two ways to publish the latest styles and scripts for these dependencies:
+- (A) If you have NOT touched you ```public/packages``` folder, or placed anything custom inside it:
+        - delete the ```public/packages``` directory and all its contents;
+        - run ```php artisan vendor:publish --provider="Backpack\CRUD\BackpackServiceProvider" --tag=public```
+        - if you use elFinder, also delete ```resources/views/vendor/elfinder``` and run ```php artisan backpack:filemanager:install```
+- (B) Run ```php artisan vendor:publish --provider="Backpack\CRUD\BackpackServiceProvider" --tag=public --force```. Please note this will overwrite anything that's already there. This B solution has a downside: unused files are not removed. A few files Backpack no longer uses will still be in your ```public/packages``` folder, even though they're no longer used.
+
+----
+
+<a name="step-19" href="#step-19" class="badge badge-info text-white" style="text-decoration: none;">Step 19.</a> We've removed the custom CSS & JS files that Backpack provided for each operation (eg. `list.css` and `create.js` - [see why here](https://github.com/Laravel-Backpack/CRUD/pull/3942)).
+
+- If you've added any custom code in `public/packages/backpack/crud/css` and `public/packages/backpack/crud/js`, copy them to a different location (we suggest `public/assets/admin/css` and `public/assets/admin/js`). Then use the brand-new `script` and `style` widgets to load them only where you need them. See the [updated docs section](/docs/{{version}}/crud-how-to#add-css-and-js-to-a-page-or-operation) for more information. This is only needed if YOU have added any custom code there. The Backpack CSS that was there is now included in the `bundle.css` and `bundle.js` files.
+- if you haven't modified those at all... it is now safe to delete the `public/packages/backpack/crud/css` and `public/packages/backpack/crud/js` directories - those files are no longer loaded.
+
+<a name="views"></a>
+### Views
+
+<a name="step-20" href="#step-20" class="badge badge-secondary-soft" style="text-decoration: none;">Step 20.</a> **Have you developed any custom fields or columns?** Rephrased: do you have anything inside your `resources/views/vendor/backpack/crud/fields` or `resources/views/vendor/backpack/crud/fields`? If so, and those fields or columns load any external CSS or JS, we recommended you load them using `@loadOnce('path/to/file.css')` and `@loadOnce('path/to/file.js')` instead of `<link href="path/to/file.css>"` and `<script src="path/to/file.js></script>"`. This will make sure that piece of JS/CSS/code is only loaded once per pageload. You can find [more info about it here](https://github.com/digitallyhappy/assets) (and why it's more than `@once`).
+
+----
+
+<a name="step-21" href="#step-21" class="badge badge-secondary-soft" style="text-decoration: none;">Step 21.</a> If you've overwritten any of the default operations in any way (blade files or PHP classes), take note that we've renamed the system GET/POST parameters (aka hidden inputs) - they're all prefixed by underscore now, to differentiate them from actual database columns. Please replace `http_referrer`, `locale`, `current_tab` with `_http_referrer`, `_locale`, `_current_tab`, respectively. [Take a look at the PR](https://github.com/Laravel-Backpack/CRUD/pull/3955/files) to see the affected files. In 99% of all cases you won't be affected by this, there's little reason to overwrite the default operations. This also applies if you've overridden the `SaveActions` or `form_content`.
+
+<a name="security"></a>
+### Security
+
+<a name="step-22" href="#step-22" class="badge badge-info" style="text-decoration: none;">Step 22.</a> By default, all columns now echo using `{{ }}` instead of `{!! !!}`. That means they "_escape the output_", assuming they contain strings, not HTML. This was done to increase _default security_, to protect the admin from any malicious strings that might have been stored in the database. There are two exceptions to this, two columns that are not `escaped` by default: `custom_html` and `markdown`, where Backpack assumes you store HTML. To upgrade:
+- If you've been showing HTML using the `array`, `array_count`, `closure`, `model_function`, `model_function_attribute`, `relationship_count` or `textarea` columns, you can use `'escaped' => false` on those columns to go back to the previous behaviour. But please [read more about this](/docs/{{version}}/crud-columns#escape-column-output), it might be a good idea to sanitize your input/output if you've forgotten to do so.
+- If you're using the `markdown` or `custom_html` columns, please note that they still DO NOT escape the output by default (since they most likely store HTML); make sure you've properly sanitized your input or output - it's super-easy using an [HTML Purifier package](https://github.com/mewebstudio/Purifier) (you can do that by casting the attribute to `CleanHtmlOutput::class` in your Model or [manually](https://github.com/Laravel-Backpack/demo/commit/7342cffb418bb568b9e4ee279859685ddc0456c1));
+
+
+<a name="cache"></a>
+### Cache
+
+<a name="step-23" href="#step-23" class="badge badge-info text-white" style="text-decoration: none;">Step 23.</a> Clear your app's cache:
+```
+php artisan config:clear
+php artisan cache:clear
+php artisan view:clear
+```
+
+---
+
+**You're done! Good job.** Thank you for taking the time to upgrade. Now you can:
+- thoroughly test your application and your admin panel;
+- start using the [new features in Backpack 4.2](/docs/{{version}}/release-notes);

--- a/5.x-dev/upgrade-guide.md
+++ b/5.x-dev/upgrade-guide.md
@@ -2,19 +2,19 @@
 
 ---
 
-This will guide you to upgrade from Backpack 4.1 to 4.2. The steps are color-coded by the probability that you will need it for your application: <span class="badge badge-info text-white" style="text-decoration: none;">High</span>, <span class="badge badge-warning text-white" style="text-decoration: none;">Medium</span> and <span class="badge badge-secondary-soft" style="text-decoration: none;">Low</span>.
+This will guide you to upgrade from Backpack 4.1 to v5. The steps are color-coded by the probability that you will need it for your application: <span class="badge badge-danger text-white" style="text-decoration: none;">High</span>, <span class="badge badge-warning text-white" style="text-decoration: none;">Medium</span> and <span class="badge badge-secondary-soft" style="text-decoration: none;">Low</span>.
 
 <a name="requirements"></a>
 ## Requirements
 
 Please make sure your project respects the requirements below, before you start the upgrade process. You can check with ```php artisan backpack:version```:
 
-- PHP 8.x, 7.4.x or 7.3.x
-- Laravel 8.x
+- PHP 8.x, 7.4 or 7.3
+- Laravel 9.x or 8.x
 - Backpack\CRUD 4.1.x
-- ~10 minutes (for most projects)
+- 10-15 minutes (for most projects)
 
-**If you're running Backpack version 3.x or 4.0, please follow ALL the minor upgrade guides first, to incrementally get to use Backpack 4.1**. Test that your app works well with each version, after each upgrade. Only _afterwards_ can you follow this guide, to upgrade from 4.0 to 4.1. Previous upgrade guides:
+**If you're running Backpack version 3.x or 4.0, please follow ALL other upgrade guides first, to incrementally get to use Backpack 4.1**. Test that your app works well with each version, after each upgrade. Only _afterwards_ can you follow this guide, to upgrade from 4.1 to v5. Previous upgrade guides:
 - [upgrade from 4.0 to 4.1](https://backpackforlaravel.com/docs/4.1/upgrade-guide);
 - [upgrade from 3.6 to 4.0](https://backpackforlaravel.com/docs/4.0/upgrade-guide); this is a major upgrade, and requires a v4 license code; if you've purchased a Backpack v3 license, but don't have a Backpack v4 license yet, [read the 4.0 Release Notes here](/docs/4.0/release-notes#backpack-v3-buyers).
 - [upgrade from 3.5 to 3.6](https://backpackforlaravel.com/docs/3.6/upgrade-guide);
@@ -24,21 +24,29 @@ Please make sure your project respects the requirements below, before you start 
 <a name="upgraade-steps"></a>
 ## Upgrade Steps
 
-The upgrade guide might seem long and intimidating, but really, it's an easy upgrade. But **most projects will only be affected by a few of the 22 breaking changes outlined below**. And when there are changes needed, they're pretty small.
+The upgrade guide might seem long or intimidating, but really, it's an easy upgrade. But **most projects will only be affected by a few of the breaking changes outlined below**. And when there are changes needed, they're pretty small.
 
-Please **go thorough all steps**, to ensure a smooth upgrade process. The steps are color-coded by how likely we think that step is needed for your project: <span class="badge badge-info text-white" style="text-decoration: none;">High</span>, <span class="badge badge-warning text-white" style="text-decoration: none;">Medium</span> and <span class="badge badge-secondary-soft" style="text-decoration: none;">Low</span>.
+Please **go thorough all steps**, to ensure a smooth upgrade process. The steps are color-coded by how likely we think that step is needed for your project: <span class="badge badge-danger text-white" style="text-decoration: none;">High</span>, <span class="badge badge-warning text-white" style="text-decoration: none;">Medium</span> and <span class="badge badge-secondary-soft" style="text-decoration: none;">Low</span>. **At the very least, read what's in bold**.
 
 <br>
 
 
-<a name="step-0" href="#step-0" class="badge badge-info" style="text-decoration: none;">Step 0.</a> **[Upgrade to Laravel 8](https://laravel.com/docs/8.x/upgrade)**, then test to confirm your app is working fine with Laravel 8 + Backpack 4.1.
+<a name="step-0" href="#step-0" class="badge badge-danger" style="text-decoration: none;">Step 0.</a> **[Upgrade to Laravel 8](https://laravel.com/docs/8.x/upgrade) or [Laravel 9](https://laravel.com/docs/9.x/upgrade), then test to confirm your app is working fine.**
 
 <a name="composer"></a>
 ### Composer
 
-<a name="step-1" href="#step-1" class="badge badge-info text-white" style="text-decoration: none;">Step 1.</a> Update your ```composer.json``` file to require ```"backpack/crud": "4.2.*"```
+<a name="step-1" href="#step-1" class="badge badge-danger text-white" style="text-decoration: none;">Step 1.</a> Update your ```composer.json``` file to require:
 
-<a name="step-2" href="#step-2" class="badge badge-warning text-white" style="text-decoration: none;">Step 2.</a> If you have a lot of Backpack add-ons installed (and their dependencies), here are their latest versions, that support Backpack 4.2. You can copy-paste the versions of the packages you're using:
+```
+        "backpack/crud": "^5.0.0",
+        "backpack/pro": "^1.0.0",
+```
+
+These two packages together will help you have all the features in v4.1 and more. But since `backpack/pro` is a closed-source package, to download it, you need to generate [your token and password here](https://backpackforlaravel.com/user/tokens). If no button is there for you, it means you don't have free access to `backpack/pro`, so you'll need to [purchase it](https://backpackforlaravel.com/products/pro), which will give you 12months of updates and upgrades, starting with the purchase date. [Follow the 2-step process called "Instructions" in your token](https://backpackforlaravel.test/user/tokens) to authenticate and add our private repo.
+
+
+<a name="step-2" href="#step-2" class="badge badge-warning text-white" style="text-decoration: none;">Step 2.</a> If you have a lot of Backpack add-ons installed (and their dependencies), here are their latest versions, that support Backpack v5. You can copy-paste the versions of the packages you're using:
 
 // TODO
 
@@ -59,14 +67,14 @@ Please **go thorough all steps**, to ensure a smooth upgrade process. The steps 
         "laracasts/generators": "^1.0"
 ```
 
-<a name="step-3" href="#step-3" class="badge badge-info text-white" style="text-decoration: none;">Step 3.</a> Run ```composer update``` in the command line.
+<a name="step-3" href="#step-3" class="badge badge-danger text-white" style="text-decoration: none;">Step 3.</a> Run ```composer update``` in the command line.
 
 <a name="models"></a>
 ### Models
 
-<a name="step-4" href="#step-4" class="badge badge-warning text-white" style="text-decoration: none;">Step 4.</a> The `repeatable` field has been completely rewritten, in order to work with values as a nested PHP array, not a JSON. This has HUGE benefits, but presents some small breaking changes. **If you've used the `repeatable` field in your CRUDs**
+<a name="step-4" href="#step-4" class="badge badge-warning text-white" style="text-decoration: none;">Step 4.</a> The `repeatable` field has been completely rewritten, in order to work with values as a nested PHP array, not a JSON. This has HUGE benefits, but it does present some small breaking changes. **If you've used the `repeatable` field in your CRUDs**
 - please make sure that db column is casted as `array` or `json` (eg. add `protected $casts = ['testimonials' => 'array'];` to your model);
-- a data syntax bug has been fixed - previously, if inside `repeatable` you used a subfield with multiple values (`select_multiple` or `select2_multiple` etc.), it would not store `'categories': [1, 2]` like you'd expect, but `'categories[]': [1, 2]`; those brackets were not intentional, but we could not fix them without telling you about  it; when upgrading to 4.2:
+- a data syntax bug has been fixed - previously, if inside `repeatable` you used a subfield with multiple values (`select_multiple` or `select2_multiple` etc.), it would not store `'categories': [1, 2]` like you'd expect, but `'categories[]': [1, 2]`; those brackets were not intentional, but we could not fix them without telling you about  it; so, when upgrading to v5:
     - if you've coded a workaround to strip those brackets, you can now remove the workaround;
     - if you use the attribute with brackets anywhere, please expect it to be either _with_ or _without_ brackets; Backpack will NOT strip all the brackets automatically, it will only strip them upon saving, when an admin edits that particular entry;
 
@@ -85,7 +93,7 @@ No changes needed.
 <a name="config"></a>
 ### Config
 
-<a name="step-6" href="#step-6" class="badge badge-secondary-soft" style="text-decoration: none;">Step 6.</a> Security improvement: Starting with v4.2, Backpack will throttle password request attempts, so that a malicious actor cannot use the "reset password" functionality to send unsolicited emails. We recommend you add this configuration entry to your `config/backpack/base.php` (before "_Authentication_"). See [#3862](https://github.com/Laravel-Backpack/CRUD/pull/3862) for details.
+<a name="step-6" href="#step-6" class="badge badge-secondary-soft" style="text-decoration: none;">Step 6.</a> Security improvement: Starting with v5, Backpack will throttle password request attempts, so that a malicious actor cannot use the "reset password" functionality to send unsolicited emails. We recommend you add this configuration entry to your `config/backpack/base.php` (before "_Authentication_"). See [#3862](https://github.com/Laravel-Backpack/CRUD/pull/3862) for details.
 
 ```php
     /*
@@ -114,7 +122,7 @@ No changes needed.
 ----
 
 
-<a name="step-7" href="#step-7" class="badge badge-info text-white" style="text-decoration: none;">Step 7.</a> Operation configurations have been moved from `config/backpack/crud.php`, each to its own file. That way, if an operation config value isn't present, it will fall back to Backpack's default value. To upgrade, please:
+<a name="step-7" href="#step-7" class="badge badge-danger text-white" style="text-decoration: none;">Step 7.</a> **Operation configurations have been moved** from `config/backpack/crud.php`, each to its own file. That way, if an operation config value isn't present, it will fall back to Backpack's default value. To upgrade, please:
 - run `php artisan vendor:publish --provider="Backpack\CRUD\BackpackServiceProvider" --tag=config` - this will publish a new config file for each operation (eg. `config/backpack/operations/create.php`, `update.php` etc.);
 - if you've changed things inside your `config/backpack/crud.php`, then make the same changes inside the config files you've published above;
 - in your `config/backpack/crud.php` delete the `operations` array entirely;
@@ -135,7 +143,7 @@ However, **if you have an array for your `saveAllInputsExcept`**, you can now ac
 +        return $request->except('_token', '_method', '_http_referrer', '_current_tab', '_save_action');
 +    }),
 ```
-But you can also do a lot more, because you have the `$request` in that closure. See more info in PR #[3987](https://github.com/Laravel-Backpack/CRUD/pull/3987). In addition, please notice that all hidden parameters are now prefixed by an underscore. Starting with 4.2, if it starts with an underscore, you know it's not an actual database column.
+But you can also do a lot more, because you have the `$request` in that closure. See more info in PR #[3987](https://github.com/Laravel-Backpack/CRUD/pull/3987). In addition, please notice that **all hidden parameters are now prefixed by an underscore**. Starting with v5, if it starts with an underscore, you know it's not an actual database column.
 
 
 ----
@@ -151,25 +159,25 @@ But you can also do a lot more, because you have the `$request` in that closure.
 ----
 
 <a name="step-11" href="#step-11" class="badge badge-secondary-soft" style="text-decoration: none;">Step 11.</a> There have been some changes in how the `repeatable` field works by default:
-- it now shows `0` rows when empty (previously it was showing `1`); we believe that provides a better UX for most projects, but if you don't like it, please define `'min_rows' => 1`;
+- it now shows no rows when empty (previously it was showing one); we believe that provides a better UX for most projects, but if you don't like it, please define `'min_rows' => 1`;
 - we're renamed the `fields` attribute to `subfields` for more clarity (but both will work);
 - if you have subfields that do NOT have their type defined, Backpack will now assume you wanted a `text` field;
 
 ----
 
-<a name="step-12" href="#step-12" class="badge badge-info text-white" style="text-decoration: none;">Step 12.</a> We have removed the **`simplemde` field**, since the JS library hasn't received any updates since 2016. However, there is a drop-in replacement called `easymde` which is well maintained. If you're using the `simplemde` field type anywhere in your project, please use `easymde` instead. A simple find & replace in your Controllers should do.
+<a name="step-12" href="#step-12" class="badge badge-danger text-white" style="text-decoration: none;">Step 12.</a> We have **removed the `simplemde` field**, since the JS library hasn't received any updates since 2016. However, there is a drop-in replacement called `easymde` which is well maintained. If you're using the `simplemde` field type anywhere in your project, please use `easymde` instead. A simple find & replace in your Controllers should do.
 
 ----
 
-<a name="step-13" href="#step-13" class="badge badge-secondary-soft" style="text-decoration: none;">Step 13.</a> If you're using the **Reorder operation** _and_ have overriden some of its functionality, please take note that the information is now passed as JSON. Replicate the [small changes here](https://github.com/Laravel-Backpack/CRUD/pull/3808/files) in your custom code too.
+<a name="step-13" href="#step-13" class="badge badge-secondary-soft" style="text-decoration: none;">Step 13.</a> If you're using the **Reorder operation** _and_ have overriden some of its functionality in your CrudController, please take note that the information is now passed as JSON. Replicate the [small changes here](https://github.com/Laravel-Backpack/CRUD/pull/3808/files) in your custom code too.
 
 ----
 
-<a name="step-14" href="#step-14" class="badge badge-info text-white" style="text-decoration: none;">Step 14.</a> When setting up your **Show operation** in Backpack 4.1, whatever you did inside `setupShowOperation()` was called _before_ the opration added all columns. That made it pretty difficult to delete auto-added columns. You might have used a workaround for this.
+<a name="step-14" href="#step-14" class="badge badge-danger text-white" style="text-decoration: none;">Step 14.</a> When setting up your **Show operation** in Backpack 4.1, after your `setupShowOperation()` was run, Backpack would try to add more columns. That made it difficult to delete auto-added columns. You might have used a workaround for this.
 
-Starting with Backpack 4.2, the operation will do its "_automatic setup_" inside an `autoSetupShowOperation()` method. If you define `setupShowOperation()`, that method will no longer be called, you have to call it inside you `setupShowOperation()` if you want what it does. To upgrade:
+Starting with Backpack v5, the operation will no longer do any "_automatic setup_" inside `setupShowOperation()` or after it. Instead, if you want Backpack to guess column names, you have to manually call a new method, `$this->autoSetupShowOperation()`. To upgrade:
 - if you _do not_ have a `setupShowOperation()` in your CrudControllers, you are not affected by this - don't worry;
-- if you _do_ have a `setupShowOperation()` method in your CrudControllers, just the fact that you have it defined will remove all guessing of columns, so that you have complete control over what columns are shown;
+- if you _do_ have a `setupShowOperation()` method in your CrudControllers:
     - **to keep the same behaviour as before (guess columns), please run `$this->autoSetupShowOperation();` wherever you want inside your `setupShowOperation()`;** add it to the end of your `setupShowOperation()` to keep the same behaviour as before;
     - if you have any workarounds for the problem mentioned above (difficult to delete columns in `setupShowOperation()`), call `$this->autoSetupShowOperation();` at the start of your `setupShowOperation()` call and eliminate your workarounds, it should now "_just work_";
 
@@ -177,7 +185,7 @@ Starting with Backpack 4.2, the operation will do its "_automatic setup_" inside
 
 <a name="step-15" href="#step-15" class="badge badge-warning text-white" style="text-decoration: none;">Step 15.</a> The **Create and Update operations** no longer save the `request()`, they save your `ProductFormRequest` (the one that contains the validation). If you have NOT modified the `request()` or `CRUD::getRequest()` in any of your CrudControllers, you will not be affected by this, move on.
 
-However, if you _have_ modified the request (most likely to add or remove inputs), those changes will never reach the db. To give you an example, if you've over overridden the `store()` or `update()` methods to add an input, it might look something like this:
+However, **if you _have_ modified the request (most likely to add or remove inputs)**, those changes will never reach the database now. To give you an example, if you've over overridden the `store()` or `update()` methods to add an input, it might look something like this:
 ```php
 use \Backpack\CRUD\app\Http\Controllers\Operations\CreateOperation { store as traitStore; }
 
@@ -237,7 +245,7 @@ Alternatively... if you absolutely _hate_ this new behaviour and want your previ
 
 ----
 
-<a name="step-16" href="#step-16" class="badge badge-secondary-soft" style="text-decoration: none;">Step 16.</a> If you've customized the saving process of the Create or Update operations (read: you've overriden the `store()` or `update()` methods), please take into consideration that starting with Backpack 4.2, **when a select multiple is emptied, it will still be part of the request, as `null`**. Whereas previously (if emptied) it was missing entirely. This applies to all `select` and `select2` fields when used as `multiple`. You might need to change your saving logic accordingly, instead of expecting them to be missing, to expect them to be `null`.
+<a name="step-16" href="#step-16" class="badge badge-secondary-soft" style="text-decoration: none;">Step 16.</a> If you've customized the saving process of the Create or Update operations (read: you've overriden the `store()` or `update()` methods), please take into consideration that starting with Backpack v5, **when a select multiple is emptied, it will still be part of the request, as `null`**. Whereas previously (if emptied) it was missing entirely. This applies to all `select` and `select2` fields when used as `multiple`. You might need to change your saving logic accordingly, instead of expecting them to be missing, to expect them to be `null`.
 
 ----
 
@@ -254,24 +262,24 @@ Alternatively... if you absolutely _hate_ this new behaviour and want your previ
 <a href="assets"></a>
 ### CSS & JS Assets
 
-<a name="step-18" href="#step-18" class="badge badge-info text-white" style="text-decoration: none;">Step 18.</a> We've updated most CSS & JS dependencies to their latest versions. There are two ways to publish the latest styles and scripts for these dependencies:
+<a name="step-18" href="#step-18" class="badge badge-danger text-white" style="text-decoration: none;">Step 18.</a> We've removed the custom CSS & JS files that Backpack provided for each operation (eg. `list.css` and `create.js` - [see why here](https://github.com/Laravel-Backpack/CRUD/pull/3942)).
+
+- If you've added any custom code in `public/packages/backpack/crud/css` and `public/packages/backpack/crud/js`, copy them to a different location (we suggest `public/assets/admin/css` and `public/assets/admin/js`). Then use the brand-new `script` and `style` widgets to load them only where you need them. See the [updated docs section](/docs/{{version}}/crud-how-to#add-css-and-js-to-a-page-or-operation) for more information. This is only needed if YOU have added any custom code there. The Backpack CSS that was there is now included in the `bundle.css` and `bundle.js` files.
+- if you haven't modified those at all... it is now safe to delete the `public/packages/backpack/crud/css` and `public/packages/backpack/crud/js` directories - those files are no longer loaded.
+
+----
+
+<a name="step-19" href="#step-19" class="badge badge-danger text-white" style="text-decoration: none;">Step 19.</a> We've updated most CSS & JS dependencies to their latest versions. There are two ways to publish the latest styles and scripts for these dependencies:
 - (A) If you have NOT touched you ```public/packages``` folder, or placed anything custom inside it:
         - delete the ```public/packages``` directory and all its contents;
         - run ```php artisan vendor:publish --provider="Backpack\CRUD\BackpackServiceProvider" --tag=public```
         - if you use elFinder, also delete ```resources/views/vendor/elfinder``` and run ```php artisan backpack:filemanager:install```
 - (B) Run ```php artisan vendor:publish --provider="Backpack\CRUD\BackpackServiceProvider" --tag=public --force```. Please note this will overwrite anything that's already there. This B solution has a downside: unused files are not removed. A few files Backpack no longer uses will still be in your ```public/packages``` folder, even though they're no longer used.
 
-----
-
-<a name="step-19" href="#step-19" class="badge badge-info text-white" style="text-decoration: none;">Step 19.</a> We've removed the custom CSS & JS files that Backpack provided for each operation (eg. `list.css` and `create.js` - [see why here](https://github.com/Laravel-Backpack/CRUD/pull/3942)).
-
-- If you've added any custom code in `public/packages/backpack/crud/css` and `public/packages/backpack/crud/js`, copy them to a different location (we suggest `public/assets/admin/css` and `public/assets/admin/js`). Then use the brand-new `script` and `style` widgets to load them only where you need them. See the [updated docs section](/docs/{{version}}/crud-how-to#add-css-and-js-to-a-page-or-operation) for more information. This is only needed if YOU have added any custom code there. The Backpack CSS that was there is now included in the `bundle.css` and `bundle.js` files.
-- if you haven't modified those at all... it is now safe to delete the `public/packages/backpack/crud/css` and `public/packages/backpack/crud/js` directories - those files are no longer loaded.
-
 <a name="views"></a>
 ### Views
 
-<a name="step-20" href="#step-20" class="badge badge-secondary-soft" style="text-decoration: none;">Step 20.</a> **Have you developed any custom fields or columns?** Rephrased: do you have anything inside your `resources/views/vendor/backpack/crud/fields` or `resources/views/vendor/backpack/crud/fields`? If so, and those fields or columns load any external CSS or JS, we recommended you load them using `@loadOnce('path/to/file.css')` and `@loadOnce('path/to/file.js')` instead of `<link href="path/to/file.css>"` and `<script src="path/to/file.js></script>"`. This will make sure that piece of JS/CSS/code is only loaded once per pageload. You can find [more info about it here](https://github.com/digitallyhappy/assets) (and why it's more than `@once`).
+<a name="step-20" href="#step-20" class="badge badge-secondary-soft" style="text-decoration: none;">Step 20.</a> **Have you developed any custom fields or columns?** Rephrased: do you have anything inside your `resources/views/vendor/backpack/crud/fields` or `resources/views/vendor/backpack/crud/fields`? If so, and those fields or columns load any external CSS or JS, we recommended you load them using `@loadOnce('path/to/file.css')` and `@loadOnce('path/to/file.js')` instead of `<link href="path/to/file.css">` and `<script src="path/to/file.js"></script>`. This will make sure that piece of JS/CSS/code is only loaded once per pageload. You can find [more info about it here](https://github.com/digitallyhappy/assets) (and why it's more than `@once`).
 
 ----
 
@@ -280,7 +288,7 @@ Alternatively... if you absolutely _hate_ this new behaviour and want your previ
 <a name="security"></a>
 ### Security
 
-<a name="step-22" href="#step-22" class="badge badge-info" style="text-decoration: none;">Step 22.</a> By default, all columns now echo using `{{ }}` instead of `{!! !!}`. That means they "_escape the output_", assuming they contain strings, not HTML. This was done to increase _default security_, to protect the admin from any malicious strings that might have been stored in the database. There are two exceptions to this, two columns that are not `escaped` by default: `custom_html` and `markdown`, where Backpack assumes you store HTML. To upgrade:
+<a name="step-22" href="#step-22" class="badge badge-danger" style="text-decoration: none;">Step 22.</a> By default, all columns now echo using `{{ }}` instead of `{!! !!}`. That means they "_escape the output_", assuming they contain strings, not HTML. This was done to increase _default security_, to protect the admin from any malicious strings that might have been stored in the database. There are two exceptions to this, two columns that are not `escaped` by default: `custom_html` and `markdown`, where Backpack assumes you store HTML. To upgrade:
 - If you've been showing HTML using the `array`, `array_count`, `closure`, `model_function`, `model_function_attribute`, `relationship_count` or `textarea` columns, you can use `'escaped' => false` on those columns to go back to the previous behaviour. But please [read more about this](/docs/{{version}}/crud-columns#escape-column-output), it might be a good idea to sanitize your input/output if you've forgotten to do so.
 - If you're using the `markdown` or `custom_html` columns, please note that they still DO NOT escape the output by default (since they most likely store HTML); make sure you've properly sanitized your input or output - it's super-easy using an [HTML Purifier package](https://github.com/mewebstudio/Purifier) (you can do that by casting the attribute to `CleanHtmlOutput::class` in your Model or [manually](https://github.com/Laravel-Backpack/demo/commit/7342cffb418bb568b9e4ee279859685ddc0456c1));
 
@@ -288,7 +296,7 @@ Alternatively... if you absolutely _hate_ this new behaviour and want your previ
 <a name="cache"></a>
 ### Cache
 
-<a name="step-23" href="#step-23" class="badge badge-info text-white" style="text-decoration: none;">Step 23.</a> Clear your app's cache:
+<a name="step-23" href="#step-23" class="badge badge-danger text-white" style="text-decoration: none;">Step 23.</a> Clear your app's cache:
 ```
 php artisan config:clear
 php artisan cache:clear
@@ -299,4 +307,4 @@ php artisan view:clear
 
 **You're done! Good job.** Thank you for taking the time to upgrade. Now you can:
 - thoroughly test your application and your admin panel;
-- start using the [new features in Backpack 4.2](/docs/{{version}}/release-notes);
+- start using the [new features in Backpack v5](/docs/{{version}}/release-notes);


### PR DESCRIPTION
Turns out we can't call this release v4.2, we _have to_ call it v5. I think that's better anyway. In this PR I've made the docs changes needed:
- renamed 4.2 to v5 everywhere
- polished the upgrade guide
- polished the release notes
- mentioned PRO for each PRO feature
- added installation steps for backpack/pro
- added explanation about open-core split to upgrade guide