### PR TITLE
remove cache busting string

### DIFF
--- a/6.x/upgrade-guide.md
+++ b/6.x/upgrade-guide.md
@@ -57,7 +57,13 @@ Please make sure your project respects the requirements below, before you start 
         "backpack/medialibrary-uploaders": "^1.0",
 ```
 
-<a name="step-3" href="#step-3" class="badge badge-danger text-white" style="text-decoration: none;">Step 3.</a> Let's get the latest Backpack and install it. If you get any conflicts with **Backpack 1st party add-ons**, most of the time you just need to move one version up, eg: from `backpack/menucrud: ^3.0` to `backpack/menucrud: ^4.0`. See the step above again. Please run:
+<a name="step-3.1" href="#step-3.1" class="badge badge-danger text-white" style="text-decoration: none;">Step 3.1.</a> We removed `PackageVersions` and the cache busting string is now handled by `Basset`.
+To avoid errors on the next step, please remove `cachebusting_string` from `config/backpack/base.php`.
+```diff
+- 'cachebusting_string' => \PackageVersions\Versions::getVersion('backpack/crud'), 
+```
+
+<a name="step-3.2" href="#step-3.2" class="badge badge-danger text-white" style="text-decoration: none;">Step 3.2.</a> Let's get the latest Backpack and install it. If you get any conflicts with **Backpack 1st party add-ons**, most of the time you just need to move one version up, eg: from `backpack/menucrud: ^3.0` to `backpack/menucrud: ^4.0`. See the step above again. Please run:
 
 ```
 composer update


### PR DESCRIPTION
This was reported in https://github.com/Laravel-Backpack/CRUD/issues/5170

If you ran `composer update` with this class still in config, the `dump-autoload` process would raise an error. 

