### PR TITLE
Fix documentation typos

### DIFF
--- a/7.x/base-components.md
+++ b/7.x/base-components.md
@@ -157,7 +157,7 @@ This component helps you show a form _anywhere you want_ inside a modal, so the 
 
 To use this component you are required to add `CreateInModalOperation` and/or `UpdateInModalOperation` in your CrudController. The dataform modal component is a extension of a CrudController - so a CrudController for that entity needs to be already set up, and passed to this component as a parameter:
 
-First, in your CrudController, either remove `CreateOperation` in favor of `CreateInModalOperation`, or you can keep both operations. Having both of them is usefull if you want your ListOperation to still show the regular "Create" button, but you would like also to have the possibility to create this entity somewhere else in your application using a modal form. 
+First, in your CrudController, either remove `CreateOperation` in favor of `CreateInModalOperation`, or you can keep both operations. Having both of them is useful if you want your ListOperation to still show the regular "Create" button, but you would like also to have the possibility to create this entity somewhere else in your application using a modal form. 
 
 ```php
 use \Backpack\DataformModal\Http\Controllers\Operations\CreateInModalOperation;

--- a/7.x/crud-buttons.md
+++ b/7.x/crud-buttons.md
@@ -80,7 +80,7 @@ CRUD::moveButton($target, $where, $destination);
 <a name="overwriting-a-default-button"></a>
 ### Overriding a Button
 
-Before showing any buttons, Backpack will check your ```resources\views\vendor\backpack\crud\buttons``` directory, to see if you've overriden any buttons. If it finds a blade file with the same name there as the operation buttons, it will use your blade file, instead of the one in the package.
+Before showing any buttons, Backpack will check your ```resources\views\vendor\backpack\crud\buttons``` directory, to see if you've overridden any buttons. If it finds a blade file with the same name there as the operation buttons, it will use your blade file, instead of the one in the package.
 
 That means **you can override an existing button simply by creating a blade file with the same name inside this directory**.
 

--- a/7.x/crud-columns.md
+++ b/7.x/crud-columns.md
@@ -349,7 +349,7 @@ The enum column will output the value of your database ENUM column or your PHP e
 ],
 ```
 
-By default, in case it's a `BackedEnum` it will show the `value` of the enum (when casted), in `database` or `UnitEnum` it will show the the enum value without parsing the value.
+By default, in case it's a `BackedEnum` it will show the `value` of the enum (when casted), in `database` or `UnitEnum` it will show the enum value without parsing the value.
 
 If you want to output something different than what your enum stores you have two options:
 - For `database enums` you need to provide the `options` that translates the enums you store in database.

--- a/7.x/crud-fields.md
+++ b/7.x/crud-fields.md
@@ -1085,7 +1085,7 @@ To know more about the `withFiles`, how it works and how to configure it, [ clic
 **Validation**
 
 You can use standard Laravel validation rules. But we've also made it easy for you to validate the `upload` fields, using a [Custom Validation Rule](/docs/{{version}}/custom-validation-rules). The `ValidUploadMultiple` validation rule allows you to define two sets of rules:
-- `::field()` - the input rules, independant of the content;
+- `::field()` - the input rules, independent of the content;
 - `file()` - rules that apply to each file that gets sent;
 
 This will help you avoid most quirks of using Laravel's standard validation rules alone.
@@ -1746,7 +1746,7 @@ CRUD::field([   // relationship
  ]);
 ```
 
-More more optional attributes on relationship fields [look here](#optional-attributes-for-fields-containing-related-entries).
+More optional attributes on relationship fields [look here](#optional-attributes-for-fields-containing-related-entries).
 
 Out of the box, it supports all common relationships:
 - ✅ `hasOne` (1-1) - shows subform if you define `subfields`

--- a/7.x/crud-operation-update.md
+++ b/7.x/crud-operation-update.md
@@ -335,7 +335,7 @@ class ProductCrudController extends CrudController
 }
 ```
 
->But before you do that, ask yourself - **_is this something that should be done when an entry is added/updated/deleted from the application, too_**? Not just the admin admin? If so, a better place for it would be the Model. Remember your Model is a pure Eloquent Model, so the cleanest way might be to use [Eloquent Event Observers](https://laravel.com/docs/5.5/eloquent#events) or [accessors and mutators](https://laravel.com/docs/master/eloquent-mutators#accessors-and-mutators).
+>But before you do that, ask yourself - **_is this something that should be done when an entry is added/updated/deleted from the application, too_**? Not just the admin? If so, a better place for it would be the Model. Remember your Model is a pure Eloquent Model, so the cleanest way might be to use [Eloquent Event Observers](https://laravel.com/docs/5.5/eloquent#events) or [accessors and mutators](https://laravel.com/docs/master/eloquent-mutators#accessors-and-mutators).
 
 <a name="translatable-models"></a>
 ### Translatable models and multi-language CRUDs

--- a/7.x/getting-started-basics.md
+++ b/7.x/getting-started-basics.md
@@ -34,7 +34,7 @@ However, you will _almost never_ use all of Backpack's features in one CRUD. But
 <a name="backpack-design"></a>
 ### Front-End Design
 
-New Backpack installs come with an HTML theme installed - you choose which theme. All themes use Bootstrap, and have many HTML blocks ready for you to use. When you're building a custom page in your admin panel, it's easy to just copy-paste the HTML from the the theme's demo or from its documentation. And the page will look good, without you having to design anything. Currently, we have three first-party themes:
+New Backpack installs come with an HTML theme installed - you choose which theme. All themes use Bootstrap, and have many HTML blocks ready for you to use. When you're building a custom page in your admin panel, it's easy to just copy-paste the HTML from the theme's demo or from its documentation. And the page will look good, without you having to design anything. Currently, we have three first-party themes:
 - [Tabler](https://github.com/Laravel-Backpack/theme-tabler)
 - [CoreUI v4](https://github.com/Laravel-Backpack/theme-coreuiv4)
 - [CoreUI v2](https://github.com/Laravel-Backpack/theme-tabler) (which still provides IE support)


### PR DESCRIPTION
A few small documentation typos noticed while reading the 7.x docs:

- `base-components.md`: "usefull" -> "useful"
- `crud-buttons.md`: "overriden" -> "overridden"
- `crud-columns.md`: "show the the enum value" -> "show the enum value"
- `crud-fields.md`: "independant" -> "independent"
- `crud-fields.md`: "More more optional attributes" -> "More optional attributes"
- `crud-operation-update.md`: "Not just the admin admin?" -> "Not just the admin?"
- `getting-started-basics.md`: "from the the theme's demo" -> "from the theme's demo"

Documentation only; no code changes.
