### PR TITLE
Add aria-label example to Crud Fields documentation (for accessibility)

### DIFF
--- a/6.x/crud-fields.md
+++ b/6.x/crud-fields.md
@@ -112,6 +112,37 @@ These will help you:
 - **attributes** - change or add actual HTML attributes of the input (ex: readonly, disabled, class, placeholder, etc);
 - **wrapper** - change or add actual HTML attributes to the div that contains the input;
 
+<a name="optional-field-attributes-for-accessibility"></a>
+#### Optional but Recommended - Field Attributes for Accessibility
+
+By default, field labels are not directly associated with input fields. To improve the accessibility of CRUD fields for screen readers and other assistive technologies (ensuring that a user entering a field will be informed of the name of the field), you can use the ```aria-label``` attribute:
+
+```php
+CRUD::field([
+    'name'  => 'email',
+    'label' => 'Email Address',
+    'type'  => 'email',
+    'attributes' => [
+        'aria-label' => 'Email Address',
+    ],
+]);
+```
+
+In most cases, the ```aria-label``` will be the same as the ```label``` but there may be times when it is helpful to provide more context to the user. For example, the field ```hint``` text appears _after_ the field itself and therefore a screen reader user will not encounter the ```hint``` until they leave the field. You might therefore want to provide a more descriptive ```aria-label```, for example:
+
+```php
+CRUD::field([
+    'name'       => 'age',
+    'label'      => 'Age',
+    'type'       => 'number',
+    'hint'       => 'Enter the exact age of the participant (as a decimal, e.g. 2.5)',
+    'attributes' => [
+        'step' => 'any',
+        'aria-label' => 'Participant Age (as a decimal number)',
+    ],
+]);
+```
+
 <a name="fake-fields"></a>
 #### Optional - Fake Field Attributes (stores fake attributes as JSON in the database)
 


### PR DESCRIPTION
In circumstances where the default Backpack field implementation is not accessible to screen readers and other assistive technologies (and in the absence of any movement on the related bug report (https://github.com/Laravel-Backpack/community-forum/issues/206), I propose to at least actively document and highlight the way to work around this for most of the common field types.   

Note, this would apply to earlier versions as well, but in case there is some need to change the wording I have currently only put this into the 6.x branch.

This, of course, does not ensure accessibility of all field types, but it is better than having no access at all to even basic fields.  