### PR TITLE
mention appends for acessors in identifiable attribute

### DIFF
--- a/5.x/crud-fields.md
+++ b/5.x/crud-fields.md
@@ -262,7 +262,7 @@ class Category
     }
 }
 ```
-
+**IMPORTANT NOTE**: If you are using acessors as the identifiable attribute, you need to add it to the `$appends` property of your model. https://laravel.com/docs/9.x/eloquent-serialization#appending-values-to-json
 
 <a name="default-field-types"></a>
 ## FREE Field Types


### PR DESCRIPTION
adds a mention to the use of `$appends` when using identifiableAttribute with acessors. 

Closes https://github.com/Laravel-Backpack/docs/issues/347