### PR TITLE
Test MonitoRSS + Discord integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,6 @@ You can find the online version of the Backpack documentation at https://backpac
 - all links should point to the current version of the documentation page (ex: ```/docs/{{version}}/installation```);
 - all images should be uploaded to ```https://backpackforlaravel.com/uploads/docs/``` and used from there; ask @tabacitu to help upload them;
 - all headings should be prepended by an HTML anchor, with the name of the heading; this way, Algolia can take the user directly to that heading (ex: ```<a name="what-my-title-says-but-with-dashes"></a>```);
+
+
+TEST


### PR DESCRIPTION
I thought our team can do support by monitoring [This Week](https://github.com/orgs/Laravel-Backpack/projects/13) and [StackOverflow](https://stackoverflow.com/questions/tagged/laravel-backpack) alone. But it turns out... no, we can't do that. Because:
- New PRs do not get added to “This Week” board
- New Discussions do not get added to “This Week” board
- New StackOverflow questions do not get added to “This Week” board

I've tried to fix the above in a bunch of ways, but failed. In the end, I found that the only thing all our support channels have in common... is RSS. Not directly (Github doesn't have one, but we can use https://openrss.org/). So here's what I've done:

I've used [MonitoRSS](https://monitorss.xyz/), so that anything that can't automatically get onto "_This Week_"... is posted on our "_Defense_" channel on Discord. This means, when it's my week to do support, I have two things to monitor:
- [This Week](https://github.com/orgs/Laravel-Backpack/projects/13)
- The "Defense" channel on Discord (open, assign myself and This Week project, handle, then tick it on Discord as done)

This isn't _great_... but it's better than what we had before, when PRs and Discussions were slipping through the cracks.

PS. Improvement idea: we could also make "new issues" show up on Discord. But I'm not sure that's necessary, since they do show up on This Week.