### PR TITLE
Fix typos and make minor edits

### DIFF
--- a/6.x/getting-started-crud-operations.md
+++ b/6.x/getting-started-crud-operations.md
@@ -4,7 +4,7 @@
 
 **Duration:** 10 minutes
 
-Let's bring back the example in our first lesson. The Tags CRUD:
+Let's bring back the example from our first lesson. The Tags CRUD:
 
 ![Tag CRUD - List Entries Operation](https://backpackforlaravel.com/uploads/docs-4-0/getting_started/tag_crud_list_entries.png)
 
@@ -58,20 +58,20 @@ In the example above, we've enabled the most common operations:
 - **Delete** - using a *button* in the *list view*
 - **Show** - using a *button* in the *list view*
 
-These are the basic operations an admin can execute on an Eloquent model, thanks to Backpack. We do have additional operations (Reorder, Revisions, Clone, BulkDelete, BulkClone), and you can easily _create a custom operation_, but let's not get ahead of ourselves. Baby steps. **Let's go through the most important features of the operations you'll be using _all the time_: List, Create and Update**.
+These are the basic operations an admin can execute on an Eloquent model, thanks to Backpack. We do have additional operations (Reorder, Revisions, Clone, BulkDelete, and BulkClone), and you can easily _create a custom operation_, but let's not get ahead of ourselves. **Let's go through the most important features of the operations you'll be using _all the time_: List, Create, and Update**.
 
 <a name="create-and-update-operations"></a>
-## Create & Update Operations
+## Create and Update Operations
 
 ![Tag CRUD - Edit Operation](https://backpackforlaravel.com/uploads/docs-4-0/getting_started/tag_crud_edit.png)
 
 <a name="fields"></a>
 ### Fields
 
-Inside your Controller's ```setupCreateOperation()``` or ```setupUpdateOperation()``` method, you'll be able to define what fields you want the admin to see, when creating/updating entries. In the example above, we only have two fields, both using the ```text``` field type. So that's what's shown to the admin. When the admin presses _Save_, assuming your model has those two attributes as ```$fillable```, Backpack will save the entry and take you back to the List view. Keep in mind we're using a _pure_ Eloquent model. So of course, inside the model you could use accessors, mutators, events, etc.
+Inside your Controller's ```setupCreateOperation()``` or ```setupUpdateOperation()``` method, you'll be able to define which fields you want the admin to see, when creating/updating entries. In the example above, we only have two fields, both using the ```text``` field type. So that's what's shown to the admin. When the admin presses _Save_, assuming your model has those two attributes as ```$fillable```, Backpack will save the entry and take you back to the List view. Keep in mind we're using a _pure_ Eloquent model. So of course, inside the model you could use accessors, mutators, events, etc.
 
 
-But a lot of times, you won't just need text inputs. You'll need datepickers, upload buttons, 1-n relationship, n-n relationships, textareas, etc. For each field, you only need to define it properly in the Controller. Here are the most used methods to manipulate fields:
+But often, you won't just need text inputs. You'll need datepickers, upload buttons, 1-n relationships, n-n relationships, textareas, etc. For each field, you only need to define it properly in the Controller. Here are the most often used methods to manipulate fields:
 
 ```php
 CRUD::field('price');
@@ -82,7 +82,7 @@ CRUD::field('price')->after('name'); // move a field after a different field
 // you can of course chain these calls:
 CRUD::field('price')->label('Product price')->prefix('$')->after('name');
 
-// you can also add multiple attribute in one go, by creating
+// you can also add multiple attributes in one go, by creating
 // a field using an array, instead of just its name (a string);
 // we call this the array syntax:
 CRUD::field([
@@ -94,14 +94,14 @@ CRUD::field([
 ```
 
 A typical *field definition* will need at least three things:
-- ```name``` - the attribute (column in the database), which will also become the name of the input;
-- ```type``` - the kind of field we'd like to use (text, number, select2, etc);
-- ```label``` - the human-readable label for the input (will be generated from ```name``` if not given);
+- ```name``` - the attribute (column in the database), which will also become the name of the input
+- ```type``` - the kind of field we want to use (text, number, select2, etc.)
+- ```label``` - the human-readable label for the input (will be generated from ```name``` if not given)
 
 
-You can use [one of the 44+ field types we've provided](/docs/{{version}}/crud-fields#default-field-types), or easily [create a custom field type](/docs/{{version}}/crud-fields#creating-a-custom-field-type) if you have some super-specific need that we haven't covered yet, or even [overwrite how a field type works](#overwriting-default-field-types). Take a few minutes and [browse the 44+ field types](/docs/{{version}}/crud-fields#default-field-types), to understand how the definition array differs from one to another and how many use cases you have already covered.
+You can use [one of the 44+ field types we've provided](/docs/{{version}}/crud-fields#default-field-types), or easily [create a custom field type](/docs/{{version}}/crud-fields#creating-a-custom-field-type) if you have a specific need that we haven't covered yet, or even [overwrite how a field type works](#overwriting-default-field-types). Take a few minutes and [browse the 44+ field types](/docs/{{version}}/crud-fields#default-field-types) to understand how the definition array differs from one to another and how many use cases you have already covered.
 
-Let's take another example, slightly more complicated than the ```text``` fields we used above. Something you'll encounter all the time is relationship fields. So let's say the ```Tag``` model has an **n-n relationship** with an Article model:
+Let's take another example, slightly more complicated than the ```text``` fields we used above. Something you'll encounter all the time are relationship fields. So let's say the ```Tag``` model has an **n-n relationship** with an Article model:
 
 ```php
     public function articles()
@@ -123,10 +123,10 @@ CRUD::field([
 ```
 
 **Notes:**
-- If we call this inside ```setupUpdateOperation()``` it will only be added on that operation;
-- Because we haven't specified a ```label```, Backpack will take the "_articles_" name and turn it into a label: "_Articles_";
+- If we call this inside ```setupUpdateOperation()```, then it will only be added on that operation
+- Because we haven't specified a ```label```, Backpack will take the "_articles_" name and turn it into a label, "_Articles_"
 
-If we had an Articles CRUD, and the reverse relationship defined on the ```Article``` model too, we could also add a ```select2_multiple``` field in the Article CRUD, to allow the admin to choose which tags apply to each article. This actually makes more sense than the above :-)
+If we had an Articles CRUD, and the reverse relationship defined on the ```Article``` model too, then we could also add a ```select2_multiple``` field in the Article CRUD to allow the admin to choose which tags apply to each article. This actually makes more sense than the above:
 
 ```php
 CRUD::field([
@@ -142,7 +142,7 @@ CRUD::field([
 <a name="callbacks"></a>
 ### Callbacks
 
-Developers coming from other CRUD systems will be looking for callbacks to run ```before_insert```, ```before_update```, ```after_insert```, ```after_update```. **There are no callbacks in Backpack**.
+Developers coming from other CRUD systems will be looking for callbacks to run ```before_insert```, ```before_update```, ```after_insert```, and ```after_update```. **There are no callbacks in Backpack**.
 
 Remember that Backpack is using Eloquent models. That means you can do X when Y is happening, by using the [model events](https://laravel.com/docs/10.x/eloquent#events). For example, in your MonsterCrudController you can do:
 
@@ -162,7 +162,7 @@ public function setup() {
 }
 ```
 
-Alternatively, if you do need to change how an operation does something... that's dead-simple too. The ```store()``` and ```update()``` code is inside a trait, so you can easily override that method, and call it inside your new method. For example, here's how we can do things before/after an item is saved in the Create operation:
+Alternatively, if you need to change how an operation does something, then that's simple too. The ```store()``` and ```update()``` code is inside a trait, so you can easily override that method and call it inside your new method. For example, here's how we can do things before/after an item is saved in the Create operation:
 
 ```php
 <?php
@@ -187,19 +187,19 @@ class ProductCrudController extends CrudController
 }
 ```
 
->But before you do that, ask yourself - **_is this something that should be done when an entry is added/updated/deleted from the application, too_**? Not just the admin panel? If so, a better place for it would be the Model. Remember your Model is a pure Eloquent Model, so the cleanest way might be to use [Eloquent Event Observers](https://laravel.com/docs/6.0/eloquent#events) or [accessors and mutators](https://laravel.com/docs/master/eloquent-mutators#accessors-and-mutators).
+>But before you do that, ask yourself - **_is this something that should be done when an entry is added/updated/deleted from the application too_**? Not just from the admin panel? If so, a better place for it would be the Model. Remember your Model is a pure Eloquent Model, so the cleanest way might be to use [Eloquent Event Observers](https://laravel.com/docs/6.0/eloquent#events) or [accessors and mutators](https://laravel.com/docs/master/eloquent-mutators#accessors-and-mutators).
 
 <a name="list-entries-operation"></a>
 ## List Operation
 
-List shows the admin a table with all entries. On the front-end, the information is pulled using AJAX calls, and shown using DataTables. It's the most feature-packed operation in Backpack, but right now we're just going through the most important features you need to know about: columns, filters and buttons.
+List shows the admin a table with all entries. On the front-end, the information is pulled using AJAX calls, and shown using DataTables. It's the most feature-packed operation in Backpack, but right now we're just going through the most important features you need to know about: columns, filters, and buttons.
 
 You should configure the List operation inside the ```setupListOperation()``` method.
 
 <a name="columns"></a>
 ### Columns
 
-Columns help you specify *which* attributes are shown in the table and *in which order*. Their syntax is a;almost identical to fields. In fact, you'll find each Backpack field has a corresponding column, with the same name and syntax:
+Columns help you specify *which* attributes are shown in the table and *in which order*. Their syntax is almost identical to fields. In fact, you'll find each Backpack field has a corresponding column, with the same name and syntax:
 
 ```php
 CRUD::column($column_definition_array); // add a single column, at the end of the table
@@ -215,7 +215,7 @@ CRUD::removeColumns(['column_name_1', 'column_name_2']); // remove an array of c
 CRUD::setColumnsDetails(['column_1', 'column_2'], ['attribute' => 'value']);
 ```
 
-You can use one of the [44+ column types](/docs/{{version}}/crud-columns#default-column-types) to show information to the user in the table, or easily [create a custom column type](/docs/{{version}}/crud-columns#creating-a-custom-column-type), if you have a super-specific need. Here's an example of using the methods above:
+You can use one of the [44+ column types](/docs/{{version}}/crud-columns#default-column-types) to show information to the user in the table, or easily [create a custom column type](/docs/{{version}}/crud-columns#creating-a-custom-column-type) if you have a specific need. Here's an example of using the methods above:
 
 ```php
 CRUD::column([
@@ -233,7 +233,7 @@ CRUD::column('text'); // adds a text column, at the end of the stack
 
 ![Monster CRUD - List Entries Filters](https://backpackforlaravel.com/uploads/docs-4-0/getting_started/backpack_filters.png)
 
-Filters provide an easy way for the admin to well… _filter_ the List table. The syntax is very similar to Fields and Columns and you can use one of the [existing 8 filter types](/docs/{{version}}/crud-filters) or easily [create a custom filter](/docs/{{version}}/crud-filters#creating-custom-filters). Note that this is a PRO feature.
+Filters provide an easy way for the admin to _filter_ the List table. The syntax is very similar to Fields and Columns and you can use one of the [existing 8 filter types](/docs/{{version}}/crud-filters) or easily [create a custom filter](/docs/{{version}}/crud-filters#creating-custom-filters). Note that this is a PRO feature.
 
 ```php
 CRUD::addFilter($options, $values, $filter_logic);
@@ -241,14 +241,14 @@ CRUD::removeFilter($name);
 CRUD::removeAllFilters();
 ```
 
-For more on this, check out the [filters documentation page](/docs/{{version}}/crud-filters), when you need them.
+For more on filters, check out the [filters documentation page](/docs/{{version}}/crud-filters).
 
 <a name="buttons"></a>
 ### Buttons
 
 ![Tag CRUD - List Entries Buttons](https://backpackforlaravel.com/uploads/docs-4-0/getting_started/backpack_buttons.png)
 
-If you want to add a custom button to an entry, you can do that. If you want to remove a button, you can also do that. Look for the [buttons documentation](/docs/{{version}}/crud-buttons) when you need it.
+If you want to add a custom button to an entry, you can do that. If you want to remove a button, you can also do that. Check out the [buttons documentation](/docs/{{version}}/crud-buttons).
 
 ```php
 // positions: 'beginning' and 'end'
@@ -259,7 +259,7 @@ CRUD::removeButton($name);
 CRUD::removeButtonFromStack($name, $stack);
 ```
 
-**That's it for today!** Thanks for sticking with us this long. This has been the most important and longest lesson. You can go ahead and [install Backpack](/docs/{{version}}/installation) now, as you've already gone through the most important features. Or [read the next lesson](/docs/{{version}}/getting-started-advanced-features), about advanced features.
+**That's it!** Thanks for sticking with us this long. This has been the most important and longest lesson. You can go ahead and [install Backpack](/docs/{{version}}/installation) now as you've already gone through the most important features. Or [read the next lesson](/docs/{{version}}/getting-started-advanced-features) about advanced features.
 
 
 <br>


### PR DESCRIPTION
Fix typos and make minor edits.

I was thinking whether to change 1-n to One-to-Many to use the same format as the Laravel documentation, but I decided not to do anything.

"super-specific" is overkill, a simple "specific" will do here.

I was not sure about adding "from" in the following phrase, but I think it should be there: "Not just from the admin panel"