### PR TITLE
add invokable stripRequest to docs

### DIFF
--- a/5.x/crud-how-to.md
+++ b/5.x/crud-how-to.md
@@ -620,7 +620,7 @@ Please read the relationship [BelongsToMany](#belongstomany) documentation, ever
 
 You might want to add a new attribute to the Model that gets saved. Let's say you want to add an `updated_by` indicator to the Update operation, containing the ID of the user currently logged in (`backpack_user()->id`).
 
-Backpack uses the `strippedRequest` configuration to determine the fields that should be saved. **By default it will only save fields that have a corresponding CRUD field defined**
+Backpack uses the `strippedRequest` configuration to determine the fields that should be saved. **By default it will only save inputs that have a corresponding CRUD field defined.**
 
 **Option 1.** You can change the `strippedRequest` closure inside your `ProductCrudController::setup()`:
 ```php

--- a/5.x/crud-how-to.md
+++ b/5.x/crud-how-to.md
@@ -652,9 +652,9 @@ public function setupUpdateOperation()
     }
 ```
 
-**Option 3.** You can create an `invokable` class strippedRequest will use, acting like a closure, but can also used in config files. 
+**Option 3.** You can create an `invokable` class strippedRequest will use, acting like a closure.
 
-Create the invokable class:
+#####Create the invokable class:
 ```php
 <?php
 
@@ -666,12 +666,14 @@ class StripBackpackRequest
 {
     public function __invoke(Request $request)
     {
-        return $request->except('_token', '_method', '_http_referrer', '_current_tab', '_save_action');
+        $input = $request->only(\CRUD::getAllFieldNames());
+        $input['updated_by'] = backpack_user()->id;
+        return $input;
     }
 }
 ```
 
-and use it in your controller:
+#####Use it in your controller:
 
 ```php
 use App\Http\Requests\StripBackpackRequest;
@@ -681,6 +683,7 @@ public function setupUpdateOperation()
     CRUD::setOperationSetting('strippedRequest', StripBackpackRequest::class);
 }
 ```
+>**Note**: You can also add this class in your `config/backpack/crud/operations/update.php` or create file and make it a global setting for all update/create operations.
 
 
 <a name="how-to-make-the-form-smaller-or-bigger"></a>

--- a/5.x/crud-how-to.md
+++ b/5.x/crud-how-to.md
@@ -620,9 +620,16 @@ Please read the relationship [BelongsToMany](#belongstomany) documentation, ever
 
 You might want to add a new attribute to the Model that gets saved. Let's say you want to add an `updated_by` indicator to the Update operation, containing the ID of the user currently logged in (`backpack_user()->id`).
 
-Backpack uses the `strippedRequest` configuration to determine the fields that should be saved. **By default it will only save inputs that have a corresponding CRUD field defined.**
+**By default, Backpack it will only save inputs that have a corresponding CRUD field defined.** But you can override this behaviour, by using the setting called `strippedRequest`, which determine the which fields should actually be saved, and which fields should be "stripped" from the request.
 
-**Option 1.** You can change the `strippedRequest` closure inside your `ProductCrudController::setup()`:
+Here's how you can use `strippedRequest` to add an `updated_by` item to be saved (but this will work for any changes you want to make to the request, really). You can change the request at various points in the request:
+- (a) in your CrudController (eg. `CRUD::setOperationSetting('strippedRequest', StripBackpackRequest::class);` in your `setup()`);
+- (b) in your Request (eg. same as above, inside `prepareForValidation()`);
+- (c) in your config, if you want it to apply for all CRUDs (eg. inside `config/backpack/operations/update.php`);
+
+Let's demonstrate each one of the above:
+
+**Option 1.** In the controller. You can change the `strippedRequest` closure inside your `ProductCrudController::setup()`:
 ```php
 public function setupUpdateOperation()
 {
@@ -637,7 +644,7 @@ public function setupUpdateOperation()
 }
 ```
 
-**Option 2.** You can change the same `strippedRequest` closure inside the `ProductFormRequest` that contains your validation:
+**Option 2.** In the request. You can change the same `strippedRequest` closure inside the `ProductFormRequest` that contains your validation:
 ```php
     protected function prepareForValidation()
     {
@@ -652,9 +659,8 @@ public function setupUpdateOperation()
     }
 ```
 
-**Option 3.** You can create an `invokable` class strippedRequest will use, acting like a closure.
+**Option 3.** In the config file. You cannot use a closure (because closures don't get cached). But you can create an invokable class, and use that as your `strippedRequest`, in your `config/backpack/operations/update.php` (for example). Then it will apply to ALL update operations, on all entities:
 
-#####Create the invokable class:
 ```php
 <?php
 
@@ -672,18 +678,6 @@ class StripBackpackRequest
     }
 }
 ```
-
-#####Use it in your controller:
-
-```php
-use App\Http\Requests\StripBackpackRequest;
-
-public function setupUpdateOperation()
-{
-    CRUD::setOperationSetting('strippedRequest', StripBackpackRequest::class);
-}
-```
->**Note**: You can also add this class in your `config/backpack/crud/operations/update.php` or create file and make it a global setting for all update/create operations.
 
 
 <a name="how-to-make-the-form-smaller-or-bigger"></a>

--- a/5.x/upgrade-guide.md
+++ b/5.x/upgrade-guide.md
@@ -116,23 +116,36 @@ No changes needed.
 
 <a name="step-8" href="#step-8" class="badge badge-secondary-soft" style="text-decoration: none;">Step 8.</a> Inside `config/backpack/crud.php`, you were previously able to change what inputs are stripped from the request before saving, by configuring `saveAllInputsExcept` for the Create and Update operations. We have moved the configuration to `config/backpack/operations/create.php` & `config/backpack/operations/update.php`, then:
 - renamed it to `strippedRequest`;
-- given you the possibility to do whatever you want to the request, by using a `closure` instead of `array`;
+- given you the possibility to do whatever you want to the request,by allowing you to add an `invokable` class, acting like a closure, that backpack will run to strip the request.
 - kept the default behaviour; if `strippedRequest` is undefined or false, Backpack will strip all inputs that don't have fields, which we consider is the safest approach;
 
 **If in your `config/backpack/operations/create.php` or `config/backpack/operations/update.php` you've copied `saveAllInputsExcept` as `null` or `false`, you don't have to do anything.**
 
-However, **if you have an array for your `saveAllInputsExcept`**, you can now achieve the same thing by stripping the request yourself in a closure. Basically:
+However, **if you have an array for your `saveAllInputsExcept`**, you can now achieve the same thing by stripping the request yourself in an invokable class. Basically you first create the invokable class and then add it into the config:
+```php
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Http\Request;
+
+class StripBackpackRequest
+{
+    public function __invoke(Request $request)
+    {
+        return $request->except('_token', '_method', '_http_referrer', '_current_tab', '_save_action');
+    }
+}
+```
 ```diff
 -    'saveAllInputsExcept' => ['_token', '_method', 'http_referrer', 'current_tab', 'save_action'],
-+    'strippedRequest' => (function ($request) {
-+        return $request->except('_token', '_method', '_http_referrer', '_current_tab', '_save_action');
++    'strippedRequest' => '\App\Http\Requests\StripBackpackRequest',
 +    }),
 ```
-But you can also do a lot more, because you have the `$request` in that closure. See more info in PR #[3987](https://github.com/Laravel-Backpack/CRUD/pull/3987). In addition, please notice that **all hidden parameters are now prefixed by an underscore**. Starting with v5, if it starts with an underscore, you know it's not an actual database column.
-
+But you can also do a lot more, because you have the `$request` in that class. See examples here: https://backpackforlaravel.com/docs/5.x/crud-how-to#add-non-editable-input-inside-create-or-update-operation-stripped-request
+In addition, please notice that **all hidden parameters are now prefixed by an underscore**. Starting with v5, if it starts with an underscore, you know it's not an actual database column.
 
 ----
-
 
 <a name="step-9" href="#step-9" class="badge badge-secondary-soft" style="text-decoration: none;">Step 9.</a> The **Show operation** will now show `created_at`, `updated_at` columns by default, if they exist. In most cases, this is what you want - show as many things as possible inside the Show operation - and `created_at` and `updated_at` provide some useful information about the entry. So it should NOT negatively affect you. But if you _don't_ want to show those columns, you can turn off this new default behavior in your `config/backpack/operations/show.php`, by defining `'timestamps' => false,`. You can also do `'softDeletes' => true,` if you want to show that column, by the way.
 

--- a/5.x/upgrade-guide.md
+++ b/5.x/upgrade-guide.md
@@ -142,7 +142,7 @@ class StripBackpackRequest
 +    'strippedRequest' => '\App\Http\Requests\StripBackpackRequest',
 +    }),
 ```
-But you can also do a lot more, because you have the `$request` in that class. See examples here: https://backpackforlaravel.com/docs/5.x/crud-how-to#add-non-editable-input-inside-create-or-update-operation-stripped-request
+But you can also do a lot more, because you have the `$request` in that class. You can see [an example here]( https://backpackforlaravel.com/docs/5.x/crud-how-to#add-non-editable-input-inside-create-or-update-operation-stripped-request).
 In addition, please notice that **all hidden parameters are now prefixed by an underscore**. Starting with v5, if it starts with an underscore, you know it's not an actual database column.
 
 ----


### PR DESCRIPTION
I replaced the ocurrences of `strippedRequest` with the invokable instead of closure.

![image](https://user-images.githubusercontent.com/7188159/177971536-a3e407c0-9920-4888-9918-b14846e79ece.png)

I removed option 1 from `unchangeable-crud-field` because that option is not appropriate for that example. Added invokable as an option too. 