### PR TITLE
fix tinymce documentation

### DIFF
--- a/5.x/crud-fields.md
+++ b/5.x/crud-fields.md
@@ -2287,7 +2287,11 @@ Show a wysiwyg (TinyMCE) to the user.
     'label' => 'Description',
     'type'  => 'tinymce',
     // optional overwrite of the configuration array
-    // 'options' => [ 'selector' => 'textarea.tinymce',  'skin' => 'dick-light', 'plugins' => 'image,link,media,anchor' ],
+    // 'options' => [ 
+        //'selector' => 'textarea.tinymce',  
+        //'skin' => 'dick-light', 
+        //'plugins' => 'image link media anchor' 
+    // ],
 ],
 ```
 
@@ -2295,6 +2299,13 @@ Input preview:
 
 ![CRUD Field - tinymce](https://backpackforlaravel.com/uploads/docs-4-2/fields/tinymce.png)
 
+**NOTE**: if you want to modify the toolbar buttons (add or remove), here is the default configured toolbar so you can modify it:
+
+```php
+'options' => ['toolbar' => 'undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | outdent indent'],
+```
+
+Some buttons are related to specific plugins and need them to work, please read more about it here: [tiny mce available toolbar buttons](https://www.tiny.cloud/docs/advanced/available-toolbar-buttons/)
 
 <hr>
 


### PR DESCRIPTION
as the title says, updates the tiny mce documentation. I also think that we should change the image to show the "default" tinymce state, because in the image we show a tinymce instance with extra plugins and custom toolbar etc. That migth lead the users to wrongly think that what is shown is what they will get without aditional configurations. I let that up for you to decide @tabacitu 

Cheers!