### PR TITLE
Correct/improve English and add example snippet

### DIFF
--- a/6.x/crud-fields.md
+++ b/6.x/crud-fields.md
@@ -172,7 +172,7 @@ You can now split your create/edit inputs into multiple tabs.
 
 ![CRUD Fields Tabs](https://backpackforlaravel.com/uploads/docs-4-0/operations/create_tabs.png)
 
-To use this feature, just specify the tab name for each of your fields. for example:
+To use this feature, specify the tab name for each of your fields. For example:
 
 ```php
 CRUD::field('price')->tab('Tab name here');

--- a/6.x/crud-fields.md
+++ b/6.x/crud-fields.md
@@ -172,14 +172,19 @@ You can now split your create/edit inputs into multiple tabs.
 
 ![CRUD Fields Tabs](https://backpackforlaravel.com/uploads/docs-4-0/operations/create_tabs.png)
 
-In order to use this feature, you just need to specify the tab name for each of your fields. Example:
+To use this feature, just specify the tab name for each of your fields. for example:
 
 ```php
 CRUD::field('price')->tab('Tab name here');
 ```
 
-If you forget to specify a tab name for a field, Backpack will place it above all tabs.
+If you don't specify a tab name for a field, then Backpack will place it above all of the tabs, for example:
 
+```php
+CRUD::field('product');
+CRUD::field('description')->tab('Information');
+CRUD::field('price')->tab('Prices');
+```
 
 <a name="entity-model-and-attribute"></a>
 #### Optional - Attributes for Fields Containing Related Entries


### PR DESCRIPTION
The snippet makes it clear what the code should look like. 

Instead of "forget", the words "omit" or "don't specify" are clearer and better. I suggest "don't specify".

I thought of adding a screenshot, but I am not sure that it is necessary.