### PR TITLE
Fix typos and make minor edits.

### DIFF
--- a/6.x/getting-started-advanced-features.md
+++ b/6.x/getting-started-advanced-features.md
@@ -2,9 +2,9 @@
 
 ---
 
-**Duration:** 5 min
+**Duration:** 5 minutes
 
-Here are some other cool things Backpack makes easy for you. We recommend going through them one by one, just browsing. You might not need the feature _right now_, but when _you do_, you'll know how to find it.
+Here are some other cool things Backpack makes easy for you. We recommend going through them one by one, just browsing. You might not need the feature _right now_, but when _you do_, you'll know where to find it.
 
 ---
 
@@ -13,9 +13,9 @@ Here are some other cool things Backpack makes easy for you. We recommend going 
 - [Show](/docs/{{version}}/crud-operation-show) Operation - helps admins preview an entry <span class="badge badge-pill badge-success">FREE</span>
 - [Reorder](/docs/{{version}}/crud-operation-reorder) Operation - helps reorder and nest entries (hierarchy tree) <span class="badge badge-pill badge-success">FREE</span>
 - [Revise](/docs/{{version}}/crud-operation-revisions) Operation - helps record all changes to an entry and undo them <span class="badge badge-pill badge-success">FREE</span>
-- [Clone](/docs/{{version}}/crud-operation-clone) Operation - helps make a copy of an entry; <span class="badge badge-pill badge-info">PRO</span>
-- [BulkDelete](/docs/{{version}}/crud-operation-delete) Operation - helps delete multiple items in one go; <span class="badge badge-pill badge-info">PRO</span>
-- [BulkClone](/docs/{{version}}/crud-operation-clone) Operation - helps clone multiple items in one go; <span class="badge badge-pill badge-info">PRO</span>
+- [Clone](/docs/{{version}}/crud-operation-clone) Operation - helps make a copy of an entry <span class="badge badge-pill badge-info">PRO</span>
+- [BulkDelete](/docs/{{version}}/crud-operation-delete) Operation - helps delete multiple items in one go <span class="badge badge-pill badge-info">PRO</span>
+- [BulkClone](/docs/{{version}}/crud-operation-clone) Operation - helps clone multiple items in one go <span class="badge badge-pill badge-info">PRO</span>
 
 ---
 
@@ -30,9 +30,9 @@ Here are some other cool things Backpack makes easy for you. We recommend going 
 --
 
 - **ListEntries**
-    - you can add a "+" button next to each entry, to allow the admin to easily preview some quick information that was too big to fit inside a column - we call it [details row](/docs/{{version}}/crud-operation-list-entries#details-row) <span class="badge badge-pill badge-info">PRO</span>
+    - you can add a "+" button next to each entry to allow an admin to easily preview some quick information that was too big to fit inside a column - we call this [details row](/docs/{{version}}/crud-operation-list-entries#details-row) <span class="badge badge-pill badge-info">PRO</span>
     - export all visible items in the table by adding [export buttons](/docs/{{version}}/crud-operation-list-entries#export-buttons) <span class="badge badge-pill badge-info">PRO</span>
-    - [custom search logic](/docs/{{version}}/crud-columns#custom-search-logic) for the columns in the list view <span class="badge badge-pill badge-success">FREE</span>
+    - [custom search logic](/docs/{{version}}/crud-columns#custom-search-logic) for the columns in a list view <span class="badge badge-pill badge-success">FREE</span>
 
 
 Additionally, here are a few more ways you can customize your CRUDs:
@@ -40,7 +40,7 @@ Additionally, here are a few more ways you can customize your CRUDs:
 - [Custom Content Class for each CRUD](/docs/{{version}}/crud-how-to#resize-the-content-wrapper-for-an-operation)
 - [Custom CSS or JS](/docs/{{version}}/crud-how-to#customize-css-and-js-for-default-crud-operations) for each CRUD Operation
 
-**That's it for today!** Told you we're done with long lessons :-) Hopefully some of the above have peaked your interest and you've clicked to see what Backpack can do. In the [next lesson](/docs/{{version}}/getting-started-license-and-support) we'll go through a few other Backpack packages that cover some recurring use cases.
+**That's it!** We told you we're done with long lessons. Hopefully, some of the above has peaked your interest and you've clicked through to see what Backpack can do. In the [next lesson](/docs/{{version}}/getting-started-license-and-support) we'll go through a few other Backpack packages that cover some recurring use cases.
 
 
 <br>


### PR DESCRIPTION
Fix typos and make minor edits.

I removed the semi-colons from the bullet points as most of the bullet points here did not have semi-colons.

I removed the old-fashioned smiley : -) as it looks a little bit odd.

I also noticed that the links to BulkDelete and BulkClone are to the top of the page whereas they could be linked to the particular section.

Also, it appears that the three links at the end for the Custom CRUDs are broken. I think the anchors on the target page have probably changed.