### PR TITLE
wrong example for daterange

### DIFF
--- a/6.x/crud-filters.md
+++ b/6.x/crud-filters.md
@@ -253,7 +253,7 @@ CRUD::filter('from_to')
     ->whenActive(function($value) {
       // $dates = json_decode($value);
       // CRUD::addClause('where', 'date', '>=', $dates->from);
-      // CRUD::addClause('where', 'date', '<=', $dates->to . ' 23:59:59');
+      // CRUD::addClause('where', 'date', '<=', $dates->to);
     });
 ```
 


### PR DESCRIPTION
This comes from client:
'2024-01-21 00:00:00'
'2024-01-29 23:59:59'

we don't need to concat 23:59:59