### PR TITLE
Fix sample bulkTrash usage where parameter should not be provided.

### DIFF
--- a/5.x/crud-operation-trash.md
+++ b/5.x/crud-operation-trash.md
@@ -140,7 +140,7 @@ In case you need to change how this operation works, just create a ```bulkTrash(
 ```php
 use \Backpack\Pro\Http\Controllers\Operations\BulkTrashOperation { bulkTrash as traitBulkTrash; }
 
-public function bulkTrash($id)
+public function bulkTrash()
 {
     $this->crud->hasAccessOrFail('bulkTrash');
 

--- a/6.x/crud-operation-trash.md
+++ b/6.x/crud-operation-trash.md
@@ -147,7 +147,7 @@ In case you need to change how this operation works, just create a ```bulkTrash(
 ```php
 use \Backpack\Pro\Http\Controllers\Operations\BulkTrashOperation { bulkTrash as traitBulkTrash; }
 
-public function bulkTrash($id)
+public function bulkTrash()
 {
     CRUD::hasAccessOrFail('bulkTrash');
 


### PR DESCRIPTION
The example usage for `bulkTrash` contains the parameter `$id`, which causes errors when copy-pasted from the docs, like:

```
Too few arguments to function App\Http\Controllers\Admin\UserCrudController::bulkTrash(), 0 passed in ...
```

Updating the sample code block to `bulkTrash()` from `bulkTrash($id)` resolved the error.