### PR TITLE
Add documentation about access and permission

### DIFF
--- a/6.x/base-themes.md
+++ b/6.x/base-themes.md
@@ -65,7 +65,7 @@ This fallback mechanism might look complex at first, but you'll quickly get used
 
 Each theme can provide its own config file. That file overrides anything that was set in `config/backpack/ui.php`, because each theme may want to do things differently, include other assets etc. So:
 - if you change `config/backpack/ui.php`, your change will apply to ALL themes, unless that theme has overriden the config in its own config file;
-- if you change `config/backpack/theme-table.php`, your change will only apply to that theme;
+- if you change `config/backpack/theme-tabler.php`, your change will only apply to that theme;
 
 Inside your files you can access a theme config by using `backpack_theme_config('something')`.
 

--- a/6.x/crud-operation-list-entries.md
+++ b/6.x/crud-operation-list-entries.md
@@ -387,30 +387,3 @@ If an error is thrown during the AJAX request, Backpack will show that error in 
 If you want to see or optimize database queries, you can do that using any Laravel tool that analyzes AJAX request. For example, here's how to analyze AJAX requests using the excellent [barryvdh/laravel-debugbar](https://github.com/barryvdh/laravel-debugbar). You just click the Folder icon to the right, and you select the latest request. Debugbar will then show you all info for that last AJAX request:
 
 ![How to use DebugBar with Backpack's ListOperation](https://user-images.githubusercontent.com/1032474/227514264-0a95ac8f-1bfa-4009-86c4-3c8313ca3399.gif)
-
-
-<a name="access-and-permission"></a>
-## Access and Permission
-
-In this section we are going to cover the access and permission in your **ListOperation**
-So now let's imagine that we have a few roles and every role has its own permissions, so we want to check the permission before we show the form or view to the user, how can we achieve that?
-it's simple we can manipulate our **ListOperation** with this, so just add this permission check before our other code.
-
-```php
-/**
- * Define what happens when the List operation is loaded.
- * 
- * @see  https://backpackforlaravel.com/docs/crud-operation-list-entries
- * @return void
- */
-protected function setupListOperation()
-{
-    //sometimes when we install the backpack permission package we can use something like backpack_user()->can('some_permission')
-    $somePermission = true; 
-    if($somePermission){
-        $this->crud->denyAccess('list');
-        // here's the message for the user, you can change it with whatever you want
-        abort(403, 'You dont have permission to access this page'); 
-    }
-}
-```

--- a/6.x/crud-operation-list-entries.md
+++ b/6.x/crud-operation-list-entries.md
@@ -387,3 +387,30 @@ If an error is thrown during the AJAX request, Backpack will show that error in 
 If you want to see or optimize database queries, you can do that using any Laravel tool that analyzes AJAX request. For example, here's how to analyze AJAX requests using the excellent [barryvdh/laravel-debugbar](https://github.com/barryvdh/laravel-debugbar). You just click the Folder icon to the right, and you select the latest request. Debugbar will then show you all info for that last AJAX request:
 
 ![How to use DebugBar with Backpack's ListOperation](https://user-images.githubusercontent.com/1032474/227514264-0a95ac8f-1bfa-4009-86c4-3c8313ca3399.gif)
+
+
+<a name="access-and-permission"></a>
+## Access and Permission
+
+In this section we are going to cover the access and permission in your **ListOperation**
+So now let's imagine that we have a few roles and every role has its own permissions, so we want to check the permission before we show the form or view to the user, how can we achieve that?
+it's simple we can manipulate our **ListOperation** with this, so just add this permission check before our other code.
+
+```php
+/**
+ * Define what happens when the List operation is loaded.
+ * 
+ * @see  https://backpackforlaravel.com/docs/crud-operation-list-entries
+ * @return void
+ */
+protected function setupListOperation()
+{
+    //sometimes when we install the backpack permission package we can use something like backpack_user()->can('some_permission')
+    $somePermission = true; 
+    if($somePermission){
+        $this->crud->denyAccess('list');
+        // here's the message for the user, you can change it with whatever you want
+        abort(403, 'You dont have permission to access this page'); 
+    }
+}
+```


### PR DESCRIPTION
Hi,

I make this PR because I think it's kinda hard to find out how can we prevent users before they access the page, then I think it's a good idea to add documentation about the access and permission to every Operation.

Currently, I'm working on a new project and using the latest version of backpack, and I found that when I use
```php
CRUD::denyAccess('list');
```
and not adding this code right after ``` CRUD::denyAccess('list'); ```
```php
abort(403, 'You dont have permission to access this page'); 
```

it will show you this error
<img width="919" alt="image" src="https://github.com/Laravel-Backpack/docs/assets/34405837/e7d7bca5-e158-41ed-94d6-44ab5b99b2cc">

but when I use this full code
```php
CRUD::denyAccess('list');
abort(403, 'You dont have permission to access this page'); 
```
It works properly, idk if I miss something, let me know if I did something wrong, thank you

also if you agree with this idea, I will continue to add this **access and permission section** to every Operation that backpack provides

Cheers