### PR TITLE
reorganize uploader docs

### DIFF
--- a/7.x-dev/crud-fields.md
+++ b/7.x-dev/crud-fields.md
@@ -872,6 +872,9 @@ CRUD::field([
 
 > NOTE: Summernote does NOT sanitize the input. If you do not trust the users of this field, you should sanitize the input or output using something like HTML Purifier. Personally we like to use install [mewebstudio/Purifier](https://github.com/mewebstudio/Purifier) and add an [accessor or mutator](https://laravel.com/docs/8.x/eloquent-mutators#accessors-and-mutators) on the Model, so that wherever the model is created from (admin panel or app), the output will always be clean. [Example here](https://github.com/Laravel-Backpack/demo/commit/7342cffb418bb568b9e4ee279859685ddc0456c1).
 
+#### Uploading files with summernote
+
+Summernote saves images as base64 encoded strings in the database. If you want to save them as files on the server, you can use the [Summernote File Upload](https://backpackforlaravel.com/docs/7.x/crud-uploaders) . Please note that the Summernote Uploader is part of the `backpack/pro` package. 
 Input preview:
 
 ![CRUD Field - summernote](https://backpackforlaravel.com/uploads/docs-4-2/fields/summernote.png)

--- a/7.x-dev/crud-fields.md
+++ b/7.x-dev/crud-fields.md
@@ -874,7 +874,7 @@ CRUD::field([
 
 #### Uploading files with summernote
 
-Summernote saves images as base64 encoded strings in the database. If you want to save them as files on the server, you can use the [Summernote File Upload](https://backpackforlaravel.com/docs/7.x/crud-uploaders) . Please note that the Summernote Uploader is part of the `backpack/pro` package. 
+Summernote saves images as base64 encoded strings in the database. If you want to save them as files on the server, you can use the [Summernote Uploader](https://backpackforlaravel.com/docs/7.x/crud-uploaders). Please note that the Summernote Uploader is part of the `backpack/pro` package. 
 Input preview:
 
 ![CRUD Field - summernote](https://backpackforlaravel.com/uploads/docs-4-2/fields/summernote.png)

--- a/7.x-dev/crud-uploaders.md
+++ b/7.x-dev/crud-uploaders.md
@@ -97,9 +97,20 @@ class CustomUploader extends Uploader
         return $valueToBeStoredInTheDatabaseEntry;
     }
 
-    // in case you want to use your uploader inside repeatable fields
-    protected function uploadRepeatableFiles($values, $previousValues, $entry = null)
+    // this is called when your uploader field is a subfield of a repeatable field. In here you receive 
+    // the sent values in the current request and the previous repeatable values (only the uploads values).
+    protected function uploadRepeatableFiles($values, $previousValues)
     {
+        // you should return an array of arrays (each sub array is a repeatable row) where the array key is the field name.
+        // backpack will merge this values along the other repeatable fields and save them in the database.
+        return [
+            [
+                'custom_upload' => 'path/file.jpg'
+            ],
+            [
+                'custom_upload' => 'path/file.jpg'
+            ]
+        ];
     }
 }
 ```
@@ -179,9 +190,20 @@ class CustomUploader extends BackpackAjaxUploader
         return $valueToBeStoredInTheDatabaseEntry;
     }
 
-    // in case you want to use your uploader inside repeatable fields
-    protected function uploadRepeatableFiles($values, $previousValues, $entry = null)
+    // this is called when your uploader field is a subfield of a repeatable field. In here you receive 
+    // the sent values in the current request and the previous repeatable values (only the uploads values).
+    protected function uploadRepeatableFiles($values, $previousValues)
     {
+        // you should return an array of arrays (each sub array is a repeatable row) where the array key is the field name.
+        // backpack will merge this values along the other repeatable fields and save them in the database.
+        return [
+            [
+                'custom_upload' => 'path/file.jpg'
+            ],
+            [
+                'custom_upload' => 'path/file.jpg'
+            ]
+        ];
     }
 }
 ```

--- a/7.x-dev/crud-uploaders.md
+++ b/7.x-dev/crud-uploaders.md
@@ -330,6 +330,22 @@ class SomeModel extends Model
 }
 ```
 
+<a name="deleting-temporary-files"></a>
+## Deleting temporary files
+
+When using ajax uploaders, the files are uploaded to a temporary disk and path before being moved to the final disk and path. If by some reason the user does not finish the operation, those files may lay around in your server temporary folder. 
+To delete them, we have created a `backpack:purge-temporary-folder` command that you can schedule to run every day, or in the time frame that better suits your needs.
+
+```php
+// in your routes/console
+use Illuminate\Console\Scheduling\Schedule;
+
+Schedule::command('backpack:purge-temporary-folder')->daily();
+
+```
+
+For additional configuration check the `config/backpack/operations/ajax-uploads.php` file. Those configurations can also be passed on a "per-command" basis, eg: `backpack:purge-temporary-folder --disk=public --path=temp --older-than=5`.
+
 <a name="custom-upload-fields"></a>
 ### Configuring uploaders in custom fields
 

--- a/7.x-dev/crud-uploaders.md
+++ b/7.x-dev/crud-uploaders.md
@@ -10,7 +10,7 @@ Uploading and managing files is a common task in Admin Panels. In Backpack v7, y
 <a name="how-to-use-uploaders"></a>
 ## How to Use Uploaders
 
-When adding an upload field (`upload`, `upload_multiple`, `image` or `dropzone`) to your operation, tell Backpack that you want to use the appropriate Uploader, by using `withFiles()`:
+When adding an upload field (`upload`, `upload_multiple`, `image`, `dropzone`, `easymde`, `summernote`) to your operation, tell Backpack that you want to use the appropriate Uploader, by using `withFiles()`:
 
 ```php
 CRUD::field('avatar')->type('upload')->withFiles();
@@ -61,7 +61,7 @@ It accepts a `FileNameGeneratorInterface` instance or a closure. As the name imp
 
 We've already created Uploaders for the most common scenarios:
 - CRUD comes with `SingleFile`, `MultipleFiles`, `SingleBas64Image`
-- PRO comes with `AjaxUploader`, `DropzoneUploader`, `EasyMDEUploader`
+- PRO comes with `DropzoneUploader`, `EasyMDEUploader`, `SummernoteUploader`
 - if you want to use spatie/medialibrary you can just install [medialibrary-uploaders](https://github.com/Laravel-Backpack/medialibrary-uploaders) to get `MediaAjaxUploader`, `MediaMultipleFiles`, `MediaSingleBase64Image`, `MediaSingleFile`
 
 

--- a/7.x-dev/crud-uploaders.md
+++ b/7.x-dev/crud-uploaders.md
@@ -75,7 +75,7 @@ First thing you need to decide if you are creating a _non-ajax_ or _ajax_ upload
 - _ajax_ uploaders process the file upload before the form is submitted, by submitting an AJAX request using Javascript; 
 
 <a name="how-to-create-a-custom-non-ajax-uploader"></a>
-## How to Create a Custom Non-Ajax Uploader
+### How to Create a Custom Non-Ajax Uploader
 
 First let's see how to create a non-ajax uploader, for that we will create a `CustomUploader` class that extends the abstract class `Uploader`. 
 
@@ -159,7 +159,7 @@ protected function shouldUploadFiles($value): bool
 }
 
 <a name="how-to-create-a-custom-ajax-uploader"></a>
-## How to Create a Custom Ajax Uploader
+### How to Create a Custom Ajax Uploader
 
 For the ajax uploaders, the process is similar, but your custom uploader class should extend `BackpackAjaxUploader` instead of `Uploader` (**note that this requires backpack/pro**).
 

--- a/7.x-dev/crud-uploaders.md
+++ b/7.x-dev/crud-uploaders.md
@@ -125,7 +125,7 @@ protected function boot()
 
 You can now use `CRUD::field('avatar')->type('custom_upload')->withFiles();` and it will use your custom uploader. What happens behind the scenes is that Backpack will register your uploader to run on 3 different model events: `saving`, `retrieved` and `deleting`.
 
-The `Uploader` class has 3 "entry points" for the mentioned events: **`storeUploadedFiles()`**, **`retrieveUploadedFiles()`** and **`deleteUploadedFiles()`**. You can overwrite these methods in your custom uploader to add your custom logic but for most uploaders you will not need to overwrite them as they are "setup" methods for the action that will be performed, and after setup they call the relevant methods that each uploader will implement, like ```uploadFiles()``` or ```uploadRepeatableFiles()```.
+The `Uploader` class has 3 "entry points" for the mentioned events: **`storeUploadedFiles()`**, **`retrieveUploadedFiles()`** and **`deleteUploadedFiles()`**. You can override these methods in your custom uploader, but typically you will not need to do that. The methods already delegate what will happen to the relevant methods (eg. if it's not a repeatable, call ```uploadFiles()```, othewise call ```uploadRepeatableFiles()```).
 
 Notice this custom class you're creating is extending `Backpack\CRUD\app\Library\Uploaders\Uploader`. That base uploader class has most of the functionality implemented and uses **"strategy methods"** to configure the underlying behavior. 
 

--- a/7.x-dev/crud-uploaders.md
+++ b/7.x-dev/crud-uploaders.md
@@ -130,6 +130,8 @@ The base uploader class has most of the functionality implemented and use **"str
 
 **`hasDeletedFiles`** - a method that returns a boolean to determine if the files were deleted from the field.
 
+**`getUploadedFilesFromRequest`** - this is the method that will be called to get the values sent in the request. Some uploaders require you get the `->files()` others the `->input()`. By default it returns the `->files()`.
+
 This is the implementation of those methods in `SingleFile` uploader:
 ```php
 protected function shouldKeepPreviousValueUnchanged(Model $entry, $entryValue): bool

--- a/7.x-dev/crud-uploaders.md
+++ b/7.x-dev/crud-uploaders.md
@@ -5,10 +5,10 @@
 <a name="upload-about"></a>
 ## About
 
-Uploading and managing files is a common task in Admin Panels. Starting with Backpack v6, you can fully setup your upload fields in your field definition, using purpose-built classes we call Uploaders. No more need to create mutators, manual validation of input or custom code to handle the files - though you can still do that, if you want.
+Uploading and managing files is a common task in Admin Panels. In Backpack v7, your field definition can include uploading logic, thanks to some classes we call Uploaders. You don't need to create mutators, manual validation of input or custom code to handle file upload - though you can still do that, if you want.
 
-<a name="upload-how-it-works"></a>
-## How it works
+<a name="how-to-use-uploaders"></a>
+## How to Use Uploaders
 
 When adding an upload field (`upload`, `upload_multiple`, `image` or `dropzone`) to your operation, tell Backpack that you want to use the appropriate Uploader, by using `withFiles()`:
 
@@ -23,8 +23,8 @@ That's it. Backpack will now handle the upload, storage and deletion of the file
 > - (*) If you want your files to be deleted when the entry is deleted, please [Configure File Deletion](#deleting-files-when-entry-is-deleted)
 
 
-<a name="upload-configuration"></a>
-## Configuring the Uploaders
+<a name="how-to-configure-uploaders"></a>
+## How to Configure Uploaders
 
 The `withFiles()` method accepts an array of options that you can use to customize the upload.
 
@@ -55,6 +55,25 @@ When `temporaryUrl` is set to `true`, this configures the amount of time in minu
 This allows you to overwrite or set the uploader class for this field. You can use any class that implements `UploaderInterface`.
 - **`fileNamer`** - default: **null**
 It accepts a `FileNameGeneratorInterface` instance or a closure. As the name implies, this will be used to generate the file name. Read more about in the [Naming uploaded files](#upload-name-files) section.
+
+<a name="available-uploaders"></a>
+## Available Uploaders
+
+We've already created Uploaders for the most common scenarios:
+- CRUD comes with `SingleFile`, `MultipleFiles`, `SingleBas64Image`
+- PRO comes with `AjaxUploader`, `DropzoneUploader`, `EasyMDEUploader`
+- if you want to use spatie/medialibrary you can just install [medialibrary-uploaders](https://github.com/Laravel-Backpack/medialibrary-uploaders) to get `MediaAjaxUploader`, `MediaMultipleFiles`, `MediaSingleBase64Image`, `MediaSingleFile`
+
+
+<a name="how-to-create-uploaders"></a>
+## How to Create Uploaders
+
+Do you want to create your own Uploader class, for your custom field? Here's how you can do that, and how Uploader classes work behind the scenes.
+
+// TODO
+
+<a name="faq-uploaders"></a>
+## FAQ about Uploaders
 
 <a name="handling-uploaders-in-relationship-fields"></a>
 ### Handling uploads in relationship fields


### PR DESCRIPTION
This PR changes the titles of our Uploader docs a little bit, to make them easier to understand... and introduces a new title that I consider important - HOW TO CREATE AN UPLOADER.

We don't have a guide for that right now. And I myself don't know how uploaders work. So I think it's important to add this bit of documentation, that explains... if you want to create an Uploader here's what you do... what rules you have to respect... and WHY. That will FORCE US to basically make Uploaders understandable, by anyone (including me 😅).

@pxpm can you please fill in this TODO with actual docs on how to create an Uploader. In the process, it will help me understand Uploaders and help me review the PRs we have in the pipeline.