### PR TITLE
add note about key requirements

### DIFF
--- a/6.x/crud-fields.md
+++ b/6.x/crud-fields.md
@@ -1138,6 +1138,13 @@ CRUD::field([   // Address google
 
 Using Google Places API is dependent on using an API Key. Please [get an API key](https://console.cloud.google.com/apis/credentials) - you do have to configure billing, but you qualify for $200/mo free usage, which covers most use cases. Then copy-paste that key as your ```services.google_places.key``` value. 
 
+**IMPORTANT NOTE**: Your key needs access to the following APIS:
+- Maps JavaScript API;
+- Places API;
+- Geocoding API.
+
+While developing you can use an "unrestricted key" (no restrictions for where the key is used), but for production you should use a separate key, and **MAKE SURE** you restrict the usage of that key to your own domain. 
+
 So inside your ```config/services.php``` please add the items below:
 ```php
 'google_places' => [
@@ -1557,6 +1564,13 @@ Using Google Places API is dependent on using an API Key. Please [get an API key
     'key' => 'the-key-you-got-from-google-places'
 ],
 ```
+
+**IMPORTANT NOTE**: Your key needs access to the following APIS:
+- Maps JavaScript API;
+- Places API;
+- Geocoding API.
+
+While developing you can use an "unrestricted key" (no restrictions for where the key is used), but for production you should use a separate key, and **MAKE SURE** you restrict the usage of that key to your own domain. 
 
 **How to save in multiple inputs?**
 

--- a/7.x-dev/crud-fields.md
+++ b/7.x-dev/crud-fields.md
@@ -1138,6 +1138,13 @@ CRUD::field([   // Address google
 
 Using Google Places API is dependent on using an API Key. Please [get an API key](https://console.cloud.google.com/apis/credentials) - you do have to configure billing, but you qualify for $200/mo free usage, which covers most use cases. Then copy-paste that key as your ```services.google_places.key``` value. 
 
+**IMPORTANT NOTE**: Your key needs access to the following APIS:
+- Maps JavaScript API;
+- Places API;
+- Geocoding API.
+
+While developing you can use an "unrestricted key" (no restrictions for where the key is used), but for production you should use a separate key, and **MAKE SURE** you restrict the usage of that key to your own domain. 
+
 So inside your ```config/services.php``` please add the items below:
 ```php
 'google_places' => [
@@ -1422,6 +1429,13 @@ Using Google Places API is dependent on using an API Key. Please [get an API key
     'key' => 'the-key-you-got-from-google-places'
 ],
 ```
+
+**IMPORTANT NOTE**: Your key needs access to the following APIS:
+- Maps JavaScript API;
+- Places API;
+- Geocoding API.
+
+While developing you can use an "unrestricted key" (no restrictions for where the key is used), but for production you should use a separate key, and **MAKE SURE** you restrict the usage of that key to your own domain. 
 
 **How to save in multiple inputs?**
 


### PR DESCRIPTION
This adds a note to the google fields about what API's should be selected when generating a key. Also an important note to restrict the key to the application domain when in production. 

Done for both v6 and v7 docs.