### PR TITLE
Add `attribute` in relationship field pivot select example

### DIFF
--- a/6.x/crud-fields.md
+++ b/6.x/crud-fields.md
@@ -1793,6 +1793,7 @@ CRUD::field([
      // you can use the same configurations you use in any relationship select
      // like making it an ajax, constraining the options etc.
     'pivotSelect'=> [
+        // 'attribute' => "title", // attribute on model that is shown to user
         'placeholder' => 'Pick a company',
         'wrapper' => [
             'class' => 'col-md-6',


### PR DESCRIPTION
Solves https://github.com/Laravel-Backpack/docs/issues/487

A user requested to put the missing `attribute` in the pivotSelect example of the relationship field.
This `attribute` allows users change the `display value`

The attribute is present in other relationship field examples except for pivotSelect.
- [Basic Example](https://backpackforlaravel.com/docs/6.x/crud-fields#relationship-pro)✅
- [Ajax Example](https://backpackforlaravel.com/docs/6.x/crud-fields#load-entries-from-ajax-calls-using-the-fetch-operation-1)✅
- [PivotSelect Example](https://backpackforlaravel.com/docs/6.x/crud-fields#configuring-the-pivot-select-field)❌