### PR TITLE
Added undocumented button methods

### DIFF
--- a/5.x/crud-buttons.md
+++ b/5.x/crud-buttons.md
@@ -34,7 +34,11 @@ Default buttons are invisible if an operation has been disabled. For example, yo
 Here are a few things you can call in your EntityCrudController's ```setupListOperation()``` method, to manipulate buttons:
 
 ```php
+// possible stacks: 'top', 'line', 'bottom';
 // possible positions: 'beginning' and 'end'; defaults to 'beginning' for the 'line' stack, 'end' for the others;
+
+// collection of all buttons
+$this->crud->buttons();
 
 // add a button; possible types are: view, model_function
 $this->crud->addButton($stack, $name, $type, $content, $position);
@@ -48,9 +52,28 @@ $this->crud->addButtonFromView($stack, $name, $view, $position);
 // remove a button
 $this->crud->removeButton($name);
 
-// remove a button for a certain stack (top, line, bottom)
+// remove a button for a certain stack
 $this->crud->removeButtonFromStack($name, $stack);
+
+// remove multiple buttons
+$this->crud->removeButtons($names, $stack);
+
+// remove all buttons
+$this->crud->removeAllButtons();
+
+// remove all buttons for a certain stack
+$this->crud->removeAllButtonsFromStack($stack);
+
+// order buttons in a stack, order is an array with the ordered names of the buttons
+$this->crud->orderButtons($stack, $order);
+
+// modify button, modifications are the attributes and their new values.
+$this->crud->modifyButton($name, $modifications);
+
+// Move the target button to the destination position, target and destion are the button names, where is 'before' or 'after'
+$this->crud->moveButton($target, $where, $destination);
 ```
+
 <a name="overwriting-a-default-button"></a>
 ### Overwriting a Default Button
 
@@ -199,4 +222,16 @@ public function import()
 - Now we can actually add this button to any of ```UserCrudController::setupListOperation()```:
 ```php
 $this->crud->addButtonFromView('top', 'import', 'import', 'end');
+```
+
+### Reorder buttons
+
+The default order of line stack buttons is 'edit', 'delete'. Let's say you are using the `ShowOperation`, by default the preview button gets placed in the beggining of that stack, if you want to move it to the end of the stack you may use `orderButtons` or `moveButton`.
+
+```php
+CRUD::orderButtons('line', ['update', 'delete', 'show']);
+```
+
+```php
+CRUD::moveButton('show', 'after', 'delete');
 ```

--- a/5.x/crud-cheat-sheet.md
+++ b/5.x/crud-cheat-sheet.md
@@ -38,15 +38,23 @@ $this->crud->addColumn()->makeFirstColumn();
 <a name="buttons-api"></a>
 #### Buttons
 
-<small>Methods: addButton(), addButtonFromModelFunction(), addButtonFromView(), removeButton(), removeButtonFromStack()</small>
+<small>Methods: buttons(), addButton(), addButtonFromModelFunction(), addButtonFromView(), removeButton(), removeButtonFromStack(), removeButtons(), removeAllButtons(), removeAllButtonsFromStack(), modifyButton(), moveButton()</small>
 
 ```php
+// possible stacks: 'top', 'line', 'bottom';
 // possible positions: 'beginning' and 'end'; defaults to 'beginning' for the 'line' stack, 'end' for the others;
-$this->crud->addButton($stack, $name, $type, $content, $position); // add a button; possible types are: view, model_function
+$this->crud->buttons(); // collection of all buttons
+$this->crud->addButton($stack, $name, $type, $content, $position); // possible types are: 'view', 'model_function'
 $this->crud->addButtonFromModelFunction($stack, $name, $model_function_name, $position); // add a button whose HTML is returned by a method in the CRUD model
 $this->crud->addButtonFromView($stack, $name, $view, $position); // add a button whose HTML is in a view placed at resources\views\vendor\backpack\crud\buttons
 $this->crud->removeButton($name);
 $this->crud->removeButtonFromStack($name, $stack);
+$this->crud->removeButtons($names, $stack);
+$this->crud->removeAllButtons();
+$this->crud->removeAllButtonsFromStack($stack);
+$this->crud->orderButtons($stack, $order); // order is an array with button names in the new order
+$this->crud->modifyButton($name, $modifications); // modifications are the attributes and their new values
+$this->crud->moveButton($target, $where, $destination); // move the target button to the destination position, target and destion are the button names, where is 'before' or 'after'
 ```
 
 <a name="filters-api"></a>


### PR DESCRIPTION
Fix for https://github.com/Laravel-Backpack/docs/issues/237.

Added all undocumented button methods to `crud-buttons.md` and `crud-cheat-sheet.md` pages.