### PR TITLE
Remove figma from v6 docs

### DIFF
--- a/6.x/add-ons-official.md
+++ b/6.x/add-ons-official.md
@@ -5,7 +5,6 @@ In addition to our core packages (CRUD and PRO), we've developed a few packages 
 Premium add-ons (paid separately):
 - [Backpack PRO](https://backpackforlaravel.com/products/pro-for-unlimited-projects) - adds 6 more operations, 10 filters, 28 more fields, 28 more columns and 1 more widget to your toolbelt; we believe it's everything you need to build admin panels... of any complexity <span class="badge badge-pill badge-warning">PAID EXTRA</span>
 - [Backpack DevTools](https://backpackforlaravel.com/products/devtools) - a GUI to easily generate Migrations, Models, Seeders, Factories and CRUDs, right from your browser window; a power user's dream come true! <span class="badge badge-pill badge-warning">PAID EXTRA</span>
-- [Backpack Figma Template](https://backpackforlaravel.com/products/figma-template) - quickly create designs and mockups, using Backpack's design, screens and components; empower your designers to design admin panels that are easy-to-code; <span class="badge badge-pill badge-warning">PAID EXTRA</span>
 - [Backpack EditableColumns](https://backpackforlaravel.com/products/editable-columns) - let admins make quick edits, right from the table view; <span class="badge badge-pill badge-warning">PAID EXTRA</span>
 
 

--- a/6.x/features-free-vs-paid.md
+++ b/6.x/features-free-vs-paid.md
@@ -205,7 +205,7 @@ Both `backpack/crud` and `backpack/pro` will keep receiving active attention, ma
 
 In addition the our main packages (`backpack\crud` and `backpack\pro`), whose features we've detailed above, we've also developed a series of single-purpose Backpack add-ons. Most developers won't need these, but those who do... will be grateful that we took the time:
     - some free: `backpack\permissionmanager`, `backpack\settings`, `backpack\pagemanager`, `backpack\newscrud`, `backpack\menucrud`, `backpack\filemanager`, `backpack\logmanager`, `backpack\backupmanager`, `backpack\revise-operation` etc. <span class="badge badge-pill badge-success">FREE</span>
-    - some paid: `backpack\devtools`, `backpack\figma-template` <span class="badge badge-pill badge-warning">PAID EXTRA</span>
+    - some paid: `backpack\devtools`, `backpack\editable-columns` <span class="badge badge-pill badge-warning">PAID EXTRA</span>
 
 We also encourage our community to build third-party add-ons (we've made it [super-easy](/docs/{{version}}/add-ons-tutorial-using-the-addon-skeleton)). Our plan is to create more and more add-ons, as we discover more recurring problems, that we can solve for Laravel freelancers & development teams.
 

--- a/6.x/introduction.md
+++ b/6.x/introduction.md
@@ -102,10 +102,9 @@ When you buy a premium Backpack addon, you get access to not only _updates_, but
 
 Backpack's core is open-source and free (Backpack\CRUD). <span class="badge badge-pill badge-success">FREE</span>
 
-The reason we've been able to build and maintain Backpack since 2016 is that Laravel professionals have supported us, by buying our paid products. As of 2022, these are all Backpack add-ons, which we highly recommend:
+The reason we've been able to build and maintain Backpack since 2016 is that Laravel professionals have supported us, by buying our paid products. As of 2023, these are all Backpack add-ons, which we highly recommend:
 - [Backpack PRO](/products/pro-for-unlimited-projects) - a crazy amount of added features <span class="badge badge-pill badge-warning">PAID</span>
 - [Backpack DevTools](/products/devtools) - a developer UI for generating migrations, models and CRUDs; <span class="badge badge-pill badge-warning">PAID</span>
-- [Backpack FigmaTemplate](/products/figma-template) - quickly create designs and mockups, using Backpack's design; <span class="badge badge-pill badge-warning">PAID</span>
 - [Backpack EditableColumns](/products/editable-columns) - let your admins do quick edits, right in the table view; <span class="badge badge-pill badge-warning">PAID</span>
 
 


### PR DESCRIPTION
In respect of https://github.com/Laravel-Backpack/figma-template/issues/3.
we are supposed to remove figma from v6 docs