### PR TITLE
fix switch docs

### DIFF
--- a/6.x/crud-fields.md
+++ b/6.x/crud-fields.md
@@ -883,7 +883,7 @@ CRUD::field([   // Switch
     'label'    => 'I have not read the terms and conditions and I never will',
 
     // optional
-    'color'    => 'primary', // May be any bootstrap color class or an hex color
+    'color'    => '#232323', // in CoreUI v2 theme you can also specify bootstrap colors, like `primary`, `danger`, `success`, etc You can also overwrite the `--bg-switch-checked-color` css variable to change the color of the switch when it's checked
     'onLabel' => '✓',
     'offLabel' => '✕',
 ]);

--- a/7.x-dev/crud-fields.md
+++ b/7.x-dev/crud-fields.md
@@ -890,7 +890,7 @@ CRUD::field([   // Switch
     'label'    => 'I have not read the terms and conditions and I never will',
 
     // optional
-    'color'    => 'primary', // May be any bootstrap color class or an hex color
+    'color'    => '#232323', // in CoreUI v2 theme you can also specify bootstrap colors, like `primary`, `danger`, `success`, etc You can also overwrite the `--bg-switch-checked-color` css variable to change the color of the switch when it's checked
     'onLabel' => '✓',
     'offLabel' => '✕',
 ]);


### PR DESCRIPTION
Change the recommended way of defining the switch color to #hex and suggest the variable name developers can overwrite if they need more granular control, eg, assigning other `--var` they have in their application. 

