### PR TITLE
Update file name to: menu_items.blade.php

### DIFF
--- a/6.x/crud-tutorial.md
+++ b/6.x/crud-tutorial.md
@@ -37,7 +37,7 @@ The code above will have generated:
 - a controller (```app/Http/Controllers/Admin/TagCrudController.php```);
 - a request (```app/Http/Requests/TagCrudRequest.php```);
 - a resource route, as a line inside ```routes/backpack/custom.php```;
-- a new item in the sidebar menu, in ```resources/views/vendor/backpack/base/inc/sidebar_content.blade.php```;
+- a new menu item in ```resources/views/vendor/backpack/ui/inc/menu_items.blade.php```;
 
 **Next up:** we'll need to go through the generated files, and customize for our needs.
 


### PR DESCRIPTION
This line is described in detail at the bottom of this page and the file name there is the correct one that I can see in my fresh v6.0.3 backpack installation. Also, it appears that the menu items are created as components and can probably be used in many places, so reference to "sidebar menu" is probably no longer needed.