### PR TITLE
Guide the reader about how to actually use Reorder Operation

### DIFF
--- a/3.5/crud-fields.md
+++ b/3.5/crud-fields.md
@@ -962,7 +962,7 @@ Input preview:
 <a name="select2-nested"></a>
 ### select2_nested
 
-Display a select2 with the values ordered hierarchically and indented, for an entity where you use Reorder. Please mind that the connected model needs:
+Display a select2 with the values ordered hierarchically and indented, for an entity where you use [Reorder](https://backpackforlaravel.com/docs/3.5/crud-operation-reorder). Please mind that the connected model needs:
 - a ```children()``` relationship pointing to itself;
 - the usual ```lft```, ```rgt```, ```depth``` attributes;
 

--- a/3.6/crud-fields.md
+++ b/3.6/crud-fields.md
@@ -970,7 +970,7 @@ Input preview:
 <a name="select2-nested"></a>
 ### select2_nested
 
-Display a select2 with the values ordered hierarchically and indented, for an entity where you use Reorder. Please mind that the connected model needs:
+Display a select2 with the values ordered hierarchically and indented, for an entity where you use [Reorder](https://backpackforlaravel.com/docs/3.6/crud-operation-reorder). Please mind that the connected model needs:
 - a ```children()``` relationship pointing to itself;
 - the usual ```lft```, ```rgt```, ```depth``` attributes;
 

--- a/4.0/crud-fields.md
+++ b/4.0/crud-fields.md
@@ -1022,7 +1022,7 @@ Input preview:
 <a name="select2-nested"></a>
 ### select2_nested
 
-Display a select2 with the values ordered hierarchically and indented, for an entity where you use Reorder. Please mind that the connected model needs:
+Display a select2 with the values ordered hierarchically and indented, for an entity where you use [Reorder](https://backpackforlaravel.com/docs/4.0/crud-operation-reorder). Please mind that the connected model needs:
 - a ```children()``` relationship pointing to itself;
 - the usual ```lft```, ```rgt```, ```depth``` attributes;
 

--- a/4.1/crud-fields.md
+++ b/4.1/crud-fields.md
@@ -1450,7 +1450,7 @@ Input preview:
 <a name="select2-nested"></a>
 ### select2_nested
 
-Display a select2 with the values ordered hierarchically and indented, for an entity where you use Reorder. Please mind that the connected model needs:
+Display a select2 with the values ordered hierarchically and indented, for an entity where you use [Reorder](https://backpackforlaravel.com/docs/4.1/crud-operation-reorder). Please mind that the connected model needs:
 - a ```children()``` relationship pointing to itself;
 - the usual ```lft```, ```rgt```, ```depth``` attributes;
 

--- a/5.x/crud-fields.md
+++ b/5.x/crud-fields.md
@@ -2186,7 +2186,7 @@ Input preview:
 <a name="select2-nested"></a>
 ### select2_nested <span class="badge badge-pill badge-info">PRO</span>
 
-Display a select2 with the values ordered hierarchically and indented, for an entity where you use Reorder. Please mind that the connected model needs:
+Display a select2 with the values ordered hierarchically and indented, for an entity where you use [Reorder](https://backpackforlaravel.com/docs/5.x/crud-operation-reorder). Please mind that the connected model needs:
 - a ```children()``` relationship pointing to itself;
 - the usual ```lft```, ```rgt```, ```depth``` attributes;
 

--- a/6.x/crud-fields.md
+++ b/6.x/crud-fields.md
@@ -2194,7 +2194,7 @@ Input preview:
 <a name="select2-nested"></a>
 ### select2_nested <span class="badge badge-pill badge-info">PRO</span>
 
-Display a select2 with the values ordered hierarchically and indented, for an entity where you use Reorder. Please mind that the connected model needs:
+Display a select2 with the values ordered hierarchically and indented, for an entity where you use [Reorder](https://backpackforlaravel.com/docs/6.x/crud-operation-reorder). Please mind that the connected model needs:
 - a ```children()``` relationship pointing to itself;
 - the usual ```lft```, ```rgt```, ```depth``` attributes;
 

--- a/6.x/crud-operation-reorder.md
+++ b/6.x/crud-operation-reorder.md
@@ -12,7 +12,28 @@ This operation allows your admins to reorder & nest entries.
 <a name="requirements"></a>
 ## Requirements
 
-Your model should have the following integer fields, with a default value of 0: ```parent_id```, ```lft```, ```rgt```, ```depth```. The names are optional, you can change them in the ```setupReorderOperation()``` method. 
+Your model should have the following integer fields, with a default value of 0: `parent_id`, `lft`, `rgt`, `depth`. Additionally, the `parent_id` field has to be nullable. Here is an example migration:
+
+```php
+public function up(): void
+{
+    Schema::create('categories', function (Blueprint $table) {
+        $table->increments('id');
+        $table->string('name')->unique();
+
+        $table->unsignedInteger('parent_id')
+            ->nullable()
+            ->default(null);
+        $table->unsignedInteger('lft')->default(0);
+        $table->unsignedInteger('rgt')->default(0);
+        $table->unsignedInteger('depth')->default(0);
+
+        $table->timestamps();
+    });
+}
+```
+
+The names are optional, you can change them in the ```setupReorderOperation()``` method. 
     
 ```php
 
@@ -25,9 +46,25 @@ protected function setupReorderOperation()
         'depth' => 'deep',
     ]);
 }
-```	
+```
 
-Additionally, the `parent_id` field has to be nullable.
+Then, define the `children` relationship of the model that points to itself:
+
+```php
+<?php
+
+class Category extends Model
+{
+    public function children()
+    {
+        return $this->hasMany(
+            \App\Models\Category::class,
+            'parent_id'
+        );
+    }
+}
+
+```
 
 <a name="how-to-use"></a>
 ## How to Use


### PR DESCRIPTION
I was trying to implement the [Reorder Operation](https://backpackforlaravel.com/docs/6.x/crud-operation-reorder) and the [select2_nested](https://backpackforlaravel.com/docs/6.x/crud-fields#select2_nested-pro) field.

Had the docs added actual samples of migration and the mentioned `children` relationship,
the implementation may have gone a lot faster. I even reached the point were I reviewed `Nested Sets`, `etrepat\baum`

This PR adds sample definition of the `children` relationship and sample migration file.