### PR TITLE
Suggested method POST for when using `include_all_form_fields`

### DIFF
--- a/5.x/crud-fields.md
+++ b/5.x/crud-fields.md
@@ -1607,18 +1607,19 @@ If your related entry has hundreds, thousands or millions of entries, it's not p
     'ajax' => true,
 
     // OPTIONALS:
-    // 'label' => "Category",
-    // 'attribute' => "name", // foreign key attribute that is shown to user (identifiable attribute)
-    // 'entity' => 'category', // the method that defines the relationship in your Model
-    // 'model' => "App\Models\Category", // foreign key Eloquent model
+    // 'label'       => "Category",
+    // 'attribute'   => "name", // foreign key attribute that is shown to user (identifiable attribute)
+    // 'entity'      => 'category', // the method that defines the relationship in your Model
+    // 'model'       => "App\Models\Category", // foreign key Eloquent model
     // 'placeholder' => "Select a category", // placeholder for the select2 input
 
     // AJAX OPTIONALS:
-    // 'delay' => 500, // the minimum amount of time between ajax requests when searching in the field
-    // 'data_source' => url("fetch/category"), // url to controller search function (with /{id} should return model)
-    // 'minimum_input_length' => 2, // minimum characters to type before querying results
-    // 'dependencies'         => ['category'], // when a dependency changes, this select2 is reset to null
-    // 'include_all_form_fields'  => false, // optional - only send the current field through AJAX (for a smaller payload if you're not using multiple chained select2s)
+    // 'delay'                   => 500, // the minimum amount of time between ajax requests when searching in the field
+    // 'data_source'             => url("fetch/category"), // url to controller search function (with /{id} should return model)
+    // 'minimum_input_length'    => 2, // minimum characters to type before querying results
+    // 'dependencies'            => ['category'], // when a dependency changes, this select2 is reset to null
+    // 'method'                  => 'POST', // optional - HTTP method to use for the AJAX call (GET, POST)
+    // 'include_all_form_fields' => false, // optional - only send the current field through AJAX (for a smaller payload if you're not using multiple chained select2s)
  ],
 ```
 
@@ -2124,12 +2125,12 @@ Display a select2 that takes its values from an AJAX call.
     'data_source' => url("api/category"), // url to controller search function (with /{id} should return model)
 
     // OPTIONAL
-    // 'delay' => 500, // the minimum amount of time between ajax requests when searching in the field
+    // 'delay'                   => 500, // the minimum amount of time between ajax requests when searching in the field
     // 'placeholder'             => "Select a category", // placeholder for the select
     // 'minimum_input_length'    => 2, // minimum characters to type before querying results
     // 'model'                   => "App\Models\Category", // foreign key model
     // 'dependencies'            => ['category'], // when a dependency changes, this select2 is reset to null
-    // 'method'                  => 'GET', // optional - HTTP method to use for the AJAX call (GET, POST)
+    // 'method'                  => 'POST', // optional - HTTP method to use for the AJAX call (GET, POST)
     // 'include_all_form_fields' => false, // optional - only send the current field through AJAX (for a smaller payload if you're not using multiple chained select2s)
 ],
 ```
@@ -2201,11 +2202,12 @@ Display a select2 that takes its values from an AJAX call. Same as [select2_from
     'pivot'       => true, // on create&update, do you need to add/delete pivot table entries?
 
     // OPTIONAL
-    'delay' => 500, // the minimum amount of time between ajax requests when searching in the field
-    'model'                => "App\Models\City", // foreign key model
-    'placeholder'          => "Select a city", // placeholder for the select
-    'minimum_input_length' => 2, // minimum characters to type before querying results
-    // 'include_all_form_fields'  => false, // optional - only send the current field through AJAX (for a smaller payload if you're not using multiple chained select2s)
+    'delay'                      => 500, // the minimum amount of time between ajax requests when searching in the field
+    'model'                      => "App\Models\City", // foreign key model
+    'placeholder'                => "Select a city", // placeholder for the select
+    'minimum_input_length'       => 2, // minimum characters to type before querying results
+    // 'method'                  => 'POST', // optional - HTTP method to use for the AJAX call (GET, POST)
+    // 'include_all_form_fields' => false, // optional - only send the current field through AJAX (for a smaller payload if you're not using multiple chained select2s)
 ],
 ```
 

--- a/5.x/crud-fields.md
+++ b/5.x/crud-fields.md
@@ -2140,7 +2140,7 @@ For more information about the optional attributes that fields use when they int
 Of course, you also need to create make the data_source above respond to AJAX calls. You can use the [FetchOperation](https://backpackforlaravel.com/docs/4.1/crud-operation-fetch) to quickly do that in your current CrudController, or you can set up your custom API by creating a custom Route and Controller. Here's an example:
 
 ```php
-Route::get('/api/category', 'Api\CategoryController@index');
+Route::post('/api/category', 'Api\CategoryController@index');
 ```
 
 ```php
@@ -2216,8 +2216,8 @@ For more information about the optional attributes that fields use when they int
 Of course, you also need to create a controller and routes for the data_source above. Here's an example:
 
 ```php
-Route::get('/api/city', 'Api\CityController@index');
-Route::get('/api/city/{id}', 'Api\CityController@show');
+Route::post('/api/city', 'Api\CityController@index');
+Route::post('/api/city/{id}', 'Api\CityController@show');
 ```
 
 ```php

--- a/5.x/crud-how-to.md
+++ b/5.x/crud-how-to.md
@@ -199,9 +199,9 @@ function () { // if the filter is active (the GET parameter "draft" exits)
 This will make Backpack look for the ```resources/views/custom_filters/complex.blade.php```, and pick that up before anything else.
 
 <a name="how-to-add-a-select-that-depends-on-another-field"></a>
-### How to add a select2 field that depends on another field
+### How to add a relationship field that depends on another field
 
-The ```select2_from_ajax``` and ```select2_from_ajax_multiple``` fields allow you to filter the results of a select2, depending on what has already been selected in a form. Say you have to select2 fields. When the AJAX call is made to the second field, all other variables in the page also get passed - that means you can filter the results of the second select2.
+The `relationship`, `select2_from_ajax` and `select2_from_ajax_multiple` fields allow you to filter the results depending on what has already been written or selected in a form. Say you have two `select2` fields, when the AJAX call is made to the second field, all other variables in the page also get passed - that means you can filter the results of the second `select2`.
 
 Say you want to show two selects:
 - the first one shows Categories
@@ -210,7 +210,8 @@ Say you want to show two selects:
 1. In your CrudController you would do:
 
 ```php
-$this->crud->addField([    // SELECT2
+// select2
+$this->crud->addField([
     'label'         => 'Category',
     'type'          => 'select',
     'name'          => 'category',
@@ -218,22 +219,25 @@ $this->crud->addField([    // SELECT2
     'attribute'     => 'name',
 ]);
 
-$this->crud->addField([ // select2_from_ajax: 1-n relationship
-    'label'                => "Article", // Table column heading
-    'type'                 => 'select2_from_ajax_multiple',
-    'name'                 => 'articles', // the column that contains the ID of that connected entity;
-    'entity'               => 'article', // the method that defines the relationship in your Model
-    'attribute'            => 'title', // foreign key attribute that is shown to user
-    'data_source'          => url('api/article'), // url to controller search function (with /{id} should return model)
-    'placeholder'          => 'Select an article', // placeholder for the select
+// select2_from_ajax: 1-n relationship
+$this->crud->addField([
+    'label'                   => "Article", // Table column heading
+    'type'                    => 'select2_from_ajax_multiple',
+    'name'                    => 'articles', // the column that contains the ID of that connected entity;
+    'entity'                  => 'article', // the method that defines the relationship in your Model
+    'attribute'               => 'title', // foreign key attribute that is shown to user
+    'data_source'             => url('api/article'), // url to controller search function (with /{id} should return model)
+    'placeholder'             => 'Select an article', // placeholder for the select
     'include_all_form_fields' => true, //sends the other form fields along with the request so it can be filtered.
-    'minimum_input_length' => 0, // minimum characters to type before querying results
-    'dependencies'         => ['category'], // when a dependency changes, this select2 is reset to null
-    // 'method'                    => 'GET', // optional - HTTP method to use for the AJAX call (GET, POST)
+    'minimum_input_length'    => 0, // minimum characters to type before querying results
+    'dependencies'            => ['category'], // when a dependency changes, this select2 is reset to null
+    // 'method'               => 'POST', // optional - HTTP method to use for the AJAX call (GET, POST)
 ]);
 ```
 
 **DIFFERENT HERE**: ```minimum_input_length```,  ```dependencies``` and ```include_all_form_fields```.
+
+Note: if you are going to use `include_all_form_fields` we recommend you to set the method to `POST`, and to properly setup that in your routes. Since all the fields in the form are going to be sent in the request, `POST` support more data.
 
 2. That second select points to routes that need to be registered:
 

--- a/5.x/crud-how-to.md
+++ b/5.x/crud-how-to.md
@@ -242,8 +242,8 @@ Note: if you are going to use `include_all_form_fields` we recommend you to set 
 2. That second select points to routes that need to be registered:
 
 ```php
-Route::get('api/article', 'App\Http\Controllers\Api\ArticleController@index');
-Route::get('api/article/{id}', 'App\Http\Controllers\Api\ArticleController@show');
+Route::post('api/article', 'App\Http\Controllers\Api\ArticleController@index');
+Route::post('api/article/{id}', 'App\Http\Controllers\Api\ArticleController@show');
 ```
 
 **DIFFERENT HERE**: Nothing.


### PR DESCRIPTION
Fix for https://github.com/Laravel-Backpack/CRUD/issues/4471.

Rephrased the "How to add a relationship field that depends on another field", to include a reference to the `relationship` field.

Also added a note to suggest the usage of `POST` method.