### PR TITLE
Remove unnecessary semi-colon

### DIFF
--- a/6.x/crud-how-to.md
+++ b/6.x/crud-how-to.md
@@ -623,7 +623,7 @@ Let's say we have `comments`, that can be either for `videos` or `posts`.
 ```php
 // in CommentCrudController you can add the morphTo fields by naming the field the morphTo relation name
 CRUD::field('commentable')
-    ->addMorphOption('App\Models\Video');
+    ->addMorphOption('App\Models\Video')
     ->addMorphOption('App\Models\Post');
 ```
 This will generate two inputs:


### PR DESCRIPTION
The semi-colon is not necessary in the middle of the fluent syntax