### PR TITLE
Remove backpack:publish-assets command from v6

### DIFF
--- a/6.x/generating-code.md
+++ b/6.x/generating-code.md
@@ -132,10 +132,6 @@ If you've installed Backpack, you already have access to Backpack's command line
     <td>Require Backpack Editable Columns</td>
 </tr>
 <tr>
-    <td><code>php artisan backpack:publish-assets</code></td>
-    <td>Publish new CSS and JS assets (will override existing ones).</td>
-</tr>
-<tr>
     <td><code>php artisan backpack:publish-middleware</code></td>
     <td>Publish the CheckIfAdmin middleware</td>
 </tr>


### PR DESCRIPTION
Command `backpack:publish-assets` being removed here https://github.com/Laravel-Backpack/CRUD/pull/5248 

Removing from docs as well.