### PR TITLE
Add notes to docs about bulk actions.

### DIFF
--- a/5.x/crud-operation-clone.md
+++ b/5.x/crud-operation-clone.md
@@ -93,6 +93,10 @@ In addition to the button for each entry, you can show checkboxes next to each e
 
 Using AJAX, a POST request is performed towards ```/entity-name/bulk-clone```, which points to the ```bulkClone()``` method in your EntityCrudController.
 
+**`NOTES:`** 
+- The bulk checkbox is added inside the first column defined in the table. For that reason the first column should be visible on table to display the bulk actions checkbox next to it.
+- `Bulk Actions` also disable all click events for the first column, so make sure the first column **dont** contain any anchor tags (`<a>`), as they wont work.
+
 <a name="enabling"></a>
 ### How to Use
 

--- a/5.x/crud-operation-clone.md
+++ b/5.x/crud-operation-clone.md
@@ -95,7 +95,7 @@ Using AJAX, a POST request is performed towards ```/entity-name/bulk-clone```, w
 
 **`NOTES:`** 
 - The bulk checkbox is added inside the first column defined in the table. For that reason the first column should be visible on table to display the bulk actions checkbox next to it.
-- `Bulk Actions` also disable all click events for the first column, so make sure the first column **dont** contain any anchor tags (`<a>`), as they wont work.
+- `Bulk Actions` also disable all click events for the first column, so make sure the first column **doesn't** contain an anchor tag (`<a>`), as it won't work.
 
 <a name="enabling"></a>
 ### How to Use

--- a/5.x/crud-operation-delete.md
+++ b/5.x/crud-operation-delete.md
@@ -72,7 +72,7 @@ Using AJAX, a DELETE request is performed towards ```/entity-name/bulk-delete```
 
 **`NOTES:`** 
 - The bulk checkbox is added inside the first column defined in the table. For that reason the first column should be visible on table to display the bulk actions checkbox next to it.
-- `Bulk Actions` also disable all click events for the first column, so make sure the first column **dont** contain any anchor tags (`<a>`), as they wont work.
+- `Bulk Actions` also disable all click events for the first column, so make sure the first column **doesn't** contain an anchor tag (`<a>`), as it won't work.
 
 
 <a name="enabling"></a>

--- a/5.x/crud-operation-delete.md
+++ b/5.x/crud-operation-delete.md
@@ -70,6 +70,11 @@ In addition to the button for each entry, <span class="badge badge-info">PRO</sp
 
 Using AJAX, a DELETE request is performed towards ```/entity-name/bulk-delete```, which points to the ```bulkDelete()``` method in your EntityCrudController.
 
+**`NOTES:`** 
+- The bulk checkbox is added inside the first column defined in the table. For that reason the first column should be visible on table to display the bulk actions checkbox next to it.
+- `Bulk Actions` also disable all click events for the first column, so make sure the first column **dont** contain any anchor tags (`<a>`), as they wont work.
+
+
 <a name="enabling"></a>
 ### How to Use
 


### PR DESCRIPTION
When using bulk actions in a `CrudController` developer should know that the bulk check box is added inside the first column, because of that fact he must be aware that the first column should be visible in the table, and also that it could not contain any anchor because bulk checkbox disables all clicks in that row. 