### PR TITLE
V6 upgrade-guide: steps required for filemanager

### DIFF
--- a/6.x/upgrade-guide.md
+++ b/6.x/upgrade-guide.md
@@ -242,6 +242,20 @@ If the table view still looks wonky (search bar out of place, big + instead of e
 
 ---
 
+<a name="addons"></a>
+### Upgrade Add-ons
+
+For any addons you might have upgraded, please double-check if they have an upgrade guide. For example, **elFinder** needs to replace it's old view files:
+
+```
+rm -rf resources/views/vendor/elfinder
+php artisan backpack:filemanager:install
+```
+
+This will remove elfinder view files and publish new ones.
+
+---
+
 **You're done! Good job.** Thank you for taking the time to upgrade. Now you can:
 - thoroughly test your application and your admin panel;
 - start using the [new features in Backpack v6](/docs/{{version}}/release-notes);


### PR DESCRIPTION
Solves https://github.com/Laravel-Backpack/docs/issues/474

### ERROR
I upgraded my project and found that the URL `admin/elfinder` started throwing **500**.
```
No hint path defined for [backpack]. {"view":{"view":"/home/bulkmake/public_html/resources/views/vendor/elfinder/elfinder.blade.php","data":[]},"userId":1,"exception":"[object] (Spatie\\LaravelIgnition\\Exceptions\\ViewException(code: 0): No hint path defined for [backpack]. at /home/bulkmake/public_html/vendor/laravel/framework/src/Illuminate/View/FileViewFinder.php:112)
```
### I fixed it by republishing the updated views:

### [And @tabacitu suggested the following](https://github.com/Laravel-Backpack/docs/issues/474#issuecomment-1647775656):

```
rm -rf resources/views/vendor/elfinder
php artisan backpack:filemanager:install
```
Do this as a LAST step. And make it more general. _For any add-ons you might have upgraded, please double-check if they have an upgrade guide. For example, elFinder needs you to do this xxx_