### PR TITLE
Add example based on column available in FREE package

### DIFF
--- a/6.x/crud-operation-show.md
+++ b/6.x/crud-operation-show.md
@@ -71,6 +71,13 @@ But you can also do both - let Backpack guess columns, and do stuff before or af
 
         // for example, let's add some new columns
         CRUD::column([
+            'name'  => 'my_custom_html',
+            'label' => 'Custom HTML',
+            'type'  => 'custom_html',
+            'value' => '<span class="text-danger">Something</span>',
+        ]);
+        // in the following examples, please note that the table type is a PRO feature
+        CRUD::column([
             'name' => 'table',
             'label' => 'Table',
             'type' => 'table',


### PR DESCRIPTION
The table type column is a PRO feature and so the table type example does nothing and will confuse anybody testing Backpack before committing to purchase. I choose the custom_html type because it did not need to access a database.