### PR TITLE
add docs for chip widget

### DIFF
--- a/7.x-dev/base-widgets.md
+++ b/7.x-dev/base-widgets.md
@@ -349,6 +349,23 @@ class ChartjsPieController extends ChartController
 
 <hr>
 
+<a name="chip"></a>
+### Chip
+
+Shows a chip blade view - which is useful to show more information about a database entry, using little screen real estate.
+
+```php
+[
+    'type' => 'chip',
+    'view' => 'crud::chips.general',
+    'title' => 'invoices',
+    'entry' => Invoice::first(),
+]
+```
+
+
+<hr>
+
 <a name="datatable"></a>
 ### DataTable
 
@@ -360,7 +377,7 @@ Shows a datatable component from a particular CrudController. For more info abou
     'controller' => 'App\Http\Controllers\Admin\PetShop\InvoiceCrudController',
     'name' => 'invoices',
     'setup' => function($crud, $parent) {
-        // you can use this closure to modify your CrudController definition. 
+        // you can use this closure to modify your CrudController definition.
         if ($parent) {
             $crud->addClause('where', 'owner_id', $parent->id);
         }
@@ -388,7 +405,7 @@ Allows you to include multiple widgets within a "div" element with the attribute
 ]
 ```
 
-Anything you specify on this widget, other than ```type``` and ```content```, has to be a string, and will be considered an attribute of the "div" element. 
+Anything you specify on this widget, other than ```type``` and ```content```, has to be a string, and will be considered an attribute of the "div" element.
 For example, in the following snippet, ```class``` and ```custom-attribute``` are attributes of the "div" element:
 
 ```php

--- a/7.x-dev/crud-chips.md
+++ b/7.x-dev/crud-chips.md
@@ -1,0 +1,222 @@
+# Chips
+
+---
+
+<a name="about"></a>
+## About
+
+A chips helps show the information of a database entry, in a format that takes up little space visually.
+
+It can be used inside operations to:
+- show more info inside a table cell in **ListOperation**;
+- show a related item in more detail in **ShowOperation**;
+
+A chip consists of only one file - a blade file with the same name as the chip type (ex: ```general.blade.php```). Backpack provides you with one chip type, that is designed to accomodate many types of database entries, but you can easily [create an entirely new chip type](#creating-a-custom-chip-type).
+
+<a name="default-chip-types"></a>
+### Default Chip Types
+
+<a name="general-chip"></a>
+#### General Chip
+
+// TODO: add image of general chip
+
+This chip was designed to be so general, that it's useful to show _most_ types of information from the database.
+
+```php
+@include('crud::chips.general', [
+    'text' => 'John Doe',
+    'title' => 'Example of a chip without URL',
+    'url' => 'https://google.com',
+    'target' => '_blank',
+    'image' => asset('uploads/person1.jpg'),
+    'details' => [
+        [
+            'icon' => 'la la-hashtag',
+            'text' => '8AH13A7',
+            'url' => 'mailto:john.doe@example.com',
+            'title' => 'Click to email',
+        ],
+        [
+            'icon' => 'la la-envelope',
+            'text' => 'john.doe@example.com',
+            'url' => 'mailto:john.doe@example.com',
+            'title' => 'Click to email',
+        ],
+        [
+            'icon' => 'la la-phone',
+            'text' => '+1 (555) 123-4567',
+            'url' => 'tel:+15551234567',
+            'title' => 'Click to call',
+        ]
+    ]
+])
+```
+
+<a name="how-to-use-chips"></a>
+### How to use chips
+
+Depending on _where_ you want to use a chip, there are a few ways you can do that. Remember - a chip is a simple blade file, so the methods below should be pretty intuitive:
+
+<a name="how-to-use-a-chip-inside-a-custom-blade-view"></a>
+#### How to use a chip inside a custom blade view
+
+// TODO: image with chip inside a custom blade view
+
+If you want to load a chip inside a custom page, custom component or anything else custom, you can just include the blade view directly, and pass whatever attributes you want to show. For example, if you want to use the `general` chip you can just include that blade file, and pass some of the variables it supports:
+
+```php
+{{-- Example of General chip for a person, with data from Eloquent model --}}
+@include('crud::chips.general', [
+    'text' => $user->name,
+    'url' => backpack_url('user/'.$user->id.'/show'),
+    'showImage' => false,
+    // 'image' => backpack_avatar_url($user), // doesn't work well with dummy data
+    'details' => [
+        [
+            'icon' => 'la la-hashtag',
+            'text' => $user->id,
+            'url' => backpack_url('user/'.$user->id.'/show'),
+            'title' => 'Click to preview',
+        ],
+        [
+            'icon' => 'la la-envelope',
+            'text' => $user->email,
+            'url' => 'mailto:'.$user->email,
+            'title' => 'Click to email',
+        ],
+        [
+            'icon' => 'la la-calendar',
+            'text' => $user->created_at->format('F j, Y'),
+            'title' => 'Created at '.$user->created_at,
+        ]
+    ]
+])
+```
+
+<a name="how-to-use-a-chip-as-a-datatable-column"></a>
+#### How to use a chip as a datatable column
+
+// TODO: image of CRUD before and after using chips in a Datatable
+
+When your datatables have too many columns, chips become very useful. They allow you to group multiple columns inside a chip, reducing the number of columns and thereby showing more information in less space. No longer will your admins have to expand the table row or use horizontal scrolling to see important info.
+
+Remember, a chip is just a simple blade file. So to use a chip as a column, we can just use the `view` column type, and pass the path to our chip file. For example:
+
+```php
+// after we create an `invoice` chip
+// we can use that chip as a column:
+CRUD::addColumn([
+    'name' => 'info',
+    'type' => 'view',
+    'view' => 'crud::chips.invoice',
+]);
+```
+By default, the view column type is not searchable. In order to make your chip columns searchable you need to [specify a custom ```searchLogic``` in your declaration](/docs/{{version}}/crud-columns#custom-search-logic).
+
+<a name="how-to-use-a-chip-as-a-widget"></a>
+#### How to use a chip as a widget
+
+// TODO: image with chip as a widget
+
+Chip files usually only contain the minimum content and styling necessary. You can include them as widgets directly, but they probably won't look very pretty on a custom page, because they don't have a background, borders, shadow etc. That's why we've also created a `chip` widget, which adds wrappers just like the other widgets - so that your chip will look good when placed on a custom page (or an existing CRUD page, why not).
+
+To use the `chip` widget, you can do:
+
+```php
+Widget::add()
+    ->to('after_content') // optional
+    ->type('chip')
+    ->view('crud::chips.owner')
+    ->title('Owner')
+    ->entry($owner);
+```
+
+<hr>
+
+<a name="overwriting-default-chip-types"></a>
+## Overwriting Default Chip Types
+
+You can overwrite a chip type by placing a file with the same name in your ```resources\views\vendor\backpack\crud\chips``` directory. But it is NOT recommended to do so. When you're overwriting a default chip type, you're forfeiting any future updates for that chip. We can't push updates to a file that you're no longer using.
+
+In 99.9% of the cases, it's recommended NOT to override the default `general` chip file, but to create a _custom_ chip file. That will make it a lot easier to upgrade to newer versions of Backpack - because the file is completely in your control.
+
+<hr>
+
+<a name="creating-a-custom-chip-type"></a>
+## Creating a Custom Chip Type
+
+Chips consist of only one file - a blade file with the same name as the chip type (ex: ```person.blade.php```). You can create one by placing a new blade file inside ```resources\views\vendor\backpack\crud\chips```. Be careful to choose a distinctive name - usually the model name works best.
+
+// TODO: create this command
+To create a new chip file in the standard directory, you can run `php artisan backpack:chip {chip-file-name}`. This will create a new file in that directory, from a stub, for you to customize however you want.
+
+For example, you can do `php artisan backpack:chip person` to create a ```person.blade.php``` then includes the HTML content directly:
+
+```html
+<div class="card mb-2">
+    <div class="card-body">
+        <div class="row align-items-center bp-chip">
+            <div class="col-auto">
+                <div class="d-block">
+                    <a href="https://google.com" title="Example of a chip" target="_blank" class="d-inline-block"><span class="avatar avatar-2 rounded" style="background-image: url(http://bp-v7-alpha7.test/uploads/person1.jpg)"> </span></a>
+                </div>
+            </div>
+        <div class="col text-truncate">
+            <div class="d-block">
+                <a href="https://google.com" class="mb-1 d-inline-block " title="Example of a chip without URL" target="_blank">
+                    John Doe
+                </a>
+            </div>
+            <div class="d-block text-secondary text-truncate mt-n1">
+                <small class="d-inline-block me-1">
+                    <i class="la la-hashtag" title="Click to email"></i>
+                    <a href="mailto:john.doe@example.com" class="text-reset" title="Click to email">8AH13A7</a>
+                </small>
+                            <small class="d-inline-block me-1">
+                    <i class="la la-envelope" title="Click to email"></i>
+                    <a href="mailto:john.doe@example.com" class="text-reset" title="Click to email">john.doe@example.com</a>
+                </small>
+                            <small class="d-inline-block me-1">
+                    <i class="la la-phone" title="Click to call"></i>
+                    <a href="tel:+15551234567" class="text-reset" title="Click to call">+1 (555) 123-4567</a>
+                </small>
+            </div>
+        </div>
+    </div>
+</div>
+```
+
+But most likely, you'll want to create a chip that outputs some information for a particular database entry. If you like how the `general` chip looks, and only want to make it easy to re-use the chip, you can create a chip that includes the `general` chip. For example:
+
+```php
+@php
+    $last_purchase = $entry->invoices()->orderBy('issuance_date', 'DESC')->first()->issuance_date;
+@endphp
+
+@include('crud::chips.general', [
+    'text' => $entry->name,
+    'url' => backpack_url('pet-shop/owner/'.$entry->id.'/show'),
+    'image' => asset($entry->avatar->url),
+    // 'showImage' => false,
+    'details' => [
+        [
+            'icon' => 'la la-dog',
+            'text' => $entry->pets->count().' pets',
+            'title' => 'Number of pets: '.$entry->pets->count(),
+        ],
+        [
+            'icon' => 'la la-shopping-cart',
+            'text' => $entry->invoices->count(). ' purchases',
+            'title' => 'Number of purchases: '.$entry->invoices->count(),
+        ],
+        [
+            'icon' => 'la la-calendar',
+            'text' => $last_purchase->format('F j, Y'),
+            'title' => 'Last purchase: '.$last_purchase,
+        ]
+    ]
+])
+```
+
+Otherwise, you can create a completely custom chip, that looks and works differently from the `general` chip. There are no limitations - since chips are simple blade files.

--- a/7.x-dev/crud-chips.md
+++ b/7.x-dev/crud-chips.md
@@ -152,7 +152,12 @@ CRUD::addColumn([
     'view' => 'crud::chips.invoice',
 ]);
 ```
-By default, the view column type is not searchable. In order to make your chip columns searchable you need to [specify a custom ```searchLogic``` in your declaration](/docs/{{version}}/crud-columns#custom-search-logic).
+
+Now create that blade file, by running `php artisan backpack:chip invoice`. This will create a file in `resources/views/admin/chips` for you to edit, and customize as you like. By default, it just uses the `$entry` variable (which will be present if you use it as a column). You can include the `general` chip view if it's good enough for you, or copy-paste the HTML from the `general` chip, and modify it to your liking (you can run `php artisan backpack:chip invoice --from=general` to create a chip with all the HTML from general).
+
+Please note:
+- By default, the view column type is not searchable. In order to make your chip columns searchable you need to [specify a custom ```searchLogic``` in your declaration](/docs/{{version}}/crud-columns#custom-search-logic).
+- By default, the view column type is not orderable. In order to make your chip columns orderable you need to [specify a custom ```orderLogic``` in your declaration](/docs/{{version}}/crud-columns#custom-order-logic).
 
 <a name="how-to-use-a-chip-as-a-widget"></a>
 #### How to use a chip as a widget
@@ -188,9 +193,42 @@ In 99.9% of the cases, it's recommended NOT to override the default `general` ch
 
 Chips consist of only one file - a blade file with the same name as the chip type (ex: ```person.blade.php```). You can create one by placing a new blade file inside ```resources\views\vendor\backpack\crud\chips```. Be careful to choose a distinctive name - usually the model name works best.
 
-To create a new chip file in the standard directory, you can run `php artisan backpack:chip {chip-file-name}`. This will create a new file in that directory, from a stub, for you to customize however you want.
+To create a new chip file in the standard directory, you can run:
+- `php artisan backpack:chip {chip-name}` to create a new file in that directory, from our stub that assumes you want to use that chip inside the ListOperation and ShowOperation, so you'll be using the `$entry` variable to define what you want the chip to include;
+- `php artisan backpack:chip {chip-name} --from=general` to create a new file in that directory, from our `general` chip, so you can change the HTML however you want;
 
-For example, you can do `php artisan backpack:chip person` to create a ```person.blade.php``` then includes the HTML content directly:
+For example, you can do `php artisan backpack:chip invoice` to create ```invoice.blade.php``` that helps you define what that chips includes:
+
+```php
+@php
+    $last_purchase = $entry->invoices()->orderBy('issuance_date', 'DESC')->first()->issuance_date;
+@endphp
+
+@include('crud::chips.general', [
+    'heading' => [
+        'content' => 'Invoice '.$entry->series.' '.$entry->number.' - '.$entry->owner->name,
+        'href' => backpack_url('pet-shop/invoice/'.$entry->id.'/show'),
+    ],
+    'details' => [
+        [
+            'icon' => 'la la-dollar',
+            'content' => $entry->total,
+            'title' => 'Total invoice amount $'.$entry->total,
+        ],
+        [
+            'icon' => 'la la-tags',
+            'content' => $entry->items->count().' items',
+        ],
+        [
+            'icon' => 'la la-calendar',
+            'content' => $last_purchase->format('F j, Y'),
+            'title' => 'Issuance date: '.$last_purchase,
+        ]
+    ]
+])
+```
+
+But you can also run `php artisan backpack:chip custom --from=general`, wipe everything inside the generated file, and include your own custom HTML, hardcoded or not:
 
 ```html
 <div class="card mb-2">
@@ -226,36 +264,4 @@ For example, you can do `php artisan backpack:chip person` to create a ```person
 </div>
 ```
 
-But most likely, you'll want to create a chip that outputs some information for a particular database entry. If you like how the `general` chip looks, and only want to make it easy to re-use the chip, you can create a chip that includes the `general` chip. For example:
-
-```php
-@php
-    $last_purchase = $entry->invoices()->orderBy('issuance_date', 'DESC')->first()->issuance_date;
-@endphp
-
-@include('crud::chips.general', [
-    'heading' => [
-        'content' => 'Invoice '.$entry->series.' '.$entry->number.' - '.$entry->owner->name,
-        'href' => backpack_url('pet-shop/invoice/'.$entry->id.'/show'),
-    ],
-    'details' => [
-        [
-            'icon' => 'la la-dollar',
-            'content' => $entry->total,
-            'title' => 'Total invoice amount $'.$entry->total,
-        ],
-        [
-            'icon' => 'la la-tags',
-            'content' => $entry->items->count().' items',
-        ],
-        [
-            'icon' => 'la la-calendar',
-            'content' => $last_purchase->format('F j, Y'),
-            'title' => 'Issuance date: '.$last_purchase,
-        ]
-    ]
-])
-
-```
-
-Otherwise, you can create a completely custom chip, that looks and works differently from the `general` chip. There are no limitations - since chips are simple blade files. Just copy-paste the HTML from the `general` chip and change it to match your needs. Or add completely different HTML - there are no limitations.
+Otherwise, you can create a completely custom chip, that looks and works differently from the `general` chip, and re-use that in your application. There are no limitations - since chips are simple blade files. Just copy-paste the HTML from the `general` chip and change it to match your needs.

--- a/7.x-dev/crud-chips.md
+++ b/7.x-dev/crud-chips.md
@@ -156,6 +156,7 @@ CRUD::addColumn([
 Now create that blade file, by running `php artisan backpack:chip invoice`. This will create a file in `resources/views/admin/chips` for you to edit, and customize as you like. By default, it just uses the `$entry` variable (which will be present if you use it as a column). You can include the `general` chip view if it's good enough for you, or copy-paste the HTML from the `general` chip, and modify it to your liking (you can run `php artisan backpack:chip invoice --from=general` to create a chip with all the HTML from general).
 
 Please note:
+- If your chip uses any info from RELATED items, you should probably eager load those items. For example if you're in an InvoiceCrudController you could do this in your `setupListOperation()` or hell maybe even in setup(): `CRUD::with(['event', 'event.production', 'event.venue', 'event.venue.city']);` - that way when your chip needs that info, it already has it onpage, and makes no extra queries;
 - By default, the view column type is not searchable. In order to make your chip columns searchable you need to [specify a custom ```searchLogic``` in your declaration](/docs/{{version}}/crud-columns#custom-search-logic).
 - By default, the view column type is not orderable. In order to make your chip columns orderable you need to [specify a custom ```orderLogic``` in your declaration](/docs/{{version}}/crud-columns#custom-order-logic).
 

--- a/7.x-dev/crud-chips.md
+++ b/7.x-dev/crud-chips.md
@@ -5,13 +5,11 @@
 <a name="about"></a>
 ## About
 
-A chips helps show the information of a database entry, in a format that takes up little space visually.
+A chips helps show the information of a database entry, in a format that takes up little space visually. It can be used anywhere you want, but it's particularly useful inside operations to:
+- show more info inside a table cell in the **ListOperation**;
+- show a related item in more detail in the **ShowOperation**;
 
-It can be used inside operations to:
-- show more info inside a table cell in **ListOperation**;
-- show a related item in more detail in **ShowOperation**;
-
-A chip consists of only one file - a blade file with the same name as the chip type (ex: ```general.blade.php```). Backpack provides you with one chip type, that is designed to accomodate many types of database entries, but you can easily [create an entirely new chip type](#creating-a-custom-chip-type).
+A chip consists of only one file - a blade file with the same name as the chip type (ex: ```general.blade.php```). Backpack provides you with one chip type, that is very general (hence the name). This chip is designed to accomodate most types of database entries - but if your needs are more particular, you can easily [create an entirely new chip type](#creating-a-custom-chip-type).
 
 <a name="default-chip-types"></a>
 ### Default Chip Types
@@ -19,33 +17,70 @@ A chip consists of only one file - a blade file with the same name as the chip t
 <a name="general-chip"></a>
 #### General Chip
 
-// TODO: add image of general chip
+![Backpack v7 general chip](https://backpackforlaravel.com/uploads/v7/general_chip.jpg)
 
-This chip was designed to be so general, that it's useful to show _most_ types of information from the database.
+This chip was designed to be so general, that it's useful to show _most_ types of entries from the database. The general chip has 3 sections: `heading`, `image` and `details`. All sections are optional. Each of those sections has one mandatory attribute, `content`. Any other attributes you specify on those sections will be placed on that DOM element.
+
+Here's a very minimal usage of the general chip:
 
 ```php
 @include('crud::chips.general', [
-    'text' => 'John Doe',
-    'title' => 'Example of a chip without URL',
-    'url' => 'https://google.com',
-    'target' => '_blank',
-    'image' => asset('uploads/person1.jpg'),
+    'heading' => [
+        'content' => 'John Doe',
+    ],
+    'image' => [
+        'content' => asset('uploads/person1.jpg'),
+    ],
     'details' => [
         [
             'icon' => 'la la-hashtag',
-            'text' => '8AH13A7',
+            'content' => '8AH13A7',
+        ],
+        [
+            'icon' => 'la la-envelope',
+            'content' => 'john.doe@example.com',
+        ],
+        [
+            'icon' => 'la la-phone',
+            'content' => '+1 (555) 123-4567',
+        ]
+    ]
+])
+```
+
+But you can also specify more attributes, to enhance your chip with links, titles etc:
+
+```php
+@include('crud::chips.general', [
+    'heading' => [
+        'content' => 'John Doe',
+        'href' => 'https://google.com',
+        'target' => '_blank',
+        'title' => 'Example of a chip without URL',
+    ],
+    'image' => [
+        'content' => asset('uploads/person1.jpg'),
+        'element' => 'a',
+        'href' => 'https://chatgpt.com',
+        'target' => '_blank',
+        'title' => 'Image can have its own URL, but why?! Falls back to the one in the heading',
+    ],
+    'details' => [
+        [
+            'icon' => 'la la-hashtag',
+            'content' => '8AH13A7',
             'url' => 'mailto:john.doe@example.com',
             'title' => 'Click to email',
         ],
         [
             'icon' => 'la la-envelope',
-            'text' => 'john.doe@example.com',
+            'content' => 'john.doe@example.com',
             'url' => 'mailto:john.doe@example.com',
             'title' => 'Click to email',
         ],
         [
             'icon' => 'la la-phone',
-            'text' => '+1 (555) 123-4567',
+            'content' => '+1 (555) 123-4567',
             'url' => 'tel:+15551234567',
             'title' => 'Click to call',
         ]
@@ -61,33 +96,38 @@ Depending on _where_ you want to use a chip, there are a few ways you can do tha
 <a name="how-to-use-a-chip-inside-a-custom-blade-view"></a>
 #### How to use a chip inside a custom blade view
 
-// TODO: image with chip inside a custom blade view
-
 If you want to load a chip inside a custom page, custom component or anything else custom, you can just include the blade view directly, and pass whatever attributes you want to show. For example, if you want to use the `general` chip you can just include that blade file, and pass some of the variables it supports:
 
 ```php
-{{-- Example of General chip for a person, with data from Eloquent model --}}
+{{-- Example of General chip for a person, with data from a User model --}}
 @include('crud::chips.general', [
-    'text' => $user->name,
-    'url' => backpack_url('user/'.$user->id.'/show'),
-    'showImage' => false,
-    // 'image' => backpack_avatar_url($user), // doesn't work well with dummy data
+    'heading' => [
+        'content' => $user->name,
+        'href' => backpack_url('user/'.$user->id.'/show'),
+        'title' => 'Click to preview',
+    ],
+    'image' => [
+        'content' => backpack_avatar_url($user), // doesn't work well with dummy data
+        'element' => 'a',
+        'href' => backpack_url('user/'.$user->id.'/show'),
+        'title' => 'Because of dummy data, this image is not available, but it would show a profile image',
+    ],
     'details' => [
         [
             'icon' => 'la la-hashtag',
-            'text' => $user->id,
+            'content' => $user->id,
             'url' => backpack_url('user/'.$user->id.'/show'),
             'title' => 'Click to preview',
         ],
         [
             'icon' => 'la la-envelope',
-            'text' => $user->email,
+            'content' => $user->email,
             'url' => 'mailto:'.$user->email,
             'title' => 'Click to email',
         ],
         [
             'icon' => 'la la-calendar',
-            'text' => $user->created_at->format('F j, Y'),
+            'content' => $user->created_at->format('F j, Y'),
             'title' => 'Created at '.$user->created_at,
         ]
     ]
@@ -97,9 +137,9 @@ If you want to load a chip inside a custom page, custom component or anything el
 <a name="how-to-use-a-chip-as-a-datatable-column"></a>
 #### How to use a chip as a datatable column
 
-// TODO: image of CRUD before and after using chips in a Datatable
+![Backpack v7 general chip in datatable component](https://backpackforlaravel.com/uploads/v7/general_chip_in_datatable_component.jpg)
 
-When your datatables have too many columns, chips become very useful. They allow you to group multiple columns inside a chip, reducing the number of columns and thereby showing more information in less space. No longer will your admins have to expand the table row or use horizontal scrolling to see important info.
+When your datatables have too many columns, chips become particularly useful. They allow you to compress the info from 5 or more columns... into a single chip column. This improves the UX of big datatables - your admins will no longer have to expand the table row or use horizontal scrolling to see crucial info.
 
 Remember, a chip is just a simple blade file. So to use a chip as a column, we can just use the `view` column type, and pass the path to our chip file. For example:
 
@@ -117,7 +157,7 @@ By default, the view column type is not searchable. In order to make your chip c
 <a name="how-to-use-a-chip-as-a-widget"></a>
 #### How to use a chip as a widget
 
-// TODO: image with chip as a widget
+![Backpack v7 general chip as widget](https://backpackforlaravel.com/uploads/v7/general_chip_as_widget.jpg)
 
 Chip files usually only contain the minimum content and styling necessary. You can include them as widgets directly, but they probably won't look very pretty on a custom page, because they don't have a background, borders, shadow etc. That's why we've also created a `chip` widget, which adds wrappers just like the other widgets - so that your chip will look good when placed on a custom page (or an existing CRUD page, why not).
 
@@ -137,7 +177,7 @@ Widget::add()
 <a name="overwriting-default-chip-types"></a>
 ## Overwriting Default Chip Types
 
-You can overwrite a chip type by placing a file with the same name in your ```resources\views\vendor\backpack\crud\chips``` directory. But it is NOT recommended to do so. When you're overwriting a default chip type, you're forfeiting any future updates for that chip. We can't push updates to a file that you're no longer using.
+You can override a chip by create a file in ```resources\views\vendor\backpack\crud\chips``` with the same name. But it is NOT recommended to override the `general` chip type. When you do that, you're forfeiting any future updates for that chip. We can't push updates to a file that you're no longer using.
 
 In 99.9% of the cases, it's recommended NOT to override the default `general` chip file, but to create a _custom_ chip file. That will make it a lot easier to upgrade to newer versions of Backpack - because the file is completely in your control.
 
@@ -148,7 +188,6 @@ In 99.9% of the cases, it's recommended NOT to override the default `general` ch
 
 Chips consist of only one file - a blade file with the same name as the chip type (ex: ```person.blade.php```). You can create one by placing a new blade file inside ```resources\views\vendor\backpack\crud\chips```. Be careful to choose a distinctive name - usually the model name works best.
 
-// TODO: create this command
 To create a new chip file in the standard directory, you can run `php artisan backpack:chip {chip-file-name}`. This will create a new file in that directory, from a stub, for you to customize however you want.
 
 For example, you can do `php artisan backpack:chip person` to create a ```person.blade.php``` then includes the HTML content directly:
@@ -195,28 +234,28 @@ But most likely, you'll want to create a chip that outputs some information for 
 @endphp
 
 @include('crud::chips.general', [
-    'text' => $entry->name,
-    'url' => backpack_url('pet-shop/owner/'.$entry->id.'/show'),
-    'image' => asset($entry->avatar->url),
-    // 'showImage' => false,
+    'heading' => [
+        'content' => 'Invoice '.$entry->series.' '.$entry->number.' - '.$entry->owner->name,
+        'href' => backpack_url('pet-shop/invoice/'.$entry->id.'/show'),
+    ],
     'details' => [
         [
-            'icon' => 'la la-dog',
-            'text' => $entry->pets->count().' pets',
-            'title' => 'Number of pets: '.$entry->pets->count(),
+            'icon' => 'la la-dollar',
+            'content' => $entry->total,
+            'title' => 'Total invoice amount $'.$entry->total,
         ],
         [
-            'icon' => 'la la-shopping-cart',
-            'text' => $entry->invoices->count(). ' purchases',
-            'title' => 'Number of purchases: '.$entry->invoices->count(),
+            'icon' => 'la la-tags',
+            'content' => $entry->items->count().' items',
         ],
         [
             'icon' => 'la la-calendar',
-            'text' => $last_purchase->format('F j, Y'),
-            'title' => 'Last purchase: '.$last_purchase,
+            'content' => $last_purchase->format('F j, Y'),
+            'title' => 'Issuance date: '.$last_purchase,
         ]
     ]
 ])
+
 ```
 
-Otherwise, you can create a completely custom chip, that looks and works differently from the `general` chip. There are no limitations - since chips are simple blade files.
+Otherwise, you can create a completely custom chip, that looks and works differently from the `general` chip. There are no limitations - since chips are simple blade files. Just copy-paste the HTML from the `general` chip and change it to match your needs. Or add completely different HTML - there are no limitations.

--- a/7.x-dev/index.md
+++ b/7.x-dev/index.md
@@ -16,7 +16,7 @@
     - [3. Advanced Features](/docs/{{version}}/getting-started-advanced-features)
     - [4. Add-ons, License & Support](/docs/{{version}}/getting-started-license-and-support)
 - [Tutorials](/docs/{{version}}/tutorials)
-  
+
 #### Admin UI
 
 - [About](/docs/{{version}}/base-about)
@@ -36,6 +36,7 @@
         + [Columns](/docs/{{version}}/crud-columns)
         + [Buttons](/docs/{{version}}/crud-buttons)
         + [Filters](/docs/{{version}}/crud-filters)
+        + [Chips](/docs/{{version}}/crud-chips)
     + [Create](/docs/{{version}}/crud-operation-create) & [Update](/docs/{{version}}/crud-operation-update)
         + [Fields](/docs/{{version}}/crud-fields)
         + [Save Actions](/docs/{{version}}/crud-save-actions)
@@ -44,6 +45,7 @@
     + [Delete](/docs/{{version}}/crud-operation-delete)
     + [Show](/docs/{{version}}/crud-operation-show)
         + [Columns](/docs/{{version}}/crud-columns)
+        + [Chips](/docs/{{version}}/crud-chips)
 - [Additional Operations](/docs/{{version}}/crud-operations)
     + [Clone](/docs/{{version}}/crud-operation-clone)
     + [Reorder](/docs/{{version}}/crud-operation-reorder)


### PR DESCRIPTION
This PR adds docs for the chip widget introduced in https://github.com/Laravel-Backpack/CRUD/pull/5815 and with demo examples in https://github.com/Laravel-Backpack/demo/pull/701

Documented:
- [x] what is a chip
- [x] how to use the `crud::chips.general` chip
- [x] how to use chips as widgets
- [x] how to use chips as columns
- [x] how to use chips outside CrudControllers
- [x] how to create your own chip

Todo:
- [x] add images
- [x] polish text & layout