### PR TITLE
Add basset:clear to upgrade guide

### DIFF
--- a/7.x-dev/upgrade-guide.md
+++ b/7.x-dev/upgrade-guide.md
@@ -121,6 +121,7 @@ No changes needed.
 
 <a name="step-Xx" href="#step-xx" class="badge badge-danger text-white" style="text-decoration: none;">Step xx.</a> Clear your app's cache:
 ```
+php artisan basset:clear
 php artisan config:clear
 php artisan cache:clear
 php artisan view:clear


### PR DESCRIPTION
When quickly checking out the v7 alpha for possible incompatibilities with my app (first look shows that it's running fine btw, keep up the good work!), I noticed that my local environment erred when trying to render views. Given that this originated from some basset call, I guessed that clearing bassets would solve the issue and it did. I think however that this warrants adding it as a recommended step to the migration guide.